### PR TITLE
Bump zarrita to 0.6.1 for string type support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@developmentseed/raster-reproject": "^0.1.0",
         "delaunator": "^5.0.1",
         "proj4": "^2.20.2",
-        "zarrita": "^0.5.4"
+        "zarrita": "^0.6.1"
       },
       "devDependencies": {
         "@carbonplan/prettier": "^1.2.0",
@@ -1024,13 +1024,13 @@
       }
     },
     "node_modules/@zarrita/storage": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.3.tgz",
-      "integrity": "sha512-ZyCMYN3LuCNtKxro9876r/KyHyXV+ie2Bhk1qYsJR4Jp+sAjoVRRNNSJPsJxk64ZgFFezayO5S2hCu88/1Odwg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.4.tgz",
+      "integrity": "sha512-qURfJAQcQGRfDQ4J9HaCjGaj3jlJKc66bnRk6G/IeLUsM7WKyG7Bzsuf1EZurSXyc0I4LVcu6HaeQQ4d3kZ16g==",
       "license": "MIT",
       "dependencies": {
         "reference-spec-reader": "^0.2.0",
-        "unzipit": "^1.4.3"
+        "unzipit": "1.4.3"
       }
     },
     "node_modules/acorn": {
@@ -2518,12 +2518,12 @@
       }
     },
     "node_modules/zarrita": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.5.4.tgz",
-      "integrity": "sha512-i88iN2+HqIQ+uiCEWLfhjbYNXAJD7IrM4h3lFwFclfqEOOhxp10amRWtqmgN5jbuy3+h0LwdyLVVzk4y9rTLgg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.6.1.tgz",
+      "integrity": "sha512-YOMTW8FT55Rz+vadTIZeOFZ/F2h4svKizyldvPtMYSxPgSNcRkOzkxCsWpIWlWzB1I/LmISmi0bEekOhLlI+Zw==",
       "license": "MIT",
       "dependencies": {
-        "@zarrita/storage": "^0.1.3",
+        "@zarrita/storage": "^0.1.4",
         "numcodecs": "^0.3.2"
       }
     }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@developmentseed/raster-reproject": "^0.1.0",
     "delaunator": "^5.0.1",
     "proj4": "^2.20.2",
-    "zarrita": "^0.5.4"
+    "zarrita": "^0.6.1"
   },
   "lint-staged": {
     "*.{js,ts,tsx,json,md}": "prettier --write"


### PR DESCRIPTION
## Summary

- Bumps `zarrita` dependency from `^0.5.4` to `^0.6.1`
- This brings in support for `data_type: "string"` (Zarr v3) added in [zarrita@0.6.0](https://github.com/manzt/zarrita.js/releases/tag/zarrita%400.6.0)
- Also includes bug fixes for shard getRange requests and ZipFileStore sharding support