### PR TITLE
Fix stale shader cache when using customFrag

### DIFF
--- a/src/shader-program.ts
+++ b/src/shader-program.ts
@@ -69,10 +69,14 @@ export function makeShaderVariantKey(options: {
   const { projectionMode, shaderData, customShaderConfig } = options
   const useCustomShader =
     customShaderConfig && customShaderConfig.bands.length > 0
+  // Include shaderData.variantName for both paths to ensure custom shaders
+  // recompile when MapLibre changes the vertex shader prelude during globe to merc transitions
+  const shaderVariant = shaderData?.variantName ?? 'base'
+
   const baseVariant =
     useCustomShader && customShaderConfig
-      ? ['custom', customShaderConfig.bands.join('_')].join('_')
-      : shaderData?.variantName ?? 'base'
+      ? ['custom', customShaderConfig.bands.join('_'), shaderVariant].join('_')
+      : shaderVariant
   return [baseVariant, projectionMode].join('_')
 }
 


### PR DESCRIPTION
Solves a tricky bug in maplibre globe where starting past the mercator-globe transition zoom and initializing a layer, then zooming out, would result in no data being rendered despite data loading as expected. 