### PR TITLE
Improve query performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,18 @@ const result = await layer.queryData({
 // }
 ```
 
-**Note:** Query results match rendered values (`scale_factor`/`add_offset` applied, `fillValue`/NaN filtered). For datasets rendered via `proj4` reprojection, queries sample the underlying source grid; because reprojection/resampling occurs for display, a visual pixel click may not align perfectly with the nearest source pixel.
+Datasets using a custom projection (via the `proj4` option) return coordinates in the source coordinate system, with keys matching the store's axis names (e.g. `y`/`x`). All other datasets (EPSG:4326, EPSG:3857) return `lat`/`lon` keys with WGS84 degree values.
+
+You can pass a third `options` argument to control query behavior:
+
+```ts
+const result = await layer.queryData(geometry, selector, {
+  signal: abortController.signal, // cancel in-flight query
+  includeSpatialCoordinates: false, // omit per-pixel coordinates for slimmer results
+})
+```
+
+**Note:** Query results match rendered values (`scale_factor`/`add_offset` applied, `fillValue`/NaN filtered).
 
 ## authentication
 

--- a/demo/components/controls.tsx
+++ b/demo/components/controls.tsx
@@ -283,7 +283,7 @@ const Controls = () => {
   const setPointResult = useAppStore((state) => state.setPointResult)
   const themedColormap = useThemedColormap(colormap)
   const [queryInFlight, setQueryInFlight] = useState(false)
-  const queryGenRef = useRef(0)
+  const abortRef = useRef<AbortController | null>(null)
 
   const layerConfig = useMemo(
     () => datasetModule.buildLayerProps(datasetState),
@@ -299,8 +299,8 @@ const Controls = () => {
     (currentBand === 'tavg_range' || currentBand === 'prec_range')
 
   useEffect(() => {
-    // Clear query results when switching dataset or selector to avoid stale display
-    queryGenRef.current++
+    // Abort in-flight query and clear results when switching dataset or selector
+    abortRef.current?.abort()
     setPointResult(null)
     setRegionResult(null)
   }, [datasetId, datasetState, setPointResult, setRegionResult])
@@ -381,7 +381,12 @@ const Controls = () => {
   const handleViewportQuery = async () => {
     if (viewportQueryDisabled || queryInFlight) return
     if (!mapInstance || !zarrLayer || !mapInstance.getBounds) return
-    const gen = queryGenRef.current
+
+    // Abort any previous query
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
     setQueryInFlight(true)
     try {
       const bounds = mapInstance.getBounds()
@@ -389,7 +394,6 @@ const Controls = () => {
         throw new Error('Viewport query is not available')
       }
       const geometry = boundsToGeometry(bounds)
-      console.log('geometry', geometry)
       // If in range mode, query only the selected month range
       let querySelector = layerConfig.selector
       if (isRangeBand && monthStart !== null && monthEnd !== null) {
@@ -400,19 +404,17 @@ const Controls = () => {
         // Get the base band (tavg or prec) from current selection
         const baseBand = currentBand === 'tavg_range' ? 'tavg' : 'prec'
         querySelector = { band: baseBand, month: monthRange }
-        console.log(
-          `Querying range mode: band=${baseBand}, months=${monthRange.join(
-            ','
-          )}`
-        )
       }
 
-      const result = await zarrLayer.queryData(geometry, querySelector)
-      if (gen !== queryGenRef.current) return
+      const result = (await zarrLayer.queryData(geometry, querySelector, {
+        signal: controller.signal,
+        includeSpatialCoordinates: false,
+      })) as QueryResult
       setRegionResult(result)
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') return
       console.error('Viewport query failed', error)
-      if (gen === queryGenRef.current) setRegionResult(null)
+      setRegionResult(null)
     } finally {
       setQueryInFlight(false)
     }

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -40,7 +40,7 @@
     },
     "..": {
       "name": "@carbonplan/zarr-layer",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/raster-reproject": "^0.1.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,9 @@ export const MERCATOR_LAT_LIMIT = 85.05112878
 /** Default maximum error threshold for adaptive mesh refinement (in pixels) */
 export const DEFAULT_MESH_MAX_ERROR = 0.125
 
+/** Default maximum error for query polygon edge densification (in pixels) */
+export const DEFAULT_QUERY_DENSIFY_MAX_ERROR = DEFAULT_MESH_MAX_ERROR
+
 /** Minimum subdivisions for region geometry tessellation (globe projection) */
 export const MIN_SUBDIVISIONS = 2
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,12 @@ export type {
 } from './types'
 
 // Query interface exports
-export type { QueryResult, QueryDataValues, QueryGeometry } from './query/types'
+export type {
+  QueryResult,
+  QueryDataValues,
+  QueryGeometry,
+  QueryOptions,
+} from './query/types'
 
 // Codec registry — re-export for registering custom codecs
 export { registry as codecRegistry } from 'zarrita'

--- a/src/query/query-utils.ts
+++ b/src/query/query-utils.ts
@@ -327,9 +327,9 @@ export function computePixelBoundsFromGeometry(
     // Clamp to valid range
     // Use floor + 1 to ensure integer maxX/maxY values include that pixel
     const xStart = Math.max(0, Math.floor(minX))
-    const xEnd = Math.min(width, Math.floor(maxX) + 1)
+    const xEnd = Math.min(width, Math.max(Math.floor(maxX) + 1, xStart + 1))
     const yStart = Math.max(0, Math.floor(minY))
-    const yEnd = Math.min(height, Math.floor(maxY) + 1)
+    const yEnd = Math.min(height, Math.max(Math.floor(maxY) + 1, yStart + 1))
 
     if (xEnd <= xStart || yEnd <= yStart) return null
 
@@ -374,20 +374,20 @@ export function computePixelBoundsFromGeometry(
     const yFracMin = Math.min(yStartFracRaw, yEndFracRaw)
     const yFracMax = Math.max(yStartFracRaw, yEndFracRaw)
 
-    if (overlapX1 <= overlapX0 || yFracMax <= yFracMin) return null
+    if (overlapX1 < overlapX0 || yFracMax < yFracMin) return null
 
     const minX = ((overlapX0 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
     const maxX = ((overlapX1 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
 
     xStart = Math.max(0, Math.floor(minX))
-    xEnd = Math.min(width, Math.ceil(maxX))
+    xEnd = Math.min(width, Math.max(Math.ceil(maxX), xStart + 1))
     yStart = Math.max(0, Math.floor(yFracMin * height))
-    yEnd = Math.min(height, Math.ceil(yFracMax * height))
+    yEnd = Math.min(height, Math.max(Math.ceil(yFracMax * height), yStart + 1))
   } else {
     const overlapY0 = Math.max(bounds.y0, Math.min(polyY0, polyY1))
     const overlapY1 = Math.min(bounds.y1, Math.max(polyY0, polyY1))
 
-    if (overlapX1 <= overlapX0 || overlapY1 <= overlapY0) return null
+    if (overlapX1 < overlapX0 || overlapY1 < overlapY0) return null
 
     const minX = ((overlapX0 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
     const maxX = ((overlapX1 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
@@ -395,14 +395,283 @@ export function computePixelBoundsFromGeometry(
     const maxY = ((overlapY1 - bounds.y0) / (bounds.y1 - bounds.y0)) * height
 
     xStart = Math.max(0, Math.floor(minX))
-    xEnd = Math.min(width, Math.ceil(maxX))
+    xEnd = Math.min(width, Math.max(Math.ceil(maxX), xStart + 1))
     yStart = Math.max(0, Math.floor(minY))
-    yEnd = Math.min(height, Math.ceil(maxY))
+    yEnd = Math.min(height, Math.max(Math.ceil(maxY), yStart + 1))
   }
 
   if (xEnd <= xStart || yEnd <= yStart) return null
 
   return { minX: xStart, maxX: xEnd, minY: yStart, maxY: yEnd }
+}
+
+/** Number of intermediate points to insert per polygon edge for densification */
+const DENSIFY_SEGMENTS = 10
+
+/**
+ * Densify a ring by inserting intermediate points along each edge.
+ * Interpolates in the source coordinate system (lon/lat) and transforms each point.
+ */
+function densifyAndTransformRing(
+  ring: number[][],
+  transformVertex: (lon: number, lat: number) => [number, number]
+): number[][] {
+  const result: number[][] = []
+  for (let i = 0; i < ring.length - 1; i++) {
+    const [lon0, lat0] = ring[i]
+    const [lon1, lat1] = ring[i + 1]
+    // Add start point
+    result.push(transformVertex(lon0, lat0) as number[])
+    // Add intermediate points
+    for (let s = 1; s < DENSIFY_SEGMENTS; s++) {
+      const t = s / DENSIFY_SEGMENTS
+      const lon = lon0 + t * (lon1 - lon0)
+      const lat = lat0 + t * (lat1 - lat0)
+      const pt = transformVertex(lon, lat)
+      if (isFinite(pt[0]) && isFinite(pt[1])) {
+        result.push(pt as number[])
+      }
+    }
+  }
+  // Close ring
+  if (result.length > 0) {
+    result.push([result[0][0], result[0][1]])
+  }
+  return result
+}
+
+/**
+ * Transform a query geometry from WGS84 lon/lat into pixel-space coordinates.
+ * For proj4 projections: forward-transforms vertices, then converts source CRS → pixel.
+ * For standard CRS: uses mercator/equirect math → pixel.
+ * Densifies edges to preserve curvature under nonlinear projections.
+ *
+ * Returns a geometry with the same GeoJSON ring structure but in pixel coordinates,
+ * suitable for use with pointInGeoJSON / pointInPolygon.
+ */
+export function transformGeometryToPixelSpace(
+  geometry: QueryGeometry,
+  bounds: MercatorBounds,
+  width: number,
+  height: number,
+  crs: CRS,
+  latIsAscending?: boolean,
+  proj4def?: string | null,
+  sourceBounds?: Bounds | null,
+  cachedTransformer?: CachedTransformer
+): QueryGeometry | null {
+  if (geometry.type === 'Point') {
+    const [lon, lat] = geometry.coordinates
+    const px = lonLatToPixel(
+      lon,
+      lat,
+      bounds,
+      width,
+      height,
+      crs,
+      latIsAscending,
+      proj4def,
+      sourceBounds,
+      cachedTransformer
+    )
+    if (!px) return null
+    return { type: 'Point', coordinates: [px[0], px[1]] }
+  }
+
+  // Build the vertex transform function
+  const transformVertex = (lon: number, lat: number): [number, number] => {
+    const px = lonLatToPixel(
+      lon,
+      lat,
+      bounds,
+      width,
+      height,
+      crs,
+      latIsAscending,
+      proj4def,
+      sourceBounds,
+      cachedTransformer
+    )
+    return px ?? [NaN, NaN]
+  }
+
+  // Densify for any nonlinear CRS. EPSG:3857 uses latToMercatorNorm (nonlinear in Y).
+  // EPSG:4326 with lat bounds is linear and doesn't need densification.
+  const isLinear4326 =
+    crs === 'EPSG:4326' &&
+    bounds.latMin !== undefined &&
+    bounds.latMax !== undefined
+  const needsDensification =
+    !!proj4def || (!isLinear4326 && crs !== 'EPSG:4326')
+
+  const transformRing = (ring: number[][]): number[][] => {
+    if (needsDensification) {
+      return densifyAndTransformRing(ring, transformVertex)
+    }
+    // For linear projections, just transform vertices directly
+    const result: number[][] = []
+    for (const [lon, lat] of ring) {
+      const pt = transformVertex(lon, lat)
+      if (isFinite(pt[0]) && isFinite(pt[1])) {
+        result.push(pt as number[])
+      }
+    }
+    // Ensure ring is closed
+    if (
+      result.length > 1 &&
+      (result[0][0] !== result[result.length - 1][0] ||
+        result[0][1] !== result[result.length - 1][1])
+    ) {
+      result.push([result[0][0], result[0][1]])
+    }
+    return result
+  }
+
+  if (geometry.type === 'Polygon') {
+    const coords = geometry.coordinates.map(transformRing)
+    if (coords[0].length < 4) return null // Need at least a triangle
+    return { type: 'Polygon', coordinates: coords }
+  }
+
+  // MultiPolygon
+  const coords = geometry.coordinates.map((polygon) =>
+    polygon.map(transformRing)
+  )
+  // Filter out degenerate polygons
+  const valid = coords.filter((poly) => poly[0].length >= 4)
+  if (valid.length === 0) return null
+  return { type: 'MultiPolygon', coordinates: valid }
+}
+
+/**
+ * Convert a single lon/lat point to pixel coordinates.
+ * Handles proj4, EPSG:4326, and EPSG:3857.
+ */
+function lonLatToPixel(
+  lon: number,
+  lat: number,
+  bounds: MercatorBounds,
+  width: number,
+  height: number,
+  crs: CRS,
+  latIsAscending?: boolean,
+  proj4def?: string | null,
+  sourceBounds?: Bounds | null,
+  cachedTransformer?: CachedTransformer
+): [number, number] | null {
+  if (proj4def && sourceBounds) {
+    const transformer =
+      cachedTransformer ?? createWGS84ToSourceTransformer(proj4def)
+    const [srcX, srcY] = transformer.forward(lon, lat)
+    if (!isFinite(srcX) || !isFinite(srcY)) return null
+    return sourceCRSToPixel(
+      srcX,
+      srcY,
+      sourceBounds,
+      width,
+      height,
+      latIsAscending
+    )
+  }
+
+  // Standard CRS: convert to mercator normalized, then to pixel.
+  // No bounds clamping — polygon vertices can legitimately lie far outside
+  // the raster extent (e.g. when the polygon fully contains a small raster).
+  const normX = lonToMercatorNorm(lon)
+  const xFrac = (normX - bounds.x0) / (bounds.x1 - bounds.x0)
+
+  let yFrac: number
+  if (
+    crs === 'EPSG:4326' &&
+    bounds.latMin !== undefined &&
+    bounds.latMax !== undefined
+  ) {
+    const latRange = bounds.latMax - bounds.latMin
+    if (latRange === 0) return null
+    yFrac = latIsAscending
+      ? (lat - bounds.latMin) / latRange
+      : (bounds.latMax - lat) / latRange
+  } else {
+    const normY = latToMercatorNorm(lat)
+    yFrac = (normY - bounds.y0) / (bounds.y1 - bounds.y0)
+  }
+
+  return [xFrac * width, yFrac * height]
+}
+
+/**
+ * Scanline fill: precompute sorted X-intersections for each row in the pixel-space polygon.
+ * Returns a Map from integer Y to sorted array of X-intersection values.
+ * For each row, pixels between pairs of intersections (0-1, 2-3, ...) are inside.
+ *
+ * This replaces per-pixel pointInPolygon, changing complexity from O(W*H*V) to O(H*E + H*E*logE).
+ */
+export function buildScanlineTable(
+  geometry: QueryGeometry,
+  yStart: number,
+  yEnd: number
+): Map<number, number[]> {
+  const table = new Map<number, number[]>()
+
+  // Collect all edges from the geometry
+  const processRing = (ring: number[][]) => {
+    for (let i = 0; i < ring.length - 1; i++) {
+      const x0 = ring[i][0]
+      const y0 = ring[i][1]
+      const x1 = ring[i + 1][0]
+      const y1 = ring[i + 1][1]
+
+      // Skip horizontal edges
+      if (y0 === y1) continue
+
+      const edgeYMin = Math.min(y0, y1)
+      const edgeYMax = Math.max(y0, y1)
+
+      // Clamp to scan range. Use pixel edges (row, row+1) not centers (row+0.5)
+      // so that any pixel whose rect overlaps the polygon is included.
+      const scanYMin = Math.max(yStart, Math.ceil(edgeYMin) - 1)
+      const scanYMax = Math.min(yEnd - 1, Math.floor(edgeYMax))
+
+      const slope = (x1 - x0) / (y1 - y0)
+
+      for (let row = scanYMin; row <= scanYMax; row++) {
+        // Intersect at the pixel edge closest to the polygon interior.
+        // For a row spanning [row, row+1], clamp scanY to the edge's Y range.
+        const scanY = Math.max(
+          edgeYMin + 1e-10,
+          Math.min(edgeYMax - 1e-10, row + 0.5)
+        )
+        if (scanY <= edgeYMin || scanY >= edgeYMax) continue
+
+        const xIntersect = x0 + (scanY - y0) * slope
+        let arr = table.get(row)
+        if (!arr) {
+          arr = []
+          table.set(row, arr)
+        }
+        arr.push(xIntersect)
+      }
+    }
+  }
+
+  if (geometry.type === 'Polygon') {
+    for (const ring of geometry.coordinates) {
+      processRing(ring)
+    }
+  } else if (geometry.type === 'MultiPolygon') {
+    for (const polygon of geometry.coordinates) {
+      for (const ring of polygon) {
+        processRing(ring)
+      }
+    }
+  }
+
+  // Sort intersections for each row
+  for (const [, arr] of table) {
+    arr.sort((a, b) => a - b)
+  }
+
+  return table
 }
 
 /**
@@ -473,6 +742,30 @@ export function pointInGeoJSON(
 }
 
 /**
+ * Test if two line segments intersect using cross-product method.
+ * Avoids allocations by inlining the math.
+ */
+function segmentsIntersect(
+  a1: [number, number],
+  a2: [number, number],
+  b1: [number, number],
+  b2: [number, number]
+): boolean {
+  const d1x = a2[0] - a1[0]
+  const d1y = a2[1] - a1[1]
+  const d2x = b2[0] - b1[0]
+  const d2y = b2[1] - b1[1]
+  const denom = d1x * d2y - d1y * d2x
+  if (denom === 0) return false
+
+  const dx = b1[0] - a1[0]
+  const dy = b1[1] - a1[1]
+  const s = (dx * d2y - dy * d2x) / denom
+  const t = (dx * d1y - dy * d1x) / denom
+  return s >= 0 && s <= 1 && t >= 0 && t <= 1
+}
+
+/**
  * Lightweight polygon-rectangle intersection test.
  * Returns true if any rectangle corner is inside geometry,
  * any geometry vertex is inside rectangle, or if any edges intersect.
@@ -481,13 +774,11 @@ function rectIntersectsGeometry(
   rect: [number, number][],
   geometry: QueryGeometry
 ): boolean {
-  const rectMinX = Math.min(...rect.map((p) => p[0]))
-  const rectMaxX = Math.max(...rect.map((p) => p[0]))
-  const rectMinY = Math.min(...rect.map((p) => p[1]))
-  const rectMaxY = Math.max(...rect.map((p) => p[1]))
-
-  const pointInRect = (p: [number, number]) =>
-    p[0] >= rectMinX && p[0] <= rectMaxX && p[1] >= rectMinY && p[1] <= rectMaxY
+  // Inline min/max to avoid temporary arrays from Math.min(...rect.map(...))
+  const rectMinX = Math.min(rect[0][0], rect[1][0], rect[2][0], rect[3][0])
+  const rectMaxX = Math.max(rect[0][0], rect[1][0], rect[2][0], rect[3][0])
+  const rectMinY = Math.min(rect[0][1], rect[1][1], rect[2][1], rect[3][1])
+  const rectMaxY = Math.max(rect[0][1], rect[1][1], rect[2][1], rect[3][1])
 
   // Any rect corner inside geometry (supports point or polygon)
   for (const corner of rect) {
@@ -495,22 +786,29 @@ function rectIntersectsGeometry(
   }
 
   // Point geometry inside rectangle
-  if (
-    geometry.type === 'Point' &&
-    pointInRect([geometry.coordinates[0], geometry.coordinates[1]])
-  ) {
-    return true
+  if (geometry.type === 'Point') {
+    const gx = geometry.coordinates[0]
+    const gy = geometry.coordinates[1]
+    if (gx >= rectMinX && gx <= rectMaxX && gy >= rectMinY && gy <= rectMaxY) {
+      return true
+    }
+    return false
   }
 
   // Any polygon vertex inside rect
-  if (geometry.type !== 'Point') {
-    const rings =
-      geometry.type === 'Polygon'
-        ? geometry.coordinates
-        : geometry.coordinates.flatMap((poly) => poly)
-    for (const ring of rings) {
-      for (const [lon, lat] of ring) {
-        if (pointInRect([lon, lat])) return true
+  const rings =
+    geometry.type === 'Polygon'
+      ? geometry.coordinates
+      : geometry.coordinates.flatMap((poly) => poly)
+  for (const ring of rings) {
+    for (const coord of ring) {
+      if (
+        coord[0] >= rectMinX &&
+        coord[0] <= rectMaxX &&
+        coord[1] >= rectMinY &&
+        coord[1] <= rectMaxY
+      ) {
+        return true
       }
     }
   }
@@ -523,45 +821,20 @@ function rectIntersectsGeometry(
     [rect[3], rect[0]],
   ]
 
-  const edgesFromRing = (ring: number[][]) =>
-    ring
-      .slice(0, -1)
-      .map(
-        (_, i) => [ring[i], ring[i + 1]] as [[number, number], [number, number]]
-      )
-
-  const segments =
+  // Build edge segments without intermediate array allocations
+  const outerRings: number[][][] =
     geometry.type === 'Polygon'
-      ? edgesFromRing(geometry.coordinates[0])
-      : geometry.type === 'MultiPolygon'
-      ? geometry.coordinates.flatMap((poly) => edgesFromRing(poly[0]))
-      : []
-
-  const intersects = (
-    a1: [number, number],
-    a2: [number, number],
-    b1: [number, number],
-    b2: [number, number]
-  ): boolean => {
-    const cross = (v1: [number, number], v2: [number, number]) =>
-      v1[0] * v2[1] - v1[1] * v2[0]
-    const sub = (p1: [number, number], p2: [number, number]) =>
-      [p1[0] - p2[0], p1[1] - p2[1]] as [number, number]
-
-    const d1 = sub(a2, a1)
-    const d2 = sub(b2, b1)
-    const denom = cross(d1, d2)
-    if (denom === 0) return false
-
-    const s = cross(sub(b1, a1), d2) / denom
-    const t = cross(sub(b1, a1), d1) / denom
-    return s >= 0 && s <= 1 && t >= 0 && t <= 1
-  }
+      ? [geometry.coordinates[0]]
+      : geometry.coordinates.map((poly) => poly[0])
 
   for (const edge of rectEdges) {
-    for (const seg of segments) {
-      if (intersects(edge[0], edge[1], seg[0], seg[1])) {
-        return true
+    for (const ring of outerRings) {
+      for (let i = 0; i < ring.length - 1; i++) {
+        const b1 = ring[i] as [number, number]
+        const b2 = ring[i + 1] as [number, number]
+        if (segmentsIntersect(edge[0], edge[1], b1, b2)) {
+          return true
+        }
       }
     }
   }
@@ -601,48 +874,6 @@ function pixelRectLonLat(
   return corners
 }
 
-/**
- * Rectangle (pixel) corners in lon/lat for single-image mode.
- * Uses pixelToLatLon for consistent handling of all CRS types including proj4 reprojection.
- */
-function pixelRectLonLatSingle(
-  bounds: MercatorBounds,
-  width: number,
-  height: number,
-  x: number,
-  y: number,
-  crs: CRS,
-  latIsAscending?: boolean,
-  proj4def?: string | null,
-  sourceBounds?: Bounds | null,
-  cachedTransformer?: CachedTransformer
-): [number, number][] {
-  const offsets = [
-    [0, 0],
-    [1, 0],
-    [1, 1],
-    [0, 1],
-  ]
-  const corners: [number, number][] = []
-  for (const [dx, dy] of offsets) {
-    const { lon, lat } = pixelToLatLon(
-      x + dx,
-      y + dy,
-      bounds,
-      width,
-      height,
-      crs,
-      latIsAscending,
-      proj4def,
-      sourceBounds,
-      cachedTransformer,
-      false // Use pixel corners, not centers
-    )
-    corners.push([lon, lat])
-  }
-  return corners
-}
-
 export function pixelIntersectsGeometryTiled(
   tile: TileTuple,
   pixelX: number,
@@ -653,34 +884,6 @@ export function pixelIntersectsGeometryTiled(
   geometry: QueryGeometry
 ): boolean {
   const rect = pixelRectLonLat(tile, pixelX, pixelY, tileSize, crs, xyLimits)
-  return rectIntersectsGeometry(rect, geometry)
-}
-
-export function pixelIntersectsGeometrySingle(
-  bounds: MercatorBounds,
-  width: number,
-  height: number,
-  x: number,
-  y: number,
-  crs: CRS,
-  geometry: QueryGeometry,
-  latIsAscending?: boolean,
-  proj4def?: string | null,
-  sourceBounds?: Bounds | null,
-  cachedTransformer?: CachedTransformer
-): boolean {
-  const rect = pixelRectLonLatSingle(
-    bounds,
-    width,
-    height,
-    x,
-    y,
-    crs,
-    latIsAscending,
-    proj4def,
-    sourceBounds,
-    cachedTransformer
-  )
   return rectIntersectsGeometry(rect, geometry)
 }
 

--- a/src/query/query-utils.ts
+++ b/src/query/query-utils.ts
@@ -19,12 +19,34 @@ import {
   type MercatorBounds,
 } from '../map-utils'
 import type { Bounds, CRS } from '../types'
-import type { BoundingBox, QueryGeometry } from './types'
+import type { BoundingBox, QueryGeometry, GeoJSONMultiPolygon } from './types'
 import {
   createWGS84ToSourceTransformer,
   sourceCRSToPixel,
   pixelToSourceCRS,
 } from '../projection-utils'
+
+/** Pixel rectangle with exclusive max bounds. */
+export interface PixelRect {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+}
+
+/**
+ * Check if a raster's own extent crosses the antimeridian (EPSG:4326 only).
+ * Returns true when the two-strip antimeridian query path is unsupported.
+ */
+export function rasterExtentCrossesAntimeridian(
+  crs: CRS,
+  xyLimits?: XYLimits | null
+): boolean {
+  if (crs !== 'EPSG:4326' || !xyLimits) return false
+  return (
+    xyLimits.xMin > xyLimits.xMax || xyLimits.xMax > 180 || xyLimits.xMin < -180
+  )
+}
 
 /** Cached transformer type for reuse across multiple pixelToLatLon calls */
 export type CachedTransformer = ReturnType<
@@ -254,6 +276,65 @@ export function computeBoundingBox(geometry: QueryGeometry): BoundingBox {
 }
 
 /**
+ * Compute the Y pixel range for a south/north lat extent against raster bounds.
+ * Handles both EPSG:4326 (linear latitude) and Mercator (normalized coords).
+ * Returns null if no overlap.
+ */
+function computeYPixelRange(
+  south: number,
+  north: number,
+  bounds: MercatorBounds,
+  height: number,
+  crs: CRS,
+  latIsAscending?: boolean
+): { yStart: number; yEnd: number } | null {
+  if (
+    crs === 'EPSG:4326' &&
+    bounds.latMin !== undefined &&
+    bounds.latMax !== undefined
+  ) {
+    const latRange = bounds.latMax - bounds.latMin
+    if (latRange === 0) return null
+    const clampedNorth = Math.min(Math.max(north, bounds.latMin), bounds.latMax)
+    const clampedSouth = Math.min(Math.max(south, bounds.latMin), bounds.latMax)
+    const toFrac = (lat: number) =>
+      latIsAscending
+        ? (lat - bounds.latMin!) / latRange
+        : (bounds.latMax! - lat) / latRange
+    const yFracMin = Math.min(toFrac(clampedNorth), toFrac(clampedSouth))
+    const yFracMax = Math.max(toFrac(clampedNorth), toFrac(clampedSouth))
+    const yStart = Math.min(
+      Math.max(0, Math.floor(yFracMin * height)),
+      height - 1
+    )
+    const yEnd = Math.min(
+      height,
+      Math.max(Math.ceil(yFracMax * height), yStart + 1)
+    )
+    if (yEnd <= yStart) return null
+    return { yStart, yEnd }
+  }
+
+  // Mercator
+  const normNorth = latToMercatorNorm(north)
+  const normSouth = latToMercatorNorm(south)
+  const overlapY0 = Math.max(bounds.y0, Math.min(normNorth, normSouth))
+  const overlapY1 = Math.min(bounds.y1, Math.max(normNorth, normSouth))
+  if (overlapY1 < overlapY0) return null
+  const rawMinY = Math.floor(
+    ((overlapY0 - bounds.y0) / (bounds.y1 - bounds.y0)) * height
+  )
+  const rawMaxY = Math.ceil(
+    ((overlapY1 - bounds.y0) / (bounds.y1 - bounds.y0)) * height
+  )
+  if (rawMaxY <= 0 || rawMinY >= height) return null
+  const yStart = Math.min(Math.max(0, rawMinY), height - 1)
+  const yEnd = Math.min(height, Math.max(rawMaxY, yStart + 1))
+  if (yEnd <= yStart) return null
+  return { yStart, yEnd }
+}
+
+/**
  * Computes pixel bounds from a geometry's bounding box.
  * Returns the pixel range [minX, maxX, minY, maxY] that covers the geometry.
  * Supports custom projections via proj4.
@@ -268,7 +349,7 @@ export function computePixelBoundsFromGeometry(
   proj4def?: string | null,
   sourceBounds?: Bounds | null,
   cachedTransformer?: CachedTransformer
-): { minX: number; maxX: number; minY: number; maxY: number } | null {
+): PixelRect | null {
   const bbox = computeBoundingBox(geometry)
 
   // If proj4 is provided, use proj4 to transform bbox
@@ -337,73 +418,31 @@ export function computePixelBoundsFromGeometry(
     return { minX: xStart, maxX: xEnd, minY: yStart, maxY: yEnd }
   }
 
-  // Convert bbox corners to mercator normalized coords
+  // Y pixel range (shared helper for both CRS types)
+  const yRange = computeYPixelRange(
+    bbox.south,
+    bbox.north,
+    bounds,
+    height,
+    crs,
+    latIsAscending
+  )
+  if (!yRange) return null
+
+  // X pixel range (uses mercator norm for both CRS types)
   const polyX0 = lonToMercatorNorm(bbox.west)
   const polyX1 = lonToMercatorNorm(bbox.east)
-  const polyY0 = latToMercatorNorm(bbox.north)
-  const polyY1 = latToMercatorNorm(bbox.south)
-
-  // Compute overlap with image bounds
   const overlapX0 = Math.max(bounds.x0, Math.min(polyX0, polyX1))
   const overlapX1 = Math.min(bounds.x1, Math.max(polyX0, polyX1))
+  if (overlapX1 < overlapX0) return null
 
-  let xStart: number
-  let xEnd: number
-  let yStart: number
-  let yEnd: number
+  const rawMinX = ((overlapX0 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
+  const rawMaxX = ((overlapX1 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
+  const xStart = Math.min(Math.max(0, Math.floor(rawMinX)), width - 1)
+  const xEnd = Math.min(width, Math.max(Math.ceil(rawMaxX), xStart + 1))
+  if (xEnd <= xStart) return null
 
-  if (
-    crs === 'EPSG:4326' &&
-    bounds.latMin !== undefined &&
-    bounds.latMax !== undefined
-  ) {
-    // For equirectangular data, compute Y overlap in linear latitude space
-    const latMax = bounds.latMax
-    const latMin = bounds.latMin
-    const clampedNorth = Math.min(Math.max(bbox.north, latMin), latMax)
-    const clampedSouth = Math.min(Math.max(bbox.south, latMin), latMax)
-
-    const latRange = latMax - latMin
-    if (latRange === 0) return null
-
-    const toFrac = (latVal: number) =>
-      latIsAscending
-        ? (latVal - latMin) / latRange
-        : (latMax - latVal) / latRange
-    const yStartFracRaw = toFrac(clampedNorth)
-    const yEndFracRaw = toFrac(clampedSouth)
-    const yFracMin = Math.min(yStartFracRaw, yEndFracRaw)
-    const yFracMax = Math.max(yStartFracRaw, yEndFracRaw)
-
-    if (overlapX1 < overlapX0 || yFracMax < yFracMin) return null
-
-    const minX = ((overlapX0 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
-    const maxX = ((overlapX1 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
-
-    xStart = Math.min(Math.max(0, Math.floor(minX)), width - 1)
-    xEnd = Math.min(width, Math.max(Math.ceil(maxX), xStart + 1))
-    yStart = Math.min(Math.max(0, Math.floor(yFracMin * height)), height - 1)
-    yEnd = Math.min(height, Math.max(Math.ceil(yFracMax * height), yStart + 1))
-  } else {
-    const overlapY0 = Math.max(bounds.y0, Math.min(polyY0, polyY1))
-    const overlapY1 = Math.min(bounds.y1, Math.max(polyY0, polyY1))
-
-    if (overlapX1 < overlapX0 || overlapY1 < overlapY0) return null
-
-    const minX = ((overlapX0 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
-    const maxX = ((overlapX1 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
-    const minY = ((overlapY0 - bounds.y0) / (bounds.y1 - bounds.y0)) * height
-    const maxY = ((overlapY1 - bounds.y0) / (bounds.y1 - bounds.y0)) * height
-
-    xStart = Math.min(Math.max(0, Math.floor(minX)), width - 1)
-    xEnd = Math.min(width, Math.max(Math.ceil(maxX), xStart + 1))
-    yStart = Math.min(Math.max(0, Math.floor(minY)), height - 1)
-    yEnd = Math.min(height, Math.max(Math.ceil(maxY), yStart + 1))
-  }
-
-  if (xEnd <= xStart || yEnd <= yStart) return null
-
-  return { minX: xStart, maxX: xEnd, minY: yStart, maxY: yEnd }
+  return { minX: xStart, maxX: xEnd, minY: yRange.yStart, maxY: yRange.yEnd }
 }
 
 import {
@@ -881,4 +920,584 @@ export function getTilesForPolygon(
 ): TileTuple[] {
   const bbox = computeBoundingBox(geometry)
   return getTilesForBoundingBox(bbox, zoom, crs, xyLimits)
+}
+
+// ---------------------------------------------------------------------------
+// Antimeridian preprocessing
+// ---------------------------------------------------------------------------
+
+/**
+ * Bounding box that correctly represents antimeridian-crossing regions.
+ * When crossesAntimeridian is true, west > east (e.g. west=170, east=-170).
+ */
+export interface WrappedBoundingBox {
+  west: number // in [-180, 180]
+  east: number // in [-180, 180]
+  south: number
+  north: number
+  crossesAntimeridian: boolean
+}
+
+/**
+ * Wrap a longitude into (-180, 180], preserving 180 (not folding to -180).
+ */
+function wrapLon(lon: number): number {
+  let w = (lon + 180) % 360
+  if (w < 0) w += 360
+  w -= 180
+  // Preserve 180: the modulo maps 180 to -180, but we want 180
+  if (w === -180 && lon > 0) w = 180
+  return w
+}
+
+/**
+ * Ensure a ring is closed (last vertex equals first vertex).
+ */
+function closeRing(ring: number[][]): number[][] {
+  if (ring.length < 2) return ring
+  const first = ring[0]
+  const last = ring[ring.length - 1]
+  if (first[0] !== last[0] || first[1] !== last[1]) {
+    return [...ring, [first[0], first[1]]]
+  }
+  return ring
+}
+
+/**
+ * Compute the centroid longitude of a closed ring (excludes closing vertex).
+ */
+function ringCentroidLon(ring: number[][]): number {
+  const count = Math.max(1, ring.length - 1)
+  let sum = 0
+  for (let i = 0; i < count; i++) {
+    sum += ring[i][0]
+  }
+  return sum / count
+}
+
+/**
+ * Find the single ±360° shift that places centroidLon closest to targetCenter.
+ */
+function nearestLonShift(centroidLon: number, targetCenter: number): number {
+  return Math.round((targetCenter - centroidLon) / 360) * 360
+}
+
+/**
+ * Shift all ring longitudes by a fixed offset.
+ */
+function shiftRingsLon(rings: number[][][], shift: number): number[][][] {
+  return rings.map((ring) => ring.map(([lon, lat]) => [lon + shift, lat]))
+}
+
+/**
+ * Scan closed rings for longitude range (excludes closing vertices).
+ */
+function lonRangeOfRings(rings: number[][][]): {
+  min: number
+  allAbove180: boolean
+} {
+  let min = Infinity
+  let allAbove180 = true
+  for (const ring of rings) {
+    for (let i = 0; i < ring.length - 1; i++) {
+      const lon = ring[i][0]
+      if (lon < min) min = lon
+      if (lon <= 180) allAbove180 = false
+    }
+  }
+  return { min, allAbove180 }
+}
+
+/**
+ * Compute the shift needed to canonicalize a longitude range:
+ * +360 if any lon < -180, -360 if all lons > 180, else 0.
+ */
+function canonicalLonShift(rings: number[][][]): number {
+  const { min, allAbove180 } = lonRangeOfRings(rings)
+  if (min < -180) return 360
+  if (allAbove180) return -360
+  return 0
+}
+
+/**
+ * Apply canonical longitude shift to a ring array.
+ */
+function canonicalizeLonRange(rings: number[][][]): number[][][] {
+  const shift = canonicalLonShift(rings)
+  return shift !== 0 ? shiftRingsLon(rings, shift) : rings
+}
+
+/**
+ * Normalize a polygon's ring longitudes for continuity.
+ *
+ * The outer ring (index 0) determines the unwrap direction. Holes (index 1+)
+ * are shifted by a single per-ring ±360 offset to match the outer ring's
+ * coordinate frame. If the result extends below -180, all rings are shifted
+ * +360 to canonicalize to eastward extension.
+ *
+ * Output rings are always closed.
+ */
+export function normalizePolygonRings(rings: number[][][]): number[][][] {
+  if (rings.length === 0) return rings
+
+  // Check if any vertex in any ring is outside [-180, 180] (explicit crossing)
+  let hasExplicit = false
+  for (const ring of rings) {
+    for (const [lon] of ring) {
+      if (lon > 180 || lon < -180) {
+        hasExplicit = true
+        break
+      }
+    }
+    if (hasExplicit) break
+  }
+
+  // All vertices in [-180, 180]: literal interpretation, just ensure rings are closed
+  if (!hasExplicit) {
+    return rings.map((ring) => closeRing(ring.map(([lon, lat]) => [lon, lat])))
+  }
+
+  // Explicit crossing: normalize outer ring for longitude continuity
+  const outer = normalizeRingLongitudes(rings[0])
+
+  // Align hole rings to outer ring's frame with a single per-ring ±360 shift
+  const outerCenter = ringCentroidLon(outer)
+  const result: number[][][] = [outer]
+  for (let r = 1; r < rings.length; r++) {
+    const hole = normalizeRingLongitudes(rings[r])
+    const shift = nearestLonShift(ringCentroidLon(hole), outerCenter)
+    result.push(
+      shift !== 0 ? hole.map(([lon, lat]) => [lon + shift, lat]) : hole
+    )
+  }
+
+  return canonicalizeLonRange(result)
+}
+
+/**
+ * Apply per-edge longitude unwrapping for continuity.
+ *
+ * Only called when the caller has already verified explicit out-of-range
+ * coordinates (|lon| > 180). Returns a new closed ring.
+ */
+function normalizeRingLongitudes(ring: number[][]): number[][] {
+  if (ring.length < 2) return ring.map(([lon, lat]) => [lon, lat])
+
+  const result: number[][] = [[ring[0][0], ring[0][1]]]
+  let prevLon = ring[0][0]
+
+  for (let i = 1; i < ring.length; i++) {
+    let lon = ring[i][0]
+    const lat = ring[i][1]
+    const delta = lon - prevLon
+    if (delta > 180) {
+      lon -= 360
+    } else if (delta < -180) {
+      lon += 360
+    }
+    result.push([lon, lat])
+    prevLon = lon
+  }
+
+  return closeRing(result)
+}
+
+/**
+ * Compute a WrappedBoundingBox from normalized polygon rings.
+ * Input rings must already be processed by normalizePolygonRings.
+ * Uses wrap-normalization (not clamping) for crossings.
+ */
+export function computeWrappedBboxFromNormalized(
+  normalizedRings: number[][][]
+): WrappedBoundingBox {
+  let rawMin = Infinity
+  let rawMax = -Infinity
+  let south = Infinity
+  let north = -Infinity
+
+  for (const ring of normalizedRings) {
+    for (let i = 0; i < ring.length - 1; i++) {
+      const lon = ring[i][0]
+      const lat = ring[i][1]
+      if (lon < rawMin) rawMin = lon
+      if (lon > rawMax) rawMax = lon
+      if (lat < south) south = lat
+      if (lat > north) north = lat
+    }
+  }
+
+  if (rawMin >= -180 && rawMax <= 180) {
+    return {
+      west: rawMin,
+      east: rawMax,
+      south,
+      north,
+      crossesAntimeridian: false,
+    }
+  }
+
+  // Crossing: rawMax > 180 (westward was canonicalized to eastward)
+  const west = wrapLon(rawMin)
+  const east = wrapLon(rawMax)
+  // Guard: if wrapping collapses the crossing (e.g. rawMin = -180 exactly),
+  // treat as non-crossing. This can't happen for valid simple polygons after
+  // canonicalization, but defends the west > east invariant.
+  if (west <= east) {
+    return { west, east, south, north, crossesAntimeridian: false }
+  }
+  return { west, east, south, north, crossesAntimeridian: true }
+}
+
+/**
+ * Sutherland-Hodgman clip of a closed ring against a half-plane.
+ *
+ * keepBelow=true:  keep lon <= clipLon
+ * keepBelow=false: keep lon > clipLon (output lons shifted by -360)
+ *
+ * Returns a closed ring (possibly empty or degenerate).
+ */
+export function clipRingToHalfPlane(
+  ring: number[][],
+  clipLon: number,
+  keepBelow: boolean
+): number[][] {
+  if (ring.length < 4) return [] // need at least a triangle (3 vertices + close)
+
+  const output: number[][] = []
+  const isInside = keepBelow
+    ? (lon: number) => lon <= clipLon
+    : (lon: number) => lon > clipLon
+
+  // Walk edges of the closed ring (ring[i] -> ring[i+1])
+  for (let i = 0; i < ring.length - 1; i++) {
+    const [lon0, lat0] = ring[i]
+    const [lon1, lat1] = ring[i + 1]
+    const in0 = isInside(lon0)
+    const in1 = isInside(lon1)
+
+    if (in0 && in1) {
+      // Both inside: output p1
+      output.push([lon1, lat1])
+    } else if (in0 && !in1) {
+      // Inside -> outside: output intersection
+      const t = (clipLon - lon0) / (lon1 - lon0)
+      const latI = lat0 + t * (lat1 - lat0)
+      output.push([clipLon, latI])
+    } else if (!in0 && in1) {
+      // Outside -> inside: output intersection, then p1
+      const t = (clipLon - lon0) / (lon1 - lon0)
+      const latI = lat0 + t * (lat1 - lat0)
+      output.push([clipLon, latI])
+      output.push([lon1, lat1])
+    }
+    // Both outside: output nothing
+  }
+
+  if (output.length < 3) return []
+
+  // Shift longitudes for the "outside" half
+  const shifted = !keepBelow
+    ? output.map(([lon, lat]) => [lon - 360, lat])
+    : output
+
+  return closeRing(shifted)
+}
+
+/**
+ * Clip a normalized polygon (outer + holes) at the antimeridian.
+ *
+ * Input rings must already be processed by normalizePolygonRings
+ * (crossing is always > 180, never < -180).
+ *
+ * Returns west (lon <= 180) and east (lon > 180, shifted -360) ring sets.
+ * Degenerate rings (< 3 unique vertices) are dropped.
+ */
+export function clipNormalizedPolygonAtAntimeridian(
+  normalizedRings: number[][][]
+): { west: number[][][]; east: number[][][] } {
+  // Check if any vertex lon > 180; if not, no crossing
+  let crosses = false
+  for (const ring of normalizedRings) {
+    for (let i = 0; i < ring.length - 1; i++) {
+      if (ring[i][0] > 180) {
+        crosses = true
+        break
+      }
+    }
+    if (crosses) break
+  }
+
+  if (!crosses) {
+    return { west: normalizedRings, east: [] }
+  }
+
+  const west: number[][][] = []
+  const east: number[][][] = []
+
+  for (const ring of normalizedRings) {
+    const w = clipRingToHalfPlane(ring, 180, true)
+    const e = clipRingToHalfPlane(ring, 180, false)
+    if (w.length >= 4) west.push(w)
+    if (e.length >= 4) east.push(e)
+  }
+
+  return { west, east }
+}
+
+/**
+ * Align independently-normalized MultiPolygon members into one shared unwrap frame.
+ *
+ * Uses gap detection across all outer rings to find the optimal unwrap center,
+ * then shifts each member by a single ±360 offset (preserving internal continuity).
+ * Applies eastward canonicalization if the shared range extends below -180.
+ */
+export function alignMultiPolygonMembers(
+  members: number[][][][]
+): number[][][][] {
+  if (members.length <= 1) return members
+
+  // Collect all outer ring lons, wrap-normalized to [-180, 180]
+  const wrappedLons: number[] = []
+  for (const member of members) {
+    const outer = member[0]
+    for (let i = 0; i < outer.length - 1; i++) {
+      wrappedLons.push(wrapLon(outer[i][0]))
+    }
+  }
+  wrappedLons.sort((a, b) => a - b)
+
+  // Find the largest gap between consecutive sorted lons (including wrap-around)
+  let maxGap = 0
+  let gapEndIndex = 0
+  for (let i = 1; i < wrappedLons.length; i++) {
+    const gap = wrappedLons[i] - wrappedLons[i - 1]
+    if (gap > maxGap) {
+      maxGap = gap
+      gapEndIndex = i
+    }
+  }
+  // Check the wrap-around gap
+  const wrapGap = wrappedLons[0] + 360 - wrappedLons[wrappedLons.length - 1]
+  if (wrapGap > maxGap) {
+    maxGap = wrapGap
+    gapEndIndex = 0
+  }
+
+  // The unwrap center is opposite the largest gap (180° from the gap's midpoint)
+  const gapStart =
+    gapEndIndex === 0
+      ? wrappedLons[wrappedLons.length - 1]
+      : wrappedLons[gapEndIndex - 1]
+  const gapEnd = wrappedLons[gapEndIndex]
+  const gapMidpoint =
+    gapEndIndex === 0 ? (gapStart + gapEnd + 360) / 2 : (gapStart + gapEnd) / 2
+  const center = wrapLon(gapMidpoint + 180)
+
+  // Shift each member by a single ±360 offset based on its outer ring centroid
+  const aligned: number[][][][] = members.map((member) => {
+    const shift = nearestLonShift(ringCentroidLon(member[0]), center)
+    return shift !== 0
+      ? member.map((ring) => ring.map(([lon, lat]) => [lon + shift, lat]))
+      : member
+  })
+
+  // Canonicalize: shift all if any lon < -180, or all > 180
+  const shift = canonicalLonShift(aligned.flatMap((m) => m))
+  if (shift !== 0) {
+    return aligned.map((member) => shiftRingsLon(member, shift))
+  }
+
+  return aligned
+}
+
+/**
+ * Preprocess a query geometry for antimeridian handling.
+ *
+ * For Polygon/MultiPolygon: normalizes ring longitudes, computes a
+ * WrappedBoundingBox, and clips at ±180 if crossing. For Point: returns as-is.
+ *
+ * Standard CRS only (EPSG:3857, EPSG:4326). Proj4 callers should skip this.
+ */
+export function preprocessQueryGeometry(geometry: QueryGeometry): {
+  geometry: QueryGeometry
+  bbox: WrappedBoundingBox
+} {
+  if (geometry.type === 'Point') {
+    const [lon, lat] = geometry.coordinates
+    return {
+      geometry,
+      bbox: {
+        west: lon,
+        east: lon,
+        south: lat,
+        north: lat,
+        crossesAntimeridian: false,
+      },
+    }
+  }
+
+  if (geometry.type === 'Polygon') {
+    const normalized = normalizePolygonRings(geometry.coordinates)
+    const bbox = computeWrappedBboxFromNormalized(normalized)
+
+    if (!bbox.crossesAntimeridian) {
+      return { geometry: { type: 'Polygon', coordinates: normalized }, bbox }
+    }
+
+    const { west, east } = clipNormalizedPolygonAtAntimeridian(normalized)
+    const polygons: number[][][][] = []
+    if (west.length > 0) polygons.push(west)
+    if (east.length > 0) polygons.push(east)
+
+    if (polygons.length === 0) {
+      return { geometry: { type: 'Polygon', coordinates: normalized }, bbox }
+    }
+
+    return {
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: polygons,
+      } as GeoJSONMultiPolygon,
+      bbox,
+    }
+  }
+
+  // MultiPolygon: normalize each member, align, compute combined bbox, clip
+  const normalizedMembers = geometry.coordinates.map((memberRings) =>
+    normalizePolygonRings(memberRings)
+  )
+  const aligned = alignMultiPolygonMembers(normalizedMembers)
+
+  // Compute combined bbox from all aligned rings
+  const allRings: number[][][] = []
+  for (const member of aligned) {
+    for (const ring of member) {
+      allRings.push(ring)
+    }
+  }
+  const bbox = computeWrappedBboxFromNormalized(allRings)
+
+  if (!bbox.crossesAntimeridian) {
+    return {
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: aligned,
+      } as GeoJSONMultiPolygon,
+      bbox,
+    }
+  }
+
+  // Clip each member
+  const resultPolygons: number[][][][] = []
+  for (const member of aligned) {
+    const { west, east } = clipNormalizedPolygonAtAntimeridian(member)
+    if (west.length > 0) resultPolygons.push(west)
+    if (east.length > 0) resultPolygons.push(east)
+  }
+
+  if (resultPolygons.length === 0) {
+    return {
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: aligned,
+      } as GeoJSONMultiPolygon,
+      bbox,
+    }
+  }
+
+  return {
+    geometry: {
+      type: 'MultiPolygon',
+      coordinates: resultPolygons,
+    } as GeoJSONMultiPolygon,
+    bbox,
+  }
+}
+
+/**
+ * Derive two pixel rectangles from a crossing WrappedBoundingBox.
+ *
+ * West strip: [westPx, width)  — covers lon [bbox.west, 180]
+ * East strip: [0, eastPx)      — covers lon [-180, bbox.east]
+ *
+ * Uses standard-CRS floor/ceil/clamp conventions from computePixelBoundsFromGeometry.
+ * Only valid for standard CRS (EPSG:3857, EPSG:4326), not proj4.
+ */
+export function wrappedBboxToPixelSpans(
+  bbox: WrappedBoundingBox,
+  bounds: MercatorBounds,
+  width: number,
+  height: number,
+  crs: CRS,
+  latIsAscending?: boolean
+): { west?: PixelRect; east?: PixelRect } {
+  // Y range shared by both strips
+  const yRange = computeYPixelRange(
+    bbox.south,
+    bbox.north,
+    bounds,
+    height,
+    crs,
+    latIsAscending
+  )
+  if (!yRange) return {}
+  const { yStart, yEnd } = yRange
+
+  const xRange = bounds.x1 - bounds.x0
+
+  const computeStrip = (
+    normMin: number,
+    normMax: number
+  ): PixelRect | undefined => {
+    const xFracMin = (normMin - bounds.x0) / xRange
+    const xFracMax = (normMax - bounds.x0) / xRange
+    // Raw pixel range before clamping
+    const rawMinX = Math.floor(xFracMin * width)
+    const rawMaxX = Math.ceil(xFracMax * width)
+    // Check for actual overlap with [0, width) before clamping
+    if (rawMaxX <= 0 || rawMinX >= width) return undefined
+    const minX = Math.max(0, rawMinX)
+    const maxX = Math.min(width, rawMaxX)
+    if (maxX <= minX) return undefined
+    return { minX, maxX, minY: yStart, maxY: yEnd }
+  }
+
+  // West strip: [bbox.west, 180]
+  const westNormMin = lonToMercatorNorm(bbox.west)
+  const westNormMax = lonToMercatorNorm(180)
+  // East strip: [-180, bbox.east]
+  const eastNormMin = lonToMercatorNorm(-180)
+  const eastNormMax = lonToMercatorNorm(bbox.east)
+
+  const result: { west?: PixelRect; east?: PixelRect } = {}
+
+  const westStrip = computeStrip(westNormMin, westNormMax)
+  if (westStrip) result.west = westStrip
+  const eastStrip = computeStrip(eastNormMin, eastNormMax)
+  if (eastStrip) result.east = eastStrip
+
+  return result
+}
+
+/**
+ * Check if a geometry contains explicit out-of-range coordinates (|lon| > 180).
+ *
+ * This does NOT determine whether the geometry actually crosses the antimeridian —
+ * coords like [200, 210] are out-of-range but canonicalize to a non-crossing
+ * [-160, -150]. Use preprocessQueryGeometry().bbox.crossesAntimeridian for that.
+ */
+export function hasOutOfRangeCoordinates(geometry: QueryGeometry): boolean {
+  if (geometry.type === 'Point') {
+    const [lon] = geometry.coordinates
+    return lon > 180 || lon < -180
+  }
+
+  const checkRing = (ring: number[][]): boolean =>
+    ring.some(([lon]) => lon > 180 || lon < -180)
+
+  if (geometry.type === 'Polygon') {
+    return geometry.coordinates.some(checkRing)
+  }
+
+  return geometry.coordinates.some((poly) => poly.some(checkRing))
 }

--- a/src/query/query-utils.ts
+++ b/src/query/query-utils.ts
@@ -407,14 +407,12 @@ export function computePixelBoundsFromGeometry(
 
 import { DEFAULT_QUERY_DENSIFY_MAX_ERROR } from '../constants'
 
-/** Max pixel-space error before an edge is subdivided */
-const DENSIFY_MAX_ERROR = DEFAULT_QUERY_DENSIFY_MAX_ERROR
 /** Max recursion depth for adaptive subdivision */
 const DENSIFY_MAX_DEPTH = 10
 
 /**
  * Densify a ring by adaptively subdividing edges until the pixel-space error
- * is below DENSIFY_MAX_ERROR. For each edge, the midpoint is interpolated in
+ * is below DEFAULT_QUERY_DENSIFY_MAX_ERROR. For each edge, the midpoint is interpolated in
  * source coordinates (lon/lat), transformed to pixel space, and compared to
  * the straight-line midpoint in pixel space. If the deviation exceeds the
  * threshold, the edge is recursively split.
@@ -454,7 +452,10 @@ function densifyAndTransformRing(
     const dy = pxM[1] - expectedY
     const error = dx * dx + dy * dy // compare squared to avoid sqrt
 
-    if (error > DENSIFY_MAX_ERROR * DENSIFY_MAX_ERROR) {
+    if (
+      error >
+      DEFAULT_QUERY_DENSIFY_MAX_ERROR * DEFAULT_QUERY_DENSIFY_MAX_ERROR
+    ) {
       subdivide(lon0, lat0, px0, lonM, latM, pxM, depth + 1)
       result.push(pxM as number[])
       subdivide(lonM, latM, pxM, lon1, lat1, px1, depth + 1)
@@ -952,88 +953,4 @@ export function getTilesForPolygon(
 ): TileTuple[] {
   const bbox = computeBoundingBox(geometry)
   return getTilesForBoundingBox(bbox, zoom, crs, xyLimits)
-}
-
-/**
- * Converts mercator bounds to pixel coordinates within a data array.
- * Used for single-image mode queries.
- * Supports custom projections via proj4.
- */
-export function mercatorBoundsToPixel(
-  lng: number,
-  lat: number,
-  bounds: MercatorBounds,
-  width: number,
-  height: number,
-  crs: CRS,
-  latIsAscending?: boolean,
-  proj4def?: string | null,
-  sourceBounds?: Bounds | null,
-  cachedTransformer?: CachedTransformer
-): { x: number; y: number } | null {
-  // If proj4 is provided, use proj4 to transform lat/lon → source CRS → pixel
-  if (proj4def && sourceBounds) {
-    const transformer =
-      cachedTransformer ?? createWGS84ToSourceTransformer(proj4def)
-    const [srcX, srcY] = transformer.forward(lng, lat)
-
-    // Check if within source bounds
-    const [xMin, yMin, xMax, yMax] = sourceBounds
-    if (srcX < xMin || srcX > xMax || srcY < yMin || srcY > yMax) {
-      return null
-    }
-
-    // Convert source CRS coords to pixel indices
-    const [xPixel, yPixel] = sourceCRSToPixel(
-      srcX,
-      srcY,
-      sourceBounds,
-      width,
-      height,
-      latIsAscending
-    )
-
-    const x = Math.floor(xPixel)
-    const y = Math.floor(yPixel)
-
-    if (x < 0 || x >= width || y < 0 || y >= height) {
-      return null
-    }
-
-    return { x, y }
-  }
-
-  let normX: number
-  let normY: number
-
-  if (
-    crs === 'EPSG:4326' &&
-    bounds.latMin !== undefined &&
-    bounds.latMax !== undefined
-  ) {
-    // For equirectangular data, use linear lat mapping
-    normX = (lonToMercatorNorm(lng) - bounds.x0) / (bounds.x1 - bounds.x0)
-    // Convert lat to mercator for display, but sample linearly in source data
-    const latRange = bounds.latMax - bounds.latMin
-    if (latRange === 0) return null
-    const latNorm = latIsAscending
-      ? (lat - bounds.latMin) / latRange
-      : (bounds.latMax - lat) / latRange
-    normY = latNorm
-  } else {
-    normX = (lonToMercatorNorm(lng) - bounds.x0) / (bounds.x1 - bounds.x0)
-    normY = (latToMercatorNorm(lat) - bounds.y0) / (bounds.y1 - bounds.y0)
-  }
-
-  if (normX < 0 || normX > 1 || normY < 0 || normY > 1) {
-    return null
-  }
-
-  const x = Math.floor(normX * width)
-  const y = Math.floor(normY * height)
-
-  return {
-    x: Math.min(x, width - 1),
-    y: Math.min(y, height - 1),
-  }
 }

--- a/src/query/query-utils.ts
+++ b/src/query/query-utils.ts
@@ -405,7 +405,10 @@ export function computePixelBoundsFromGeometry(
   return { minX: xStart, maxX: xEnd, minY: yStart, maxY: yEnd }
 }
 
-import { DEFAULT_QUERY_DENSIFY_MAX_ERROR } from '../constants'
+import {
+  DEFAULT_QUERY_DENSIFY_MAX_ERROR,
+  MERCATOR_LAT_LIMIT,
+} from '../constants'
 
 /** Max recursion depth for adaptive subdivision */
 const DENSIFY_MAX_DEPTH = 10
@@ -495,7 +498,7 @@ function densifyAndTransformRing(
  * Densifies edges to preserve curvature under nonlinear projections.
  *
  * Returns a geometry with the same GeoJSON ring structure but in pixel coordinates,
- * suitable for use with pointInGeoJSON / pointInPolygon.
+ * suitable for use with scanline rasterization.
  */
 export function transformGeometryToPixelSpace(
   geometry: QueryGeometry,
@@ -592,6 +595,79 @@ export function transformGeometryToPixelSpace(
 }
 
 /**
+ * Transform a query geometry from WGS84 lon/lat into tile-pixel coordinates.
+ * For EPSG:3857 the lat→Y mapping is nonlinear, so edges are densified.
+ * For EPSG:4326 the mapping is linear and vertices are transformed directly.
+ */
+export function transformGeometryToTilePixelSpace(
+  geometry: QueryGeometry,
+  tile: TileTuple,
+  tileSize: number,
+  crs: CRS,
+  xyLimits: XYLimits
+): QueryGeometry | null {
+  const transformVertex = (lon: number, lat: number): [number, number] => {
+    // Clamp latitude to Mercator limits to avoid infinities at the poles
+    const clampedLat =
+      crs !== 'EPSG:4326'
+        ? Math.max(-MERCATOR_LAT_LIMIT, Math.min(MERCATOR_LAT_LIMIT, lat))
+        : lat
+    const { fracX, fracY } = geoToTileFraction(
+      lon,
+      clampedLat,
+      tile,
+      crs,
+      xyLimits
+    )
+    return [fracX * tileSize, fracY * tileSize]
+  }
+
+  if (geometry.type === 'Point') {
+    const [lon, lat] = geometry.coordinates
+    const pt = transformVertex(lon, lat)
+    if (!isFinite(pt[0]) || !isFinite(pt[1])) return null
+    return { type: 'Point', coordinates: [pt[0], pt[1]] }
+  }
+
+  // EPSG:3857 is nonlinear in Y; EPSG:4326 is linear
+  const needsDensification = crs !== 'EPSG:4326'
+
+  const transformRing = (ring: number[][]): number[][] => {
+    if (needsDensification) {
+      return densifyAndTransformRing(ring, transformVertex)
+    }
+    const result: number[][] = []
+    for (const [lon, lat] of ring) {
+      const pt = transformVertex(lon, lat)
+      if (isFinite(pt[0]) && isFinite(pt[1])) {
+        result.push(pt as number[])
+      }
+    }
+    if (
+      result.length > 1 &&
+      (result[0][0] !== result[result.length - 1][0] ||
+        result[0][1] !== result[result.length - 1][1])
+    ) {
+      result.push([result[0][0], result[0][1]])
+    }
+    return result
+  }
+
+  if (geometry.type === 'Polygon') {
+    const coords = geometry.coordinates.map(transformRing)
+    if (coords[0].length < 4) return null
+    return { type: 'Polygon', coordinates: coords }
+  }
+
+  const coords = geometry.coordinates.map((polygon) =>
+    polygon.map(transformRing)
+  )
+  const valid = coords.filter((poly) => poly[0].length >= 4)
+  if (valid.length === 0) return null
+  return { type: 'MultiPolygon', coordinates: valid }
+}
+
+/**
  * Convert a single lon/lat point to pixel coordinates.
  * Handles proj4, EPSG:4326, and EPSG:3857.
  */
@@ -648,23 +724,17 @@ function lonLatToPixel(
 }
 
 /**
- * Scanline fill: precompute sorted X-intersections for each row in the pixel-space polygon.
+ * Build a scanline table for a single polygon (outer ring + holes).
  * Returns a Map from integer Y to sorted array of X-intersection values.
- * For each row, pixels between pairs of intersections (0-1, 2-3, ...) are inside.
- *
- * Uses center-based sampling (row + 0.5) matching standard rasterization tools
- * (GDAL/rasterio default). A pixel is included if its center is inside the polygon.
- *
- * This replaces per-pixel pointInPolygon, changing complexity from O(W*H*V) to O(H*E + H*E*logE).
  */
-export function buildScanlineTable(
-  geometry: QueryGeometry,
+function buildScanlineTableForRings(
+  rings: number[][][],
   yStart: number,
   yEnd: number
 ): Map<number, number[]> {
   const table = new Map<number, number[]>()
 
-  const processRing = (ring: number[][]) => {
+  for (const ring of rings) {
     for (let i = 0; i < ring.length - 1; i++) {
       const x0 = ring[i][0]
       const y0 = ring[i][1]
@@ -675,7 +745,6 @@ export function buildScanlineTable(
 
       const edgeYMin = Math.min(y0, y1)
       const edgeYMax = Math.max(y0, y1)
-      // Only visit rows whose center (row + 0.5) falls within the edge's Y range
       const scanYMin = Math.max(yStart, Math.floor(edgeYMin + 0.5))
       const scanYMax = Math.min(yEnd - 1, Math.ceil(edgeYMax - 0.5) - 1)
       const slope = (x1 - x0) / (y1 - y0)
@@ -693,14 +762,6 @@ export function buildScanlineTable(
     }
   }
 
-  if (geometry.type === 'Polygon') {
-    for (const ring of geometry.coordinates) processRing(ring)
-  } else if (geometry.type === 'MultiPolygon') {
-    for (const polygon of geometry.coordinates)
-      for (const ring of polygon) processRing(ring)
-  }
-
-  // Sort intersections for each row
   for (const [, arr] of table) {
     arr.sort((a, b) => a - b)
   }
@@ -709,216 +770,82 @@ export function buildScanlineTable(
 }
 
 /**
- * Ray-casting point-in-polygon test.
- * Tests if a point is inside a single polygon ring.
+ * Union two sets of scanline crossing pairs.
+ * Each input is a sorted array where consecutive pairs (0-1, 2-3, ...) define filled intervals.
+ * Returns a new sorted crossing array whose pairs represent the union of both interval sets.
  */
-export function pointInPolygon(
-  point: [number, number],
-  polygon: number[][]
-): boolean {
-  let inside = false
-  const [x, y] = point
+function unionScanlineIntervals(a: number[], b: number[]): number[] {
+  // Convert crossing pairs to [start, end] intervals
+  const intervals: [number, number][] = []
+  for (let i = 0; i < a.length - 1; i += 2) intervals.push([a[i], a[i + 1]])
+  for (let i = 0; i < b.length - 1; i += 2) intervals.push([b[i], b[i + 1]])
 
-  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
-    const xi = polygon[i][0]
-    const yi = polygon[i][1]
-    const xj = polygon[j][0]
-    const yj = polygon[j][1]
+  // Sort by start
+  intervals.sort((x, y) => x[0] - y[0])
 
-    if (yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) {
-      inside = !inside
+  // Merge overlapping intervals
+  const result: number[] = []
+  let [curStart, curEnd] = intervals[0]
+  for (let i = 1; i < intervals.length; i++) {
+    if (intervals[i][0] <= curEnd) {
+      curEnd = Math.max(curEnd, intervals[i][1])
+    } else {
+      result.push(curStart, curEnd)
+      curStart = intervals[i][0]
+      curEnd = intervals[i][1]
     }
   }
-
-  return inside
+  result.push(curStart, curEnd)
+  return result
 }
 
 /**
- * Tests if a point is inside a GeoJSON geometry (Polygon or MultiPolygon).
- * Correctly handles holes in polygons.
+ * Scanline fill: precompute sorted X-intersections for each row in the pixel-space polygon.
+ * Returns a Map from integer Y to sorted array of X-intersection values.
+ * For each row, pixels between pairs of intersections (0-1, 2-3, ...) are inside.
+ *
+ * Uses center-based sampling (row + 0.5) matching standard rasterization tools
+ * (GDAL/rasterio default). A pixel is included if its center is inside the polygon.
+ *
+ * For MultiPolygon, each polygon member is rasterized independently and intervals
+ * are merged with union semantics, so overlapping members are included (not cancelled
+ * by even-odd parity across members).
+ *
+ * Complexity: O(H*E + H*E*logE) vs O(W*H*V) for per-pixel point-in-polygon.
  */
-export function pointInGeoJSON(
-  point: [number, number],
-  geometry: QueryGeometry
-): boolean {
-  if (geometry.type === 'Point') {
-    return (
-      point[0] === geometry.coordinates[0] &&
-      point[1] === geometry.coordinates[1]
-    )
-  }
-
+export function buildScanlineTable(
+  geometry: QueryGeometry,
+  yStart: number,
+  yEnd: number
+): Map<number, number[]> {
   if (geometry.type === 'Polygon') {
-    // Test outer ring
-    if (!pointInPolygon(point, geometry.coordinates[0])) return false
-    // Test holes (if inside any hole, point is outside polygon)
-    for (let i = 1; i < geometry.coordinates.length; i++) {
-      if (pointInPolygon(point, geometry.coordinates[i])) return false
-    }
-    return true
+    return buildScanlineTableForRings(geometry.coordinates, yStart, yEnd)
   }
 
-  // MultiPolygon - check each polygon
-  for (const polygon of geometry.coordinates) {
-    if (pointInPolygon(point, polygon[0])) {
-      let inHole = false
-      for (let i = 1; i < polygon.length; i++) {
-        if (pointInPolygon(point, polygon[i])) {
-          inHole = true
-          break
-        }
-      }
-      if (!inHole) return true
-    }
-  }
-
-  return false
-}
-
-/**
- * Test if two line segments intersect using cross-product method.
- * Avoids allocations by inlining the math.
- */
-function segmentsIntersect(
-  a1: [number, number],
-  a2: [number, number],
-  b1: [number, number],
-  b2: [number, number]
-): boolean {
-  const d1x = a2[0] - a1[0]
-  const d1y = a2[1] - a1[1]
-  const d2x = b2[0] - b1[0]
-  const d2y = b2[1] - b1[1]
-  const denom = d1x * d2y - d1y * d2x
-  if (denom === 0) return false
-
-  const dx = b1[0] - a1[0]
-  const dy = b1[1] - a1[1]
-  const s = (dx * d2y - dy * d2x) / denom
-  const t = (dx * d1y - dy * d1x) / denom
-  return s >= 0 && s <= 1 && t >= 0 && t <= 1
-}
-
-/**
- * Lightweight polygon-rectangle intersection test.
- * Returns true if any rectangle corner is inside geometry,
- * any geometry vertex is inside rectangle, or if any edges intersect.
- */
-function rectIntersectsGeometry(
-  rect: [number, number][],
-  geometry: QueryGeometry
-): boolean {
-  // Inline min/max to avoid temporary arrays from Math.min(...rect.map(...))
-  const rectMinX = Math.min(rect[0][0], rect[1][0], rect[2][0], rect[3][0])
-  const rectMaxX = Math.max(rect[0][0], rect[1][0], rect[2][0], rect[3][0])
-  const rectMinY = Math.min(rect[0][1], rect[1][1], rect[2][1], rect[3][1])
-  const rectMaxY = Math.max(rect[0][1], rect[1][1], rect[2][1], rect[3][1])
-
-  // Any rect corner inside geometry (supports point or polygon)
-  for (const corner of rect) {
-    if (pointInGeoJSON(corner, geometry)) return true
-  }
-
-  // Point geometry inside rectangle
   if (geometry.type === 'Point') {
-    const gx = geometry.coordinates[0]
-    const gy = geometry.coordinates[1]
-    if (gx >= rectMinX && gx <= rectMaxX && gy >= rectMinY && gy <= rectMaxY) {
-      return true
-    }
-    return false
+    return new Map()
   }
 
-  // Any polygon vertex inside rect
-  const rings =
-    geometry.type === 'Polygon'
-      ? geometry.coordinates
-      : geometry.coordinates.flatMap((poly) => poly)
-  for (const ring of rings) {
-    for (const coord of ring) {
-      if (
-        coord[0] >= rectMinX &&
-        coord[0] <= rectMaxX &&
-        coord[1] >= rectMinY &&
-        coord[1] <= rectMaxY
-      ) {
-        return true
+  // MultiPolygon: rasterize each polygon independently, then merge intervals
+  const perPolygon = geometry.coordinates.map((polygon) =>
+    buildScanlineTableForRings(polygon, yStart, yEnd)
+  )
+  if (perPolygon.length === 1) return perPolygon[0]
+
+  // Merge: collect all rows, union their interval sets
+  const merged = new Map<number, number[]>()
+  for (const table of perPolygon) {
+    for (const [row, crossings] of table) {
+      // Convert crossing pairs to intervals, then merge with existing
+      const existing = merged.get(row)
+      if (!existing) {
+        merged.set(row, crossings)
+      } else {
+        merged.set(row, unionScanlineIntervals(existing, crossings))
       }
     }
   }
-
-  // Edge intersection: rectangle edges vs polygon edges (outer rings only)
-  const rectEdges: [[number, number], [number, number]][] = [
-    [rect[0], rect[1]],
-    [rect[1], rect[2]],
-    [rect[2], rect[3]],
-    [rect[3], rect[0]],
-  ]
-
-  // Build edge segments without intermediate array allocations
-  const outerRings: number[][][] =
-    geometry.type === 'Polygon'
-      ? [geometry.coordinates[0]]
-      : geometry.coordinates.map((poly) => poly[0])
-
-  for (const edge of rectEdges) {
-    for (const ring of outerRings) {
-      for (let i = 0; i < ring.length - 1; i++) {
-        const b1 = ring[i] as [number, number]
-        const b2 = ring[i + 1] as [number, number]
-        if (segmentsIntersect(edge[0], edge[1], b1, b2)) {
-          return true
-        }
-      }
-    }
-  }
-
-  return false
-}
-
-/**
- * Rectangle (pixel) corners in lon/lat for tiled mode.
- */
-function pixelRectLonLat(
-  tile: TileTuple,
-  pixelX: number,
-  pixelY: number,
-  tileSize: number,
-  crs: CRS,
-  xyLimits: XYLimits
-): [number, number][] {
-  const corners: [number, number][] = []
-  const offsets = [
-    [0, 0],
-    [1, 0],
-    [1, 1],
-    [0, 1],
-  ]
-  for (const [dx, dy] of offsets) {
-    const p = tilePixelToLatLon(
-      tile,
-      pixelX + dx,
-      pixelY + dy,
-      tileSize,
-      crs,
-      xyLimits
-    )
-    corners.push([p.lon, p.lat])
-  }
-  return corners
-}
-
-export function pixelIntersectsGeometryTiled(
-  tile: TileTuple,
-  pixelX: number,
-  pixelY: number,
-  tileSize: number,
-  crs: CRS,
-  xyLimits: XYLimits,
-  geometry: QueryGeometry
-): boolean {
-  const rect = pixelRectLonLat(tile, pixelX, pixelY, tileSize, crs, xyLimits)
-  return rectIntersectsGeometry(rect, geometry)
+  return merged
 }
 
 /**

--- a/src/query/query-utils.ts
+++ b/src/query/query-utils.ts
@@ -405,36 +405,83 @@ export function computePixelBoundsFromGeometry(
   return { minX: xStart, maxX: xEnd, minY: yStart, maxY: yEnd }
 }
 
-/** Number of intermediate points to insert per polygon edge for densification */
-const DENSIFY_SEGMENTS = 10
+import { DEFAULT_QUERY_DENSIFY_MAX_ERROR } from '../constants'
+
+/** Max pixel-space error before an edge is subdivided */
+const DENSIFY_MAX_ERROR = DEFAULT_QUERY_DENSIFY_MAX_ERROR
+/** Max recursion depth for adaptive subdivision */
+const DENSIFY_MAX_DEPTH = 10
 
 /**
- * Densify a ring by inserting intermediate points along each edge.
- * Interpolates in the source coordinate system (lon/lat) and transforms each point.
+ * Densify a ring by adaptively subdividing edges until the pixel-space error
+ * is below DENSIFY_MAX_ERROR. For each edge, the midpoint is interpolated in
+ * source coordinates (lon/lat), transformed to pixel space, and compared to
+ * the straight-line midpoint in pixel space. If the deviation exceeds the
+ * threshold, the edge is recursively split.
+ *
+ * This matches the adaptive mesh reprojection precision (0.125px) so query
+ * polygon boundaries align with rendered pixel boundaries.
  */
 function densifyAndTransformRing(
   ring: number[][],
   transformVertex: (lon: number, lat: number) => [number, number]
 ): number[][] {
   const result: number[][] = []
+
+  function subdivide(
+    lon0: number,
+    lat0: number,
+    px0: [number, number],
+    lon1: number,
+    lat1: number,
+    px1: [number, number],
+    depth: number
+  ) {
+    if (depth >= DENSIFY_MAX_DEPTH) return
+
+    // Midpoint in source space
+    const lonM = (lon0 + lon1) * 0.5
+    const latM = (lat0 + lat1) * 0.5
+    const pxM = transformVertex(lonM, latM)
+    if (!isFinite(pxM[0]) || !isFinite(pxM[1])) return
+
+    // Straight-line midpoint in pixel space
+    const expectedX = (px0[0] + px1[0]) * 0.5
+    const expectedY = (px0[1] + px1[1]) * 0.5
+
+    // Error: distance from true projected midpoint to straight-line midpoint
+    const dx = pxM[0] - expectedX
+    const dy = pxM[1] - expectedY
+    const error = dx * dx + dy * dy // compare squared to avoid sqrt
+
+    if (error > DENSIFY_MAX_ERROR * DENSIFY_MAX_ERROR) {
+      subdivide(lon0, lat0, px0, lonM, latM, pxM, depth + 1)
+      result.push(pxM as number[])
+      subdivide(lonM, latM, pxM, lon1, lat1, px1, depth + 1)
+    }
+  }
+
   for (let i = 0; i < ring.length - 1; i++) {
     const [lon0, lat0] = ring[i]
     const [lon1, lat1] = ring[i + 1]
-    // Add start point
-    result.push(transformVertex(lon0, lat0) as number[])
-    // Add intermediate points
-    for (let s = 1; s < DENSIFY_SEGMENTS; s++) {
-      const t = s / DENSIFY_SEGMENTS
-      const lon = lon0 + t * (lon1 - lon0)
-      const lat = lat0 + t * (lat1 - lat0)
-      const pt = transformVertex(lon, lat)
-      if (isFinite(pt[0]) && isFinite(pt[1])) {
-        result.push(pt as number[])
-      }
+    const px0 = transformVertex(lon0, lat0)
+    const px1 = transformVertex(lon1, lat1)
+
+    if (isFinite(px0[0]) && isFinite(px0[1])) {
+      result.push(px0 as number[])
+    }
+    if (
+      isFinite(px0[0]) &&
+      isFinite(px0[1]) &&
+      isFinite(px1[0]) &&
+      isFinite(px1[1])
+    ) {
+      subdivide(lon0, lat0, px0, lon1, lat1, px1, 0)
     }
   }
-  // Close ring
-  if (result.length > 0) {
+
+  // Close ring (only if first vertex was valid)
+  if (result.length > 0 && isFinite(result[0][0]) && isFinite(result[0][1])) {
     result.push([result[0][0], result[0][1]])
   }
   return result
@@ -604,6 +651,9 @@ function lonLatToPixel(
  * Returns a Map from integer Y to sorted array of X-intersection values.
  * For each row, pixels between pairs of intersections (0-1, 2-3, ...) are inside.
  *
+ * Uses center-based sampling (row + 0.5) matching standard rasterization tools
+ * (GDAL/rasterio default). A pixel is included if its center is inside the polygon.
+ *
  * This replaces per-pixel pointInPolygon, changing complexity from O(W*H*V) to O(H*E + H*E*logE).
  */
 export function buildScanlineTable(
@@ -613,7 +663,6 @@ export function buildScanlineTable(
 ): Map<number, number[]> {
   const table = new Map<number, number[]>()
 
-  // Collect all edges from the geometry
   const processRing = (ring: number[][]) => {
     for (let i = 0; i < ring.length - 1; i++) {
       const x0 = ring[i][0]
@@ -621,28 +670,17 @@ export function buildScanlineTable(
       const x1 = ring[i + 1][0]
       const y1 = ring[i + 1][1]
 
-      // Skip horizontal edges
       if (y0 === y1) continue
 
       const edgeYMin = Math.min(y0, y1)
       const edgeYMax = Math.max(y0, y1)
-
-      // Clamp to scan range. Use pixel edges (row, row+1) not centers (row+0.5)
-      // so that any pixel whose rect overlaps the polygon is included.
-      const scanYMin = Math.max(yStart, Math.ceil(edgeYMin) - 1)
-      const scanYMax = Math.min(yEnd - 1, Math.floor(edgeYMax))
-
+      // Only visit rows whose center (row + 0.5) falls within the edge's Y range
+      const scanYMin = Math.max(yStart, Math.floor(edgeYMin + 0.5))
+      const scanYMax = Math.min(yEnd - 1, Math.ceil(edgeYMax - 0.5) - 1)
       const slope = (x1 - x0) / (y1 - y0)
 
       for (let row = scanYMin; row <= scanYMax; row++) {
-        // Intersect at the pixel edge closest to the polygon interior.
-        // For a row spanning [row, row+1], clamp scanY to the edge's Y range.
-        const scanY = Math.max(
-          edgeYMin + 1e-10,
-          Math.min(edgeYMax - 1e-10, row + 0.5)
-        )
-        if (scanY <= edgeYMin || scanY >= edgeYMax) continue
-
+        const scanY = row + 0.5
         const xIntersect = x0 + (scanY - y0) * slope
         let arr = table.get(row)
         if (!arr) {
@@ -655,15 +693,10 @@ export function buildScanlineTable(
   }
 
   if (geometry.type === 'Polygon') {
-    for (const ring of geometry.coordinates) {
-      processRing(ring)
-    }
+    for (const ring of geometry.coordinates) processRing(ring)
   } else if (geometry.type === 'MultiPolygon') {
-    for (const polygon of geometry.coordinates) {
-      for (const ring of polygon) {
-        processRing(ring)
-      }
-    }
+    for (const polygon of geometry.coordinates)
+      for (const ring of polygon) processRing(ring)
   }
 
   // Sort intersections for each row

--- a/src/query/query-utils.ts
+++ b/src/query/query-utils.ts
@@ -326,9 +326,10 @@ export function computePixelBoundsFromGeometry(
 
     // Clamp to valid range
     // Use floor + 1 to ensure integer maxX/maxY values include that pixel
-    const xStart = Math.max(0, Math.floor(minX))
+    // Clamp start to last pixel so points on the max edge map to the last pixel
+    const xStart = Math.min(Math.max(0, Math.floor(minX)), width - 1)
     const xEnd = Math.min(width, Math.max(Math.floor(maxX) + 1, xStart + 1))
-    const yStart = Math.max(0, Math.floor(minY))
+    const yStart = Math.min(Math.max(0, Math.floor(minY)), height - 1)
     const yEnd = Math.min(height, Math.max(Math.floor(maxY) + 1, yStart + 1))
 
     if (xEnd <= xStart || yEnd <= yStart) return null
@@ -379,9 +380,9 @@ export function computePixelBoundsFromGeometry(
     const minX = ((overlapX0 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
     const maxX = ((overlapX1 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
 
-    xStart = Math.max(0, Math.floor(minX))
+    xStart = Math.min(Math.max(0, Math.floor(minX)), width - 1)
     xEnd = Math.min(width, Math.max(Math.ceil(maxX), xStart + 1))
-    yStart = Math.max(0, Math.floor(yFracMin * height))
+    yStart = Math.min(Math.max(0, Math.floor(yFracMin * height)), height - 1)
     yEnd = Math.min(height, Math.max(Math.ceil(yFracMax * height), yStart + 1))
   } else {
     const overlapY0 = Math.max(bounds.y0, Math.min(polyY0, polyY1))
@@ -394,9 +395,9 @@ export function computePixelBoundsFromGeometry(
     const minY = ((overlapY0 - bounds.y0) / (bounds.y1 - bounds.y0)) * height
     const maxY = ((overlapY1 - bounds.y0) / (bounds.y1 - bounds.y0)) * height
 
-    xStart = Math.max(0, Math.floor(minX))
+    xStart = Math.min(Math.max(0, Math.floor(minX)), width - 1)
     xEnd = Math.min(width, Math.max(Math.ceil(maxX), xStart + 1))
-    yStart = Math.max(0, Math.floor(minY))
+    yStart = Math.min(Math.max(0, Math.floor(minY)), height - 1)
     yEnd = Math.min(height, Math.max(Math.ceil(maxY), yStart + 1))
   }
 

--- a/src/query/region-query.ts
+++ b/src/query/region-query.ts
@@ -7,33 +7,69 @@
  */
 
 import type { MercatorBounds, XYLimits } from '../map-utils'
-import {
-  latToMercatorNorm,
-  lonToMercatorNorm,
-  mercatorNormToLat,
-  mercatorNormToLon,
-  parseLevelZoom,
-  tileToKey,
-} from '../map-utils'
+import { parseLevelZoom, tileToKey } from '../map-utils'
 import type { ZarrStore } from '../zarr-store'
 import type { Bounds, CRS, Selector } from '../types'
+import { pixelToSourceCRS } from '../projection-utils'
 import type {
   QueryGeometry,
+  QueryOptions,
   QueryResult,
   QueryDataValues,
   QueryTransformOptions,
 } from './types'
 import {
-  computeBoundingBox,
   getTilesForPolygon,
-  pixelIntersectsGeometrySingle,
   pixelIntersectsGeometryTiled,
   tilePixelToLatLon,
   pixelToLatLon,
+  transformGeometryToPixelSpace,
+  buildScanlineTable,
   CachedTransformer,
 } from './query-utils'
 import { createWGS84ToSourceTransformer } from '../projection-utils'
 import { setObjectValues, getChunks, getPointValues } from './selector-utils'
+import { SPATIAL_DIMENSION_ALIASES, SPATIAL_DIM_NAMES } from '../constants'
+
+/**
+ * Determine spatial coordinate keys for query results.
+ *
+ * For proj4 data we emit source-CRS values, so keys match the store's
+ * original axis names (e.g. 'y'/'x').
+ *
+ * For standard CRS the values are always WGS84 lat/lon (from pixelToLatLon),
+ * so keys are always 'lat'/'lon' regardless of what the store calls its axes.
+ */
+function findSpatialDimNames(
+  dimensions: string[],
+  isProj4: boolean
+): {
+  yDim: string
+  xDim: string
+} {
+  if (!isProj4) return { yDim: 'lat', xDim: 'lon' }
+  const yAliases = SPATIAL_DIMENSION_ALIASES.lat
+  const xAliases = SPATIAL_DIMENSION_ALIASES.lon
+  const yDim =
+    dimensions.find((d) => yAliases.includes(d.toLowerCase())) ?? 'lat'
+  const xDim =
+    dimensions.find((d) => xAliases.includes(d.toLowerCase())) ?? 'lon'
+  return { yDim, xDim }
+}
+
+function isMultiValSelector(value: Selector[string]): boolean {
+  if (Array.isArray(value)) return true
+  if (value && typeof value === 'object' && 'selected' in value) {
+    return Array.isArray((value as any).selected)
+  }
+  return false
+}
+
+function checkAborted(signal?: AbortSignal) {
+  if (signal?.aborted) {
+    throw new DOMException('The operation was aborted.', 'AbortError')
+  }
+}
 
 /**
  * Apply scale_factor/add_offset transforms and filter invalid values.
@@ -73,8 +109,10 @@ export async function queryRegionTiled(
   xyLimits: XYLimits,
   levelIndex: number,
   tileSize: number,
-  transforms?: QueryTransformOptions
+  transforms?: QueryTransformOptions,
+  options?: QueryOptions
 ): Promise<QueryResult> {
+  const { signal, includeSpatialCoordinates = true } = options ?? {}
   const desc = zarrStore.describe()
   const dimensions = desc.dimensions
   const coordinates = desc.coordinates
@@ -83,13 +121,6 @@ export async function queryRegionTiled(
 
   // Calculate result dimension based on selector
   // resultDim = total dims - (number of single-valued dims)
-  const isMultiValSelector = (value: Selector[string]) => {
-    if (Array.isArray(value)) return true
-    if (value && typeof value === 'object' && 'selected' in value) {
-      return Array.isArray((value as any).selected)
-    }
-    return false
-  }
   const singleValuedDims = Object.keys(selector).filter(
     (k) => !isMultiValSelector(selector[k])
   ).length
@@ -99,30 +130,21 @@ export async function queryRegionTiled(
   const useNestedResults = resultDim > 2
   let results: QueryDataValues = useNestedResults ? {} : []
 
-  const latCoords: number[] = []
-  const lonCoords: number[] = []
+  const { yDim, xDim } = findSpatialDimNames(dimensions, false)
+  const yCoords: number[] = []
+  const xCoords: number[] = []
 
-  const mappedDimensions = dimensions.map((d) => {
-    const dimLower = d.toLowerCase()
-    if (['x', 'lon', 'longitude'].includes(dimLower)) return 'lon'
-    if (['y', 'lat', 'latitude'].includes(dimLower)) return 'lat'
-    return d
-  })
-
-  const resultDimensions = useNestedResults ? mappedDimensions : ['lat', 'lon']
+  const resultDimensions = useNestedResults ? dimensions : [yDim, xDim]
 
   const buildResultCoordinates = (): Record<string, (number | string)[]> => {
     const coords: Record<string, (number | string)[]> = {
-      lat: latCoords,
-      lon: lonCoords,
+      [yDim]: yCoords,
+      [xDim]: xCoords,
     }
 
     if (useNestedResults) {
       const addDimCoordinates = (dim: string) => {
-        const dimLower = dim.toLowerCase()
-        if (
-          ['x', 'lon', 'longitude', 'y', 'lat', 'latitude'].includes(dimLower)
-        ) {
+        if (SPATIAL_DIM_NAMES.has(dim.toLowerCase())) {
           return
         }
 
@@ -151,6 +173,13 @@ export async function queryRegionTiled(
     return coords
   }
 
+  const buildResult = () =>
+    ({
+      [variable]: results,
+      dimensions: resultDimensions,
+      coordinates: buildResultCoordinates(),
+    } as QueryResult)
+
   // Get level path for chunk fetching
   const levelPath = zarrStore.levels[levelIndex]
   if (!levelPath) {
@@ -162,15 +191,9 @@ export async function queryRegionTiled(
 
   // Get tiles that intersect the polygon
   const tiles = getTilesForPolygon(geometry, actualZoom, crs, xyLimits)
-  if (tiles.length === 0) {
-    // Return empty result in carbonplan/maps format
-    const result = {
-      [variable]: results,
-      dimensions: resultDimensions,
-      coordinates: buildResultCoordinates(),
-    } as QueryResult
-    return result
-  }
+  if (tiles.length === 0) return buildResult()
+
+  checkAborted(signal)
 
   // For each tile, determine which chunks we need based on selector and fetch them
   const tileChunkData = new Map<string, Map<string, Float32Array>>()
@@ -196,7 +219,11 @@ export async function queryRegionTiled(
       await Promise.all(
         chunksToFetch.map(async (chunkIndices) => {
           try {
-            const chunk = await zarrStore.getChunk(levelPath, chunkIndices)
+            const chunk = await zarrStore.getChunk(
+              levelPath,
+              chunkIndices,
+              signal ? { signal } : undefined
+            )
             // Make a proper copy to avoid buffer sharing issues
             const chunkData = new Float32Array(chunk.data as ArrayLike<number>)
 
@@ -204,6 +231,9 @@ export async function queryRegionTiled(
             const chunkKey = chunkIndices.join(',')
             chunkDataMap.set(chunkKey, chunkData)
           } catch (err) {
+            if (err instanceof DOMException && err.name === 'AbortError') {
+              throw err
+            }
             console.warn(
               `Failed to fetch chunk ${chunkIndices} for tile ${tileKey}:`,
               err
@@ -235,6 +265,7 @@ export async function queryRegionTiled(
     )
 
     for (let pixelY = 0; pixelY < tileSize; pixelY++) {
+      checkAborted(signal)
       for (let pixelX = 0; pixelX < tileSize; pixelX++) {
         if (
           !pixelIntersectsGeometryTiled(
@@ -281,17 +312,18 @@ export async function queryRegionTiled(
         // Only add coordinates and values if we have valid data
         if (pixelValues.length === 0) continue
 
-        const geo = tilePixelToLatLon(
-          tileTuple,
-          pixelX + 0.5,
-          pixelY + 0.5,
-          tileSize,
-          crs,
-          xyLimits
-        )
-
-        latCoords.push(geo.lat)
-        lonCoords.push(geo.lon)
+        if (includeSpatialCoordinates) {
+          const geo = tilePixelToLatLon(
+            tileTuple,
+            pixelX + 0.5,
+            pixelY + 0.5,
+            tileSize,
+            crs,
+            xyLimits
+          )
+          yCoords.push(geo.lat)
+          xCoords.push(geo.lon)
+        }
 
         for (const { keys, value } of pixelValues) {
           if (keys.length > 0) {
@@ -304,20 +336,14 @@ export async function queryRegionTiled(
     }
   }
 
-  const result = {
-    [variable]: results,
-    dimensions: resultDimensions,
-    coordinates: buildResultCoordinates(),
-  } as QueryResult
-
-  return result
+  return buildResult()
 }
 
 /**
  * Query a region in single-image mode.
  * Returns structure matching carbonplan/maps: { [variable]: values, dimensions, coordinates }
  */
-export async function queryRegionSingleImage(
+export function queryRegionUntiled(
   variable: string,
   geometry: QueryGeometry,
   selector: Selector,
@@ -334,16 +360,12 @@ export async function queryRegionSingleImage(
   latIsAscending?: boolean,
   transforms?: QueryTransformOptions,
   proj4def?: string | null,
-  sourceBounds?: Bounds | null
-): Promise<QueryResult> {
+  sourceBounds?: Bounds | null,
+  options?: QueryOptions
+): QueryResult {
+  const { signal, includeSpatialCoordinates = true } = options ?? {}
+
   // Calculate result dimension
-  const isMultiValSelector = (value: Selector[string]) => {
-    if (Array.isArray(value)) return true
-    if (value && typeof value === 'object' && 'selected' in value) {
-      return Array.isArray((value as any).selected)
-    }
-    return false
-  }
   const singleValuedDims = Object.keys(selector).filter(
     (k) => !isMultiValSelector(selector[k])
   ).length
@@ -353,30 +375,21 @@ export async function queryRegionSingleImage(
   const useNestedResults = resultDim > 2
   let results: QueryDataValues = useNestedResults ? {} : []
 
-  const latCoords: number[] = []
-  const lonCoords: number[] = []
+  const { yDim, xDim } = findSpatialDimNames(dimensions, !!proj4def)
+  const yCoords: number[] = []
+  const xCoords: number[] = []
 
-  const mappedDimensions = dimensions.map((d) => {
-    const dimLower = d.toLowerCase()
-    if (['x', 'lon', 'longitude'].includes(dimLower)) return 'lon'
-    if (['y', 'lat', 'latitude'].includes(dimLower)) return 'lat'
-    return d
-  })
-
-  const resultDimensions = useNestedResults ? mappedDimensions : ['lat', 'lon']
+  const resultDimensions = useNestedResults ? dimensions : [yDim, xDim]
 
   const buildResultCoordinates = (): Record<string, (number | string)[]> => {
     const coords: Record<string, (number | string)[]> = {
-      lat: latCoords,
-      lon: lonCoords,
+      [yDim]: yCoords,
+      [xDim]: xCoords,
     }
 
     if (useNestedResults) {
       const addDimCoordinates = (dim: string) => {
-        const dimLower = dim.toLowerCase()
-        if (
-          ['x', 'lon', 'longitude', 'y', 'lat', 'latitude'].includes(dimLower)
-        ) {
+        if (SPATIAL_DIM_NAMES.has(dim.toLowerCase())) {
           return
         }
 
@@ -405,195 +418,168 @@ export async function queryRegionSingleImage(
     return coords
   }
 
-  if (!data) {
-    const result = {
+  const buildResult = () =>
+    ({
       [variable]: results,
       dimensions: resultDimensions,
       coordinates: buildResultCoordinates(),
-    } as QueryResult
-    return result
-  }
+    } as QueryResult)
 
-  // Compute iteration bounds
-  // For proj4, the data is already the subset matching the geometry bbox,
-  // so iterate over all pixels. For standard CRS, compute overlap.
-  let xStart = 0
-  let xEnd = width
-  let yStart = 0
-  let yEnd = height
+  if (!data) return buildResult()
 
-  if (!proj4def) {
-    const bbox = computeBoundingBox(geometry)
-
-    // Compute overlap of polygon bbox with image bounds in mercator space
-    const polyX0 = lonToMercatorNorm(bbox.west)
-    const polyX1 = lonToMercatorNorm(bbox.east)
-    const polyY0 = latToMercatorNorm(bbox.north)
-    const polyY1 = latToMercatorNorm(bbox.south)
-
-    const overlapX0 = Math.max(bounds.x0, Math.min(polyX0, polyX1))
-    const overlapX1 = Math.min(bounds.x1, Math.max(polyX0, polyX1))
-
-    if (
-      _crs === 'EPSG:4326' &&
-      bounds.latMin !== undefined &&
-      bounds.latMax !== undefined
-    ) {
-      // For equirectangular data, compute Y overlap in linear latitude space.
-      const latMax = bounds.latMax
-      const latMin = bounds.latMin
-      const clampedNorth = Math.min(Math.max(bbox.north, latMin), latMax)
-      const clampedSouth = Math.min(Math.max(bbox.south, latMin), latMax)
-
-      const latRange = latMax - latMin
-      if (latRange === 0) {
-        const result = {
-          [variable]: results,
-          dimensions: resultDimensions,
-          coordinates: buildResultCoordinates(),
-        } as QueryResult
-        return result
-      }
-      const toFrac = (latVal: number) =>
-        latIsAscending
-          ? (latVal - latMin) / latRange
-          : (latMax - latVal) / latRange
-      const yStartFracRaw = toFrac(clampedNorth)
-      const yEndFracRaw = toFrac(clampedSouth)
-      const yFracMin = Math.min(yStartFracRaw, yEndFracRaw)
-      const yFracMax = Math.max(yStartFracRaw, yEndFracRaw)
-
-      if (overlapX1 <= overlapX0 || yFracMax <= yFracMin) {
-        const result = {
-          [variable]: results,
-          dimensions: resultDimensions,
-          coordinates: buildResultCoordinates(),
-        } as QueryResult
-        return result
-      }
-
-      const minX = ((overlapX0 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
-      const maxX = ((overlapX1 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
-
-      xStart = Math.max(0, Math.floor(minX))
-      xEnd = Math.min(width, Math.ceil(maxX + 1))
-      yStart = Math.max(0, Math.floor(yFracMin * height))
-      yEnd = Math.min(height, Math.ceil(yFracMax * height))
-    } else {
-      const overlapY0 = Math.max(bounds.y0, Math.min(polyY0, polyY1))
-      const overlapY1 = Math.min(bounds.y1, Math.max(polyY0, polyY1))
-
-      if (overlapX1 <= overlapX0 || overlapY1 <= overlapY0) {
-        const result = {
-          [variable]: results,
-          dimensions: resultDimensions,
-          coordinates: buildResultCoordinates(),
-        } as QueryResult
-        return result
-      }
-
-      const minX = ((overlapX0 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
-      const maxX = ((overlapX1 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
-      const minY = ((overlapY0 - bounds.y0) / (bounds.y1 - bounds.y0)) * height
-      const maxY = ((overlapY1 - bounds.y0) / (bounds.y1 - bounds.y0)) * height
-
-      xStart = Math.max(0, Math.floor(minX))
-      xEnd = Math.min(width, Math.ceil(maxX + 1))
-      yStart = Math.max(0, Math.floor(minY))
-      yEnd = Math.min(height, Math.ceil(maxY + 1))
-    }
-
-    if (xEnd <= xStart || yEnd <= yStart) {
-      const result = {
-        [variable]: results,
-        dimensions: resultDimensions,
-        coordinates: buildResultCoordinates(),
-      } as QueryResult
-      return result
-    }
-  }
+  checkAborted(signal)
 
   // Create transformer once for all pixels
   const cachedTransformer: CachedTransformer | undefined = proj4def
     ? createWGS84ToSourceTransformer(proj4def)
     : undefined
 
-  // Iterate pixels within bounding box
-  for (let y = yStart; y < yEnd; y++) {
-    for (let x = xStart; x < xEnd; x++) {
-      if (
-        !pixelIntersectsGeometrySingle(
-          bounds,
-          width,
-          height,
-          x,
-          y,
-          _crs,
-          geometry,
-          latIsAscending,
-          proj4def,
-          sourceBounds,
-          cachedTransformer
-        )
-      ) {
-        continue
+  // Transform the query polygon into pixel-space coordinates once.
+  // This eliminates per-pixel proj4 calls during the intersection test.
+  const pixelGeometry = transformGeometryToPixelSpace(
+    geometry,
+    bounds,
+    width,
+    height,
+    _crs,
+    latIsAscending,
+    proj4def,
+    sourceBounds,
+    cachedTransformer
+  )
+  if (!pixelGeometry) return buildResult()
+
+  // For proj4 data, emit source CRS coordinates via pure linear math (no inverse transform).
+  // For standard CRS, emit lat/lon via pixelToLatLon.
+  const emitCoords =
+    proj4def && sourceBounds
+      ? (x: number, y: number) => {
+          const [srcX, srcY] = pixelToSourceCRS(
+            x + 0.5,
+            y + 0.5,
+            sourceBounds,
+            width,
+            height,
+            latIsAscending
+          )
+          yCoords.push(srcY)
+          xCoords.push(srcX)
+        }
+      : (x: number, y: number) => {
+          const { lat, lon } = pixelToLatLon(
+            x,
+            y,
+            bounds,
+            width,
+            height,
+            _crs,
+            latIsAscending,
+            proj4def,
+            sourceBounds,
+            cachedTransformer
+          )
+          yCoords.push(lat)
+          xCoords.push(lon)
+        }
+
+  // Helper to process a single pixel
+  const processPixel = (x: number, y: number) => {
+    const baseIndex = (y * width + x) * channels
+
+    // Single-channel fast path
+    if (channels === 1 && !useNestedResults) {
+      const rawValue = data![baseIndex]
+      const transformed = transformValue(rawValue, transforms)
+      if (transformed === null) return
+
+      if (includeSpatialCoordinates) emitCoords(x, y)
+      ;(results as number[]).push(transformed)
+      return
+    }
+
+    // Multi-channel path
+    let hasValid = false
+    for (let c = 0; c < channels; c++) {
+      const rawValue = data![baseIndex + c]
+      const transformed = transformValue(rawValue, transforms)
+      if (transformed === null) continue
+
+      if (!hasValid) {
+        if (includeSpatialCoordinates) emitCoords(x, y)
+        hasValid = true
       }
 
-      // Use consolidated helper for pixel → lat/lon conversion
-      const { lat, lon } = pixelToLatLon(
-        x,
-        y,
-        bounds,
-        width,
-        height,
-        _crs,
-        latIsAscending,
-        proj4def,
-        sourceBounds,
-        cachedTransformer
-      )
-
-      const baseIndex = (y * width + x) * channels
-
-      // Collect valid values for this pixel first
-      const pixelValues: { keys: (string | number)[]; value: number }[] = []
-
-      for (let c = 0; c < channels; c++) {
-        const rawValue = data[baseIndex + c]
-        const transformed = transformValue(rawValue, transforms)
-        if (transformed === null) continue
-
-        if (useNestedResults && multiValueDimNames) {
-          const labels = channelLabels?.[c]
-          const keys =
-            labels && labels.length === multiValueDimNames.length ? labels : [c]
-          pixelValues.push({ keys, value: transformed })
-        } else {
-          pixelValues.push({ keys: [], value: transformed })
-        }
-      }
-
-      // Only add coordinates and values if we have valid data
-      if (pixelValues.length === 0) continue
-
-      latCoords.push(lat)
-      lonCoords.push(lon)
-
-      for (const { keys, value } of pixelValues) {
-        if (keys.length > 0) {
-          setObjectValues(results, keys, value)
-        } else if (Array.isArray(results)) {
-          results.push(value)
-        }
+      if (useNestedResults && multiValueDimNames) {
+        const labels = channelLabels?.[c]
+        const keys =
+          labels && labels.length === multiValueDimNames.length ? labels : [c]
+        setObjectValues(results, keys, transformed)
+      } else if (Array.isArray(results)) {
+        results.push(transformed)
       }
     }
   }
 
-  const result = {
-    [variable]: results,
-    dimensions: resultDimensions,
-    coordinates: buildResultCoordinates(),
-  } as QueryResult
+  // Point geometry: process the single pixel directly
+  if (pixelGeometry.type === 'Point') {
+    const px = Math.floor(pixelGeometry.coordinates[0])
+    const py = Math.floor(pixelGeometry.coordinates[1])
+    if (px >= 0 && px < width && py >= 0 && py < height) {
+      processPixel(px, py)
+    }
+    return buildResult()
+  }
 
-  return result
+  // Polygon/MultiPolygon: compute tight bbox and scanline table
+  let pxMinX = Infinity
+  let pxMaxX = -Infinity
+  let pxMinY = Infinity
+  let pxMaxY = -Infinity
+
+  const scanRings = (rings: number[][][]) => {
+    for (const ring of rings) {
+      for (const [px, py] of ring) {
+        if (px < pxMinX) pxMinX = px
+        if (px > pxMaxX) pxMaxX = px
+        if (py < pxMinY) pxMinY = py
+        if (py > pxMaxY) pxMaxY = py
+      }
+    }
+  }
+  if (pixelGeometry.type === 'Polygon') {
+    scanRings(pixelGeometry.coordinates)
+  } else {
+    for (const poly of pixelGeometry.coordinates) scanRings(poly)
+  }
+
+  const xStart = Math.max(0, Math.floor(pxMinX))
+  const xEnd = Math.min(width, Math.ceil(pxMaxX))
+  const yStart = Math.max(0, Math.floor(pxMinY))
+  const yEnd = Math.min(height, Math.ceil(pxMaxY))
+
+  if (xEnd <= xStart || yEnd <= yStart) return buildResult()
+
+  // Build scanline intersection table: for each row Y, sorted X-crossings of polygon edges.
+  // Pixels between consecutive pairs of crossings are inside the polygon.
+  // This replaces per-pixel pointInGeoJSON, eliminating the O(V) cost per pixel.
+  const scanlines = buildScanlineTable(pixelGeometry, yStart, yEnd)
+
+  // Iterate rows using the scanline table
+  for (let y = yStart; y < yEnd; y++) {
+    checkAborted(signal)
+    const crossings = scanlines.get(y)
+    if (!crossings || crossings.length < 2) continue
+
+    // Walk crossing pairs: include any pixel whose rect overlaps the polygon.
+    for (let i = 0; i < crossings.length - 1; i += 2) {
+      const xFrom = Math.max(xStart, Math.floor(crossings[i]))
+      const xTo = Math.min(xEnd, Math.ceil(crossings[i + 1]))
+
+      for (let x = xFrom; x < xTo; x++) {
+        processPixel(x, y)
+      }
+    }
+  }
+
+  return buildResult()
 }

--- a/src/query/region-query.ts
+++ b/src/query/region-query.ts
@@ -9,7 +9,7 @@
 import type { MercatorBounds, TileTuple, XYLimits } from '../map-utils'
 import { parseLevelZoom, tileToKey } from '../map-utils'
 import type { ZarrStore } from '../zarr-store'
-import type { Bounds, CRS, Selector } from '../types'
+import type { Bounds, CRS, DimIndicesProps, Selector } from '../types'
 import { pixelToSourceCRS } from '../projection-utils'
 import type {
   QueryGeometry,
@@ -29,32 +29,46 @@ import {
 } from './query-utils'
 import { createWGS84ToSourceTransformer } from '../projection-utils'
 import { setObjectValues, getChunks, getPointValues } from './selector-utils'
-import { SPATIAL_DIMENSION_ALIASES, SPATIAL_DIM_NAMES } from '../constants'
+import { SPATIAL_DIMENSION_ALIASES } from '../constants'
 
 /**
  * Determine spatial coordinate keys for query results.
  *
  * For proj4 data we emit source-CRS values, so keys match the store's
- * original axis names (e.g. 'y'/'x').
+ * original axis names (e.g. 'y'/'x' or 'projection_y_coordinate').
  *
  * For standard CRS the values are always WGS84 lat/lon (from pixelToLatLon),
  * so keys are always 'lat'/'lon' regardless of what the store calls its axes.
+ *
+ * Uses dimIndices (which incorporates spatialDimensions overrides) when available,
+ * falling back to alias matching on the raw dimension names.
  */
 function findSpatialDimNames(
   dimensions: string[],
-  isProj4: boolean
+  isProj4: boolean,
+  dimIndices?: DimIndicesProps
 ): {
   yDim: string
   xDim: string
+  /** The raw store dimension name for y, used to map resultDimensions */
+  yStoreDim: string
+  /** The raw store dimension name for x, used to map resultDimensions */
+  xStoreDim: string
 } {
-  if (!isProj4) return { yDim: 'lat', xDim: 'lon' }
-  const yAliases = SPATIAL_DIMENSION_ALIASES.lat
-  const xAliases = SPATIAL_DIMENSION_ALIASES.lon
-  const yDim =
-    dimensions.find((d) => yAliases.includes(d.toLowerCase())) ?? 'lat'
-  const xDim =
-    dimensions.find((d) => xAliases.includes(d.toLowerCase())) ?? 'lon'
-  return { yDim, xDim }
+  // Resolve the actual store dimension names from dimIndices if available
+  const yStoreDim = dimIndices?.lat?.name ?? findByAlias(dimensions, 'lat')
+  const xStoreDim = dimIndices?.lon?.name ?? findByAlias(dimensions, 'lon')
+
+  if (!isProj4) {
+    return { yDim: 'lat', xDim: 'lon', yStoreDim, xStoreDim }
+  }
+  // For proj4, emit coordinates under the store's own axis names
+  return { yDim: yStoreDim, xDim: xStoreDim, yStoreDim, xStoreDim }
+}
+
+function findByAlias(dimensions: string[], axis: 'lat' | 'lon'): string {
+  const aliases = SPATIAL_DIMENSION_ALIASES[axis]
+  return dimensions.find((d) => aliases.includes(d.toLowerCase())) ?? axis
 }
 
 function isMultiValSelector(value: Selector[string]): boolean {
@@ -205,11 +219,20 @@ export async function queryRegionTiled(
   const useNestedResults = resultDim > 2
   let results: QueryDataValues = useNestedResults ? {} : []
 
-  const { yDim, xDim } = findSpatialDimNames(dimensions, false)
+  const { yDim, xDim, yStoreDim, xStoreDim } = findSpatialDimNames(
+    dimensions,
+    false,
+    desc.dimIndices
+  )
   const yCoords: number[] = []
   const xCoords: number[] = []
 
-  const resultDimensions = useNestedResults ? dimensions : [yDim, xDim]
+  // Map spatial dimensions in the result to the emitted coordinate keys
+  const resultDimensions = useNestedResults
+    ? dimensions.map((d) =>
+        d === yStoreDim ? yDim : d === xStoreDim ? xDim : d
+      )
+    : [yDim, xDim]
 
   const buildResultCoordinates = (): Record<string, (number | string)[]> => {
     const coords: Record<string, (number | string)[]> = {
@@ -218,10 +241,9 @@ export async function queryRegionTiled(
     }
 
     if (useNestedResults) {
-      const addDimCoordinates = (dim: string) => {
-        if (SPATIAL_DIM_NAMES.has(dim.toLowerCase())) {
-          return
-        }
+      for (const dim of dimensions) {
+        // Skip spatial dimensions — they're already emitted as yDim/xDim
+        if (dim === yStoreDim || dim === xStoreDim) continue
 
         const sel = selector[dim]
         let values: (number | string)[] | undefined
@@ -241,8 +263,6 @@ export async function queryRegionTiled(
           coords[dim] = values
         }
       }
-
-      dimensions.forEach(addDimCoordinates)
     }
 
     return coords
@@ -443,7 +463,8 @@ export function queryRegionUntiled(
   transforms?: QueryTransformOptions,
   proj4def?: string | null,
   sourceBounds?: Bounds | null,
-  options?: QueryOptions
+  options?: QueryOptions,
+  dimIndices?: DimIndicesProps
 ): QueryResult {
   const { signal, includeSpatialCoordinates = true } = options ?? {}
 
@@ -457,11 +478,20 @@ export function queryRegionUntiled(
   const useNestedResults = resultDim > 2
   let results: QueryDataValues = useNestedResults ? {} : []
 
-  const { yDim, xDim } = findSpatialDimNames(dimensions, !!proj4def)
+  const { yDim, xDim, yStoreDim, xStoreDim } = findSpatialDimNames(
+    dimensions,
+    !!proj4def,
+    dimIndices
+  )
   const yCoords: number[] = []
   const xCoords: number[] = []
 
-  const resultDimensions = useNestedResults ? dimensions : [yDim, xDim]
+  // Map spatial dimensions in the result to the emitted coordinate keys
+  const resultDimensions = useNestedResults
+    ? dimensions.map((d) =>
+        d === yStoreDim ? yDim : d === xStoreDim ? xDim : d
+      )
+    : [yDim, xDim]
 
   const buildResultCoordinates = (): Record<string, (number | string)[]> => {
     const coords: Record<string, (number | string)[]> = {
@@ -470,10 +500,8 @@ export function queryRegionUntiled(
     }
 
     if (useNestedResults) {
-      const addDimCoordinates = (dim: string) => {
-        if (SPATIAL_DIM_NAMES.has(dim.toLowerCase())) {
-          return
-        }
+      for (const dim of dimensions) {
+        if (dim === yStoreDim || dim === xStoreDim) continue
 
         const sel = selector[dim]
         let values: (number | string)[] | undefined
@@ -493,8 +521,6 @@ export function queryRegionUntiled(
           coords[dim] = values
         }
       }
-
-      dimensions.forEach(addDimCoordinates)
     }
 
     return coords

--- a/src/query/region-query.ts
+++ b/src/query/region-query.ts
@@ -6,7 +6,7 @@
  * Matches carbonplan/maps structure and behavior.
  */
 
-import type { MercatorBounds, TileTuple, XYLimits } from '../map-utils'
+import type { MercatorBounds, XYLimits } from '../map-utils'
 import { parseLevelZoom, tileToKey } from '../map-utils'
 import type { ZarrStore } from '../zarr-store'
 import type { Bounds, CRS, DimIndicesProps, Selector } from '../types'
@@ -108,81 +108,6 @@ function transformValue(
   }
 
   return result
-}
-
-/**
- * Process a single pixel in tiled mode: extract values from chunks and emit results.
- */
-function processPixelTiled(
-  pixelX: number,
-  pixelY: number,
-  tileTuple: [number, number, number],
-  chunksForTile: number[][],
-  chunkDataMap: Map<string, Float32Array>,
-  selector: Selector,
-  dimensions: string[],
-  coordinates: Record<string, (number | string)[]>,
-  shape: number[],
-  chunks: number[],
-  transforms: QueryTransformOptions | undefined,
-  includeSpatialCoordinates: boolean,
-  tileSize: number,
-  crs: CRS,
-  xyLimits: XYLimits,
-  yCoords: number[],
-  xCoords: number[],
-  results: QueryDataValues,
-  useNestedResults: boolean
-) {
-  const pixelValues: { keys: (string | number)[]; value: number }[] = []
-
-  for (const chunkIndices of chunksForTile) {
-    const chunkKey = chunkIndices.join(',')
-    const chunkData = chunkDataMap.get(chunkKey)
-    if (!chunkData) continue
-
-    const valuesToSet = getPointValues(
-      chunkData,
-      pixelX,
-      pixelY,
-      selector,
-      dimensions,
-      coordinates,
-      shape,
-      chunks,
-      chunkIndices
-    )
-
-    for (const { keys, value } of valuesToSet) {
-      const transformed = transformValue(value, transforms)
-      if (transformed !== null) {
-        pixelValues.push({ keys, value: transformed })
-      }
-    }
-  }
-
-  if (pixelValues.length === 0) return
-
-  if (includeSpatialCoordinates) {
-    const geo = tilePixelToLatLon(
-      tileTuple,
-      pixelX + 0.5,
-      pixelY + 0.5,
-      tileSize,
-      crs,
-      xyLimits
-    )
-    yCoords.push(geo.lat)
-    xCoords.push(geo.lon)
-  }
-
-  for (const { keys, value } of pixelValues) {
-    if (keys.length > 0) {
-      setObjectValues(results, keys, value)
-    } else if (Array.isArray(results)) {
-      results.push(value)
-    }
-  }
 }
 
 /**
@@ -369,32 +294,66 @@ export async function queryRegionTiled(
       y
     )
 
-    // Point geometry: process the single pixel directly
-    if (tileGeometry.type === 'Point') {
-      const px = Math.min(Math.floor(tileGeometry.coordinates[0]), tileSize - 1)
-      const py = Math.min(Math.floor(tileGeometry.coordinates[1]), tileSize - 1)
-      if (px >= 0 && py >= 0) {
-        processPixelTiled(
-          px,
-          py,
-          tileTuple,
-          chunksForTile,
-          chunkDataMap,
+    // Process a single pixel: extract values from chunks and emit results.
+    // Defined per-tile so it captures tileTuple/chunksForTile/chunkDataMap.
+    const processPixel = (pixelX: number, pixelY: number) => {
+      const pixelValues: { keys: (string | number)[]; value: number }[] = []
+
+      for (const chunkIndices of chunksForTile) {
+        const chunkKey = chunkIndices.join(',')
+        const chunkData = chunkDataMap.get(chunkKey)
+        if (!chunkData) continue
+
+        const valuesToSet = getPointValues(
+          chunkData,
+          pixelX,
+          pixelY,
           selector,
           dimensions,
           coordinates,
           shape,
           chunks,
-          transforms,
-          includeSpatialCoordinates,
+          chunkIndices
+        )
+
+        for (const { keys, value } of valuesToSet) {
+          const transformed = transformValue(value, transforms)
+          if (transformed !== null) {
+            pixelValues.push({ keys, value: transformed })
+          }
+        }
+      }
+
+      if (pixelValues.length === 0) return
+
+      if (includeSpatialCoordinates) {
+        const geo = tilePixelToLatLon(
+          tileTuple,
+          pixelX + 0.5,
+          pixelY + 0.5,
           tileSize,
           crs,
-          xyLimits,
-          yCoords,
-          xCoords,
-          results,
-          useNestedResults
+          xyLimits
         )
+        yCoords.push(geo.lat)
+        xCoords.push(geo.lon)
+      }
+
+      for (const { keys, value } of pixelValues) {
+        if (keys.length > 0) {
+          setObjectValues(results, keys, value)
+        } else if (Array.isArray(results)) {
+          results.push(value)
+        }
+      }
+    }
+
+    // Point geometry: process the single pixel directly
+    if (tileGeometry.type === 'Point') {
+      const px = Math.min(Math.floor(tileGeometry.coordinates[0]), tileSize - 1)
+      const py = Math.min(Math.floor(tileGeometry.coordinates[1]), tileSize - 1)
+      if (px >= 0 && py >= 0) {
+        processPixel(px, py)
       }
       continue
     }
@@ -412,27 +371,7 @@ export async function queryRegionTiled(
         const xTo = Math.min(tileSize, Math.floor(crossings[i + 1] - 0.5) + 1)
 
         for (let pixelX = xFrom; pixelX < xTo; pixelX++) {
-          processPixelTiled(
-            pixelX,
-            pixelY,
-            tileTuple,
-            chunksForTile,
-            chunkDataMap,
-            selector,
-            dimensions,
-            coordinates,
-            shape,
-            chunks,
-            transforms,
-            includeSpatialCoordinates,
-            tileSize,
-            crs,
-            xyLimits,
-            yCoords,
-            xCoords,
-            results,
-            useNestedResults
-          )
+          processPixel(pixelX, pixelY)
         }
       }
     }
@@ -557,8 +496,8 @@ export function queryRegionUntiled(
   )
   if (!pixelGeometry) return buildResult()
 
-  // For proj4 data, emit source CRS coordinates via pure linear math (no inverse transform).
-  // For standard CRS, emit lat/lon via pixelToLatLon.
+  // Emit pixel-center coordinates: source CRS for proj4, lat/lon otherwise.
+  // Both paths use pixel centers (+0.5); pixelToLatLon applies it internally.
   const emitCoords =
     proj4def && sourceBounds
       ? (x: number, y: number) => {
@@ -581,10 +520,7 @@ export function queryRegionUntiled(
             width,
             height,
             _crs,
-            latIsAscending,
-            proj4def,
-            sourceBounds,
-            cachedTransformer
+            latIsAscending
           )
           yCoords.push(lat)
           xCoords.push(lon)

--- a/src/query/region-query.ts
+++ b/src/query/region-query.ts
@@ -20,12 +20,14 @@ import type {
 } from './types'
 import {
   getTilesForPolygon,
+  getTilesForBoundingBox,
   tilePixelToLatLon,
   pixelToLatLon,
   transformGeometryToPixelSpace,
   transformGeometryToTilePixelSpace,
   buildScanlineTable,
   CachedTransformer,
+  type WrappedBoundingBox,
 } from './query-utils'
 import { createWGS84ToSourceTransformer } from '../projection-utils'
 import { setObjectValues, getChunks, getPointValues } from './selector-utils'
@@ -43,7 +45,7 @@ import { SPATIAL_DIMENSION_ALIASES } from '../constants'
  * Uses dimIndices (which incorporates spatialDimensions overrides) when available,
  * falling back to alias matching on the raw dimension names.
  */
-function findSpatialDimNames(
+export function findSpatialDimNames(
   dimensions: string[],
   isProj4: boolean,
   dimIndices?: DimIndicesProps
@@ -124,7 +126,8 @@ export async function queryRegionTiled(
   levelIndex: number,
   tileSize: number,
   transforms?: QueryTransformOptions,
-  options?: QueryOptions
+  options?: QueryOptions,
+  wrappedBbox?: WrappedBoundingBox
 ): Promise<QueryResult> {
   const { signal, includeSpatialCoordinates = true } = options ?? {}
   const desc = zarrStore.describe()
@@ -210,7 +213,9 @@ export async function queryRegionTiled(
   const actualZoom = parseLevelZoom(levelPath, levelIndex)
 
   // Get tiles that intersect the polygon
-  const tiles = getTilesForPolygon(geometry, actualZoom, crs, xyLimits)
+  const tiles = wrappedBbox
+    ? getTilesForBoundingBox(wrappedBbox, actualZoom, crs, xyLimits)
+    : getTilesForPolygon(geometry, actualZoom, crs, xyLimits)
   if (tiles.length === 0) return buildResult()
 
   checkAborted(signal)

--- a/src/query/region-query.ts
+++ b/src/query/region-query.ts
@@ -570,10 +570,10 @@ export function queryRegionUntiled(
     const crossings = scanlines.get(y)
     if (!crossings || crossings.length < 2) continue
 
-    // Walk crossing pairs: include any pixel whose rect overlaps the polygon.
+    // Walk crossing pairs: include pixels whose center (x+0.5) is inside the interval.
     for (let i = 0; i < crossings.length - 1; i += 2) {
-      const xFrom = Math.max(xStart, Math.floor(crossings[i]))
-      const xTo = Math.min(xEnd, Math.ceil(crossings[i + 1]))
+      const xFrom = Math.max(xStart, Math.ceil(crossings[i] - 0.5))
+      const xTo = Math.min(xEnd, Math.floor(crossings[i + 1] - 0.5) + 1)
 
       for (let x = xFrom; x < xTo; x++) {
         processPixel(x, y)

--- a/src/query/region-query.ts
+++ b/src/query/region-query.ts
@@ -6,7 +6,7 @@
  * Matches carbonplan/maps structure and behavior.
  */
 
-import type { MercatorBounds, XYLimits } from '../map-utils'
+import type { MercatorBounds, TileTuple, XYLimits } from '../map-utils'
 import { parseLevelZoom, tileToKey } from '../map-utils'
 import type { ZarrStore } from '../zarr-store'
 import type { Bounds, CRS, Selector } from '../types'
@@ -20,10 +20,10 @@ import type {
 } from './types'
 import {
   getTilesForPolygon,
-  pixelIntersectsGeometryTiled,
   tilePixelToLatLon,
   pixelToLatLon,
   transformGeometryToPixelSpace,
+  transformGeometryToTilePixelSpace,
   buildScanlineTable,
   CachedTransformer,
 } from './query-utils'
@@ -94,6 +94,81 @@ function transformValue(
   }
 
   return result
+}
+
+/**
+ * Process a single pixel in tiled mode: extract values from chunks and emit results.
+ */
+function processPixelTiled(
+  pixelX: number,
+  pixelY: number,
+  tileTuple: [number, number, number],
+  chunksForTile: number[][],
+  chunkDataMap: Map<string, Float32Array>,
+  selector: Selector,
+  dimensions: string[],
+  coordinates: Record<string, (number | string)[]>,
+  shape: number[],
+  chunks: number[],
+  transforms: QueryTransformOptions | undefined,
+  includeSpatialCoordinates: boolean,
+  tileSize: number,
+  crs: CRS,
+  xyLimits: XYLimits,
+  yCoords: number[],
+  xCoords: number[],
+  results: QueryDataValues,
+  useNestedResults: boolean
+) {
+  const pixelValues: { keys: (string | number)[]; value: number }[] = []
+
+  for (const chunkIndices of chunksForTile) {
+    const chunkKey = chunkIndices.join(',')
+    const chunkData = chunkDataMap.get(chunkKey)
+    if (!chunkData) continue
+
+    const valuesToSet = getPointValues(
+      chunkData,
+      pixelX,
+      pixelY,
+      selector,
+      dimensions,
+      coordinates,
+      shape,
+      chunks,
+      chunkIndices
+    )
+
+    for (const { keys, value } of valuesToSet) {
+      const transformed = transformValue(value, transforms)
+      if (transformed !== null) {
+        pixelValues.push({ keys, value: transformed })
+      }
+    }
+  }
+
+  if (pixelValues.length === 0) return
+
+  if (includeSpatialCoordinates) {
+    const geo = tilePixelToLatLon(
+      tileTuple,
+      pixelX + 0.5,
+      pixelY + 0.5,
+      tileSize,
+      crs,
+      xyLimits
+    )
+    yCoords.push(geo.lat)
+    xCoords.push(geo.lon)
+  }
+
+  for (const { keys, value } of pixelValues) {
+    if (keys.length > 0) {
+      setObjectValues(results, keys, value)
+    } else if (Array.isArray(results)) {
+      results.push(value)
+    }
+  }
 }
 
 /**
@@ -246,11 +321,21 @@ export async function queryRegionTiled(
     })
   )
 
-  // Iterate over tiles and pixels to extract values
+  // Iterate over tiles, using scanline rasterization per tile
   for (const tileTuple of tiles) {
     const tileKey = tileToKey(tileTuple)
     const chunkDataMap = tileChunkData.get(tileKey)
     if (!chunkDataMap || chunkDataMap.size === 0) continue
+
+    // Transform geometry into this tile's pixel space once
+    const tileGeometry = transformGeometryToTilePixelSpace(
+      geometry,
+      tileTuple,
+      tileSize,
+      crs,
+      xyLimits
+    )
+    if (!tileGeometry) continue
 
     // Get all chunk indices for this tile
     const [, x, y] = tileTuple
@@ -264,73 +349,70 @@ export async function queryRegionTiled(
       y
     )
 
+    // Point geometry: process the single pixel directly
+    if (tileGeometry.type === 'Point') {
+      const px = Math.min(Math.floor(tileGeometry.coordinates[0]), tileSize - 1)
+      const py = Math.min(Math.floor(tileGeometry.coordinates[1]), tileSize - 1)
+      if (px >= 0 && py >= 0) {
+        processPixelTiled(
+          px,
+          py,
+          tileTuple,
+          chunksForTile,
+          chunkDataMap,
+          selector,
+          dimensions,
+          coordinates,
+          shape,
+          chunks,
+          transforms,
+          includeSpatialCoordinates,
+          tileSize,
+          crs,
+          xyLimits,
+          yCoords,
+          xCoords,
+          results,
+          useNestedResults
+        )
+      }
+      continue
+    }
+
+    // Build scanline table for this tile's pixel range
+    const scanlines = buildScanlineTable(tileGeometry, 0, tileSize)
+
     for (let pixelY = 0; pixelY < tileSize; pixelY++) {
       checkAborted(signal)
-      for (let pixelX = 0; pixelX < tileSize; pixelX++) {
-        if (
-          !pixelIntersectsGeometryTiled(
+      const crossings = scanlines.get(pixelY)
+      if (!crossings || crossings.length < 2) continue
+
+      for (let i = 0; i < crossings.length - 1; i += 2) {
+        const xFrom = Math.max(0, Math.ceil(crossings[i] - 0.5))
+        const xTo = Math.min(tileSize, Math.floor(crossings[i + 1] - 0.5) + 1)
+
+        for (let pixelX = xFrom; pixelX < xTo; pixelX++) {
+          processPixelTiled(
+            pixelX,
+            pixelY,
             tileTuple,
-            pixelX,
-            pixelY,
-            tileSize,
-            crs,
-            xyLimits,
-            geometry
-          )
-        ) {
-          continue
-        }
-
-        // Collect all values for this pixel first
-        const pixelValues: { keys: (string | number)[]; value: number }[] = []
-
-        for (const chunkIndices of chunksForTile) {
-          const chunkKey = chunkIndices.join(',')
-          const chunkData = chunkDataMap.get(chunkKey)
-          if (!chunkData) continue
-
-          const valuesToSet = getPointValues(
-            chunkData,
-            pixelX,
-            pixelY,
+            chunksForTile,
+            chunkDataMap,
             selector,
             dimensions,
             coordinates,
             shape,
             chunks,
-            chunkIndices
-          )
-
-          for (const { keys, value } of valuesToSet) {
-            const transformed = transformValue(value, transforms)
-            if (transformed !== null) {
-              pixelValues.push({ keys, value: transformed })
-            }
-          }
-        }
-
-        // Only add coordinates and values if we have valid data
-        if (pixelValues.length === 0) continue
-
-        if (includeSpatialCoordinates) {
-          const geo = tilePixelToLatLon(
-            tileTuple,
-            pixelX + 0.5,
-            pixelY + 0.5,
+            transforms,
+            includeSpatialCoordinates,
             tileSize,
             crs,
-            xyLimits
+            xyLimits,
+            yCoords,
+            xCoords,
+            results,
+            useNestedResults
           )
-          yCoords.push(geo.lat)
-          xCoords.push(geo.lon)
-        }
-
-        for (const { keys, value } of pixelValues) {
-          if (keys.length > 0) {
-            setObjectValues(results, keys, value)
-          } else if (Array.isArray(results)) {
-            results.push(value)
-          }
         }
       }
     }
@@ -522,9 +604,9 @@ export function queryRegionUntiled(
 
   // Point geometry: process the single pixel directly
   if (pixelGeometry.type === 'Point') {
-    const px = Math.floor(pixelGeometry.coordinates[0])
-    const py = Math.floor(pixelGeometry.coordinates[1])
-    if (px >= 0 && px < width && py >= 0 && py < height) {
+    const px = Math.min(Math.floor(pixelGeometry.coordinates[0]), width - 1)
+    const py = Math.min(Math.floor(pixelGeometry.coordinates[1]), height - 1)
+    if (px >= 0 && py >= 0) {
       processPixel(px, py)
     }
     return buildResult()
@@ -561,7 +643,7 @@ export function queryRegionUntiled(
 
   // Build scanline intersection table: for each row Y, sorted X-crossings of polygon edges.
   // Pixels between consecutive pairs of crossings are inside the polygon.
-  // This replaces per-pixel pointInGeoJSON, eliminating the O(V) cost per pixel.
+  // Scanline table eliminates the O(V) per-pixel cost of point-in-polygon tests.
   const scanlines = buildScanlineTable(pixelGeometry, yStart, yEnd)
 
   // Iterate rows using the scanline table

--- a/src/query/types.ts
+++ b/src/query/types.ts
@@ -17,6 +17,10 @@ export type QueryDataValues = number[] | NestedValues
 /**
  * Result from a query (point or region).
  * Matches carbonplan/maps structure: { [variable]: values, dimensions, coordinates }
+ *
+ * Spatial coordinate keys depend on the dataset's CRS:
+ * - Standard CRS (EPSG:3857/4326): `lat`/`lon`
+ * - Projected CRS (proj4): `y`/`x` in the source coordinate system
  */
 export interface QueryResult {
   /** Variable name mapped to its values (flat array or nested based on selector) */
@@ -24,12 +28,10 @@ export interface QueryResult {
     | QueryDataValues
     | string[]
     | { [key: string]: (number | string)[] }
-  /** Dimension names in order (e.g., ['month', 'lat', 'lon']) */
+  /** Dimension names in order (e.g., ['month', 'lat', 'lon'] or ['month', 'y', 'x']) */
   dimensions: string[]
   /** Coordinate arrays for each dimension */
   coordinates: {
-    lat: number[]
-    lon: number[]
     [key: string]: (number | string)[]
   }
 }
@@ -94,4 +96,14 @@ export interface QueryTransformOptions {
   addOffset?: number
   /** Fill value to filter out (along with NaN/Infinity) */
   fillValue?: number | null
+}
+
+/**
+ * Options for queryData calls.
+ */
+export interface QueryOptions {
+  /** AbortSignal to cancel the query. */
+  signal?: AbortSignal
+  /** Include per-pixel coordinates in the result. Defaults to true. */
+  includeSpatialCoordinates?: boolean
 }

--- a/src/tiled-mode.ts
+++ b/src/tiled-mode.ts
@@ -6,6 +6,10 @@ import type {
 } from './zarr-mode'
 import type { QueryGeometry, QueryOptions, QueryResult } from './query/types'
 import { queryRegionTiled } from './query/region-query'
+import {
+  preprocessQueryGeometry,
+  rasterExtentCrossesAntimeridian,
+} from './query/query-utils'
 import type {
   LoadingStateCallback,
   MapLike,
@@ -116,6 +120,8 @@ export class TiledMode implements ZarrMode {
   private selectorVersion: number = 0
   private throttleMs: number
   private fixedDataScale: number
+
+  private _antimeridianWarnings: Set<string> = new Set()
 
   // Shared state managers
   private throttleState: ThrottleState = createThrottleState()
@@ -575,22 +581,54 @@ export class TiledMode implements ZarrMode {
     const querySelector = selector ? normalizeSelector(selector) : this.selector
     const level = this.currentLevel ?? this.maxLevelIndex
     const desc = this.zarrStore.describe()
+    const transforms = {
+      scaleFactor: desc.scaleFactor,
+      addOffset: desc.addOffset,
+      fillValue: desc.fill_value,
+    }
+
+    // Antimeridian preprocessing
+    const { geometry: processedGeometry, bbox: wrappedBbox } =
+      preprocessQueryGeometry(geometry)
+
+    // Raster extent guard (EPSG:4326 only)
+    if (
+      wrappedBbox.crossesAntimeridian &&
+      rasterExtentCrossesAntimeridian(this.crs, this.xyLimits)
+    ) {
+      if (!this._antimeridianWarnings.has('raster-extent-crossing')) {
+        this._antimeridianWarnings.add('raster-extent-crossing')
+        console.warn(
+          'Antimeridian-crossing polygon queries are not supported for rasters whose own extent crosses the antimeridian; results may be incorrect'
+        )
+      }
+      // Fall back to existing non-antimeridian flow
+      return queryRegionTiled(
+        this.variable,
+        geometry,
+        querySelector,
+        this.zarrStore,
+        this.crs,
+        this.xyLimits,
+        level,
+        this.tileSize,
+        transforms,
+        options
+      )
+    }
 
     return queryRegionTiled(
       this.variable,
-      geometry,
+      processedGeometry,
       querySelector,
       this.zarrStore,
       this.crs,
       this.xyLimits,
       level,
       this.tileSize,
-      {
-        scaleFactor: desc.scaleFactor,
-        addOffset: desc.addOffset,
-        fillValue: desc.fill_value,
-      },
-      options
+      transforms,
+      options,
+      wrappedBbox
     )
   }
 }

--- a/src/tiled-mode.ts
+++ b/src/tiled-mode.ts
@@ -4,7 +4,7 @@ import type {
   TileId,
   TiledRenderState,
 } from './zarr-mode'
-import type { QueryGeometry, QueryResult } from './query/types'
+import type { QueryGeometry, QueryOptions, QueryResult } from './query/types'
 import { queryRegionTiled } from './query/region-query'
 import type {
   LoadingStateCallback,
@@ -561,7 +561,8 @@ export class TiledMode implements ZarrMode {
    */
   async queryData(
     geometry: QueryGeometry,
-    selector?: Selector
+    selector?: Selector,
+    options?: QueryOptions
   ): Promise<QueryResult> {
     if (!this.tileCache || !this.xyLimits) {
       return {
@@ -588,7 +589,8 @@ export class TiledMode implements ZarrMode {
         scaleFactor: desc.scaleFactor,
         addOffset: desc.addOffset,
         fillValue: desc.fill_value,
-      }
+      },
+      options
     )
   }
 }

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -2705,7 +2705,8 @@ export class UntiledMode implements ZarrMode {
       },
       this.proj4def,
       subsetSourceBounds,
-      options
+      options,
+      desc.dimIndices
     )
   }
 }

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -21,7 +21,13 @@ import type {
   TileId,
   RegionRenderState,
 } from './zarr-mode'
-import type { QueryGeometry, QueryOptions, QueryResult } from './query/types'
+import type {
+  QueryGeometry,
+  QueryOptions,
+  QueryResult,
+  QueryDataValues,
+  NestedValues,
+} from './query/types'
 import type {
   LoadingStateCallback,
   MapLike,
@@ -52,8 +58,14 @@ import {
 import type { ZarrRenderer, ShaderProgram } from './zarr-renderer'
 import type { CustomShaderConfig } from './renderer-types'
 import { renderMapboxTile } from './mapbox-tile-renderer'
-import { queryRegionUntiled } from './query/region-query'
-import { computePixelBoundsFromGeometry } from './query/query-utils'
+import { queryRegionUntiled, findSpatialDimNames } from './query/region-query'
+import {
+  computePixelBoundsFromGeometry,
+  preprocessQueryGeometry,
+  wrappedBboxToPixelSpans,
+  rasterExtentCrossesAntimeridian,
+  type PixelRect,
+} from './query/query-utils'
 import {
   createTransformer,
   createTransformerTo4326,
@@ -199,6 +211,7 @@ export class UntiledMode implements ZarrMode {
   // Loading state
   private isRemoved: boolean = false
   private throttleMs: number
+  private _antimeridianWarnings: Set<string> = new Set()
 
   // Shared state managers
   private throttleState: ThrottleState = createThrottleState()
@@ -2556,6 +2569,39 @@ export class UntiledMode implements ZarrMode {
   }
 
   /**
+   * Compute subset bounds from pixel bounds against the full mercator bounds.
+   */
+  private computeSubsetBounds(pixelBounds: PixelRect): MercatorBounds {
+    const { minX, maxX, minY, maxY } = pixelBounds
+    const xRange = this.mercatorBounds!.x1 - this.mercatorBounds!.x0
+    const yRange = this.mercatorBounds!.y1 - this.mercatorBounds!.y0
+    const subsetBounds: MercatorBounds = {
+      x0: this.mercatorBounds!.x0 + (minX / this.width) * xRange,
+      x1: this.mercatorBounds!.x0 + (maxX / this.width) * xRange,
+      y0: this.mercatorBounds!.y0 + (minY / this.height) * yRange,
+      y1: this.mercatorBounds!.y0 + (maxY / this.height) * yRange,
+    }
+    if (
+      this.mercatorBounds!.latMin !== undefined &&
+      this.mercatorBounds!.latMax !== undefined
+    ) {
+      const latRange = this.mercatorBounds!.latMax - this.mercatorBounds!.latMin
+      if (this.latIsAscending) {
+        subsetBounds.latMin =
+          this.mercatorBounds!.latMin + (minY / this.height) * latRange
+        subsetBounds.latMax =
+          this.mercatorBounds!.latMin + (maxY / this.height) * latRange
+      } else {
+        subsetBounds.latMax =
+          this.mercatorBounds!.latMax - (minY / this.height) * latRange
+        subsetBounds.latMin =
+          this.mercatorBounds!.latMax - (maxY / this.height) * latRange
+      }
+    }
+    return subsetBounds
+  }
+
+  /**
    * Query data for point or region geometries.
    */
   async queryData(
@@ -2563,25 +2609,25 @@ export class UntiledMode implements ZarrMode {
     selector?: Selector,
     options?: QueryOptions
   ): Promise<QueryResult> {
-    if (!this.mercatorBounds) {
-      return {
-        [this.variable]: [],
-        dimensions: [],
-        coordinates: { lat: [], lon: [] },
-      }
-    }
+    const emptyResult = (): QueryResult => ({
+      [this.variable]: [],
+      dimensions: [],
+      coordinates: { lat: [], lon: [] },
+    })
+
+    if (!this.mercatorBounds) return emptyResult()
 
     const normalizedSelector = selector
       ? normalizeSelector(selector)
       : this.selector
 
     const desc = this.zarrStore.describe()
-    // Use per-level metadata if available (for heterogeneous pyramids)
     const currentLevel = this.levels[this.currentLevelIndex]
-    const scaleFactor = currentLevel?.scaleFactor ?? desc.scaleFactor
-    const addOffset = currentLevel?.addOffset ?? desc.addOffset
-    const fill_value = currentLevel?.fillValue ?? desc.fill_value
-
+    const transforms = {
+      scaleFactor: currentLevel?.scaleFactor ?? desc.scaleFactor,
+      addOffset: currentLevel?.addOffset ?? desc.addOffset,
+      fillValue: currentLevel?.fillValue ?? desc.fill_value,
+    }
     const sourceBounds: [number, number, number, number] | null = this.xyLimits
       ? [
           this.xyLimits.xMin,
@@ -2590,123 +2636,244 @@ export class UntiledMode implements ZarrMode {
           this.xyLimits.yMax,
         ]
       : null
-    const pixelBounds = computePixelBoundsFromGeometry(
-      geometry,
+
+    // Closure for running a single pixel-bounds strip query.
+    // Captures request-scoped locals (not instance state) to avoid races
+    // when queryData is called concurrently on the same instance.
+    const runStrip = async (
+      geom: QueryGeometry,
+      pixelBounds: PixelRect,
+      opts?: QueryOptions
+    ): Promise<QueryResult | null> => {
+      const fetched = await this.fetchQueryData(
+        normalizedSelector,
+        pixelBounds,
+        opts?.signal
+      )
+      if (!fetched) return null
+
+      const subsetBounds = this.computeSubsetBounds(pixelBounds)
+
+      let subsetSourceBounds: [number, number, number, number] | null = null
+      if (this.proj4def && sourceBounds) {
+        const { minX, minY, maxX, maxY } = pixelBounds
+        const [xMin, yMin] = pixelToSourceCRS(
+          minX,
+          minY,
+          sourceBounds,
+          this.width,
+          this.height,
+          this.latIsAscending
+        )
+        const [xMax, yMax] = pixelToSourceCRS(
+          maxX,
+          maxY,
+          sourceBounds,
+          this.width,
+          this.height,
+          this.latIsAscending
+        )
+        subsetSourceBounds = [
+          Math.min(xMin, xMax),
+          Math.min(yMin, yMax),
+          Math.max(xMin, xMax),
+          Math.max(yMin, yMax),
+        ]
+      }
+
+      return queryRegionUntiled(
+        this.variable,
+        geom,
+        normalizedSelector,
+        fetched.data,
+        fetched.width,
+        fetched.height,
+        subsetBounds,
+        this.crs ?? 'EPSG:4326',
+        desc.dimensions,
+        desc.coordinates,
+        fetched.channels,
+        fetched.channelLabels,
+        fetched.multiValueDimNames,
+        this.latIsAscending,
+        transforms,
+        this.proj4def,
+        subsetSourceBounds,
+        opts,
+        desc.dimIndices
+      )
+    }
+
+    // Helper for the single-fetch path shared by proj4 and non-crossing cases
+    const singleFetch = async (geom: QueryGeometry): Promise<QueryResult> => {
+      const pixelBounds = computePixelBoundsFromGeometry(
+        geom,
+        this.mercatorBounds!,
+        this.width,
+        this.height,
+        this.crs ?? 'EPSG:4326',
+        this.latIsAscending,
+        this.proj4def,
+        sourceBounds,
+        this.cachedWGS84Transformer ?? undefined
+      )
+      if (!pixelBounds) return emptyResult()
+      const result = await runStrip(geom, pixelBounds, options)
+      return result ?? emptyResult()
+    }
+
+    // Proj4: no antimeridian preprocessing, just warn and use original geometry.
+    // Run preprocessQueryGeometry only for the bbox check — it correctly
+    // distinguishes true crossings from explicit-but-non-crossing coords
+    // (e.g., rect(200, 210) canonicalizes to [-160, -150], no crossing).
+    if (this.proj4def) {
+      const { bbox } = preprocessQueryGeometry(geometry)
+      if (bbox.crossesAntimeridian) {
+        if (!this._antimeridianWarnings.has('proj4-crossing')) {
+          this._antimeridianWarnings.add('proj4-crossing')
+          console.warn(
+            'Antimeridian-crossing polygon queries are not supported for proj4 projections; results may be incorrect'
+          )
+        }
+      }
+      return singleFetch(geometry)
+    }
+
+    // Standard CRS: preprocess (normalize, canonicalize, maybe clip)
+    const { geometry: processedGeometry, bbox: wrappedBbox } =
+      preprocessQueryGeometry(geometry)
+
+    // Non-crossing: use processedGeometry (may be canonicalized, e.g. [200,210] → [-160,-150])
+    if (!wrappedBbox.crossesAntimeridian) {
+      return singleFetch(processedGeometry)
+    }
+
+    // Crossing: raster extent guard (EPSG:4326 only — 3857 xyLimits are in meters)
+    if (
+      rasterExtentCrossesAntimeridian(this.crs ?? 'EPSG:4326', this.xyLimits)
+    ) {
+      if (!this._antimeridianWarnings.has('raster-extent-crossing')) {
+        this._antimeridianWarnings.add('raster-extent-crossing')
+        console.warn(
+          'Antimeridian-crossing polygon queries are not supported for rasters whose own extent crosses the antimeridian; results may be incorrect'
+        )
+      }
+      return singleFetch(geometry)
+    }
+
+    // Crossing: two-strip fetch
+    const spans = wrappedBboxToPixelSpans(
+      wrappedBbox,
       this.mercatorBounds,
       this.width,
       this.height,
       this.crs ?? 'EPSG:4326',
-      this.latIsAscending,
-      this.proj4def,
-      sourceBounds,
-      this.cachedWGS84Transformer ?? undefined
+      this.latIsAscending
     )
 
-    if (!pixelBounds) {
-      return {
-        [this.variable]: [],
-        dimensions: [],
-        coordinates: { lat: [], lon: [] },
-      }
-    }
+    const westResult = spans.west
+      ? await runStrip(processedGeometry, spans.west, options)
+      : null
+    const eastResult = spans.east
+      ? await runStrip(processedGeometry, spans.east, options)
+      : null
 
-    const fetched = await this.fetchQueryData(
-      normalizedSelector,
-      pixelBounds,
-      options?.signal
-    )
-    if (!fetched) {
-      return {
-        [this.variable]: [],
-        dimensions: [],
-        coordinates: { lat: [], lon: [] },
-      }
+    // If either requested strip failed, return empty rather than partial data
+    if ((spans.west && !westResult) || (spans.east && !eastResult)) {
+      return emptyResult()
     }
+    if (!westResult && !eastResult) return emptyResult()
+    if (!westResult || !eastResult) return (westResult ?? eastResult)!
 
-    // Compute adjusted bounds for the subset
-    const { minX, maxX, minY, maxY } = pixelBounds
-    const xRange = this.mercatorBounds.x1 - this.mercatorBounds.x0
-    const yRange = this.mercatorBounds.y1 - this.mercatorBounds.y0
-    const subsetBounds: MercatorBounds = {
-      x0: this.mercatorBounds.x0 + (minX / this.width) * xRange,
-      x1: this.mercatorBounds.x0 + (maxX / this.width) * xRange,
-      y0: this.mercatorBounds.y0 + (minY / this.height) * yRange,
-      y1: this.mercatorBounds.y0 + (maxY / this.height) * yRange,
-    }
-    // Preserve lat bounds if present (for EPSG:4326)
-    if (
-      this.mercatorBounds.latMin !== undefined &&
-      this.mercatorBounds.latMax !== undefined
-    ) {
-      const latRange = this.mercatorBounds.latMax - this.mercatorBounds.latMin
-      if (this.latIsAscending) {
-        subsetBounds.latMin =
-          this.mercatorBounds.latMin + (minY / this.height) * latRange
-        subsetBounds.latMax =
-          this.mercatorBounds.latMin + (maxY / this.height) * latRange
-      } else {
-        subsetBounds.latMax =
-          this.mercatorBounds.latMax - (minY / this.height) * latRange
-        subsetBounds.latMin =
-          this.mercatorBounds.latMax - (maxY / this.height) * latRange
-      }
-    }
-
-    // For proj4 reprojection, compute subset bounds in source CRS
-    let subsetSourceBounds: [number, number, number, number] | null = null
-    if (this.proj4def && sourceBounds) {
-      // Convert subset pixel range to source CRS bounds using edge-based model.
-      // pixelToSourceCRS maps: pixel 0 → xMin (left edge), pixel width → xMax (right edge)
-      // Since maxX/maxY are exclusive, they map directly to the right/bottom edges.
-      const [xMin, yMin] = pixelToSourceCRS(
-        minX,
-        minY,
-        sourceBounds,
-        this.width,
-        this.height,
-        this.latIsAscending
-      )
-      const [xMax, yMax] = pixelToSourceCRS(
-        maxX, // exclusive end maps to right edge
-        maxY,
-        sourceBounds,
-        this.width,
-        this.height,
-        this.latIsAscending
-      )
-      // Create subset bounds in source CRS
-      subsetSourceBounds = [
-        Math.min(xMin, xMax),
-        Math.min(yMin, yMax),
-        Math.max(xMin, xMax),
-        Math.max(yMin, yMax),
-      ]
-    }
-
-    return queryRegionUntiled(
-      this.variable,
-      geometry,
-      normalizedSelector,
-      fetched.data,
-      fetched.width,
-      fetched.height,
-      subsetBounds,
-      this.crs ?? 'EPSG:4326',
+    const { yDim, xDim } = findSpatialDimNames(
       desc.dimensions,
-      desc.coordinates,
-      fetched.channels,
-      fetched.channelLabels,
-      fetched.multiValueDimNames,
-      this.latIsAscending,
-      {
-        scaleFactor,
-        addOffset,
-        fillValue: fill_value,
-      },
-      this.proj4def,
-      subsetSourceBounds,
-      options,
+      false,
       desc.dimIndices
     )
+    return mergeQueryResults(westResult, eastResult, this.variable, yDim, xDim)
   }
+}
+
+/**
+ * Merge two QueryResult objects from west and east strips.
+ *
+ * Ordering: west-strip pixels first, then east-strip pixels. This does NOT
+ * preserve row-major scan order. The QueryResult contract provides parallel
+ * coordinate arrays so consumers index by position, not implicit grid layout.
+ *
+ * Spatial coordinate arrays (yDim, xDim) are concatenated.
+ * Non-spatial coordinate arrays are taken from the first result unchanged.
+ */
+function mergeQueryResults(
+  a: QueryResult,
+  b: QueryResult,
+  variable: string,
+  yDim: string,
+  xDim: string
+): QueryResult {
+  const spatialKeys = new Set([yDim, xDim])
+
+  // Merge coordinates: concatenate spatial, take first for non-spatial
+  const coordinates: Record<string, (number | string)[]> = {}
+  for (const key of Object.keys(a.coordinates)) {
+    if (spatialKeys.has(key)) {
+      coordinates[key] = [...a.coordinates[key], ...b.coordinates[key]]
+    } else {
+      coordinates[key] = a.coordinates[key]
+    }
+  }
+
+  // Merge variable values
+  const aVals = a[variable] as QueryDataValues
+  const bVals = b[variable] as QueryDataValues
+
+  let merged: QueryDataValues
+  if (Array.isArray(aVals) && Array.isArray(bVals)) {
+    merged = [...aVals, ...bVals]
+  } else if (!Array.isArray(aVals) && !Array.isArray(bVals)) {
+    merged = mergeNestedValues(aVals as NestedValues, bVals as NestedValues)
+  } else {
+    merged = aVals // Mismatched types: take first
+  }
+
+  return {
+    [variable]: merged,
+    dimensions: a.dimensions,
+    coordinates,
+  }
+}
+
+/**
+ * Recursively merge two NestedValues objects by concatenating leaf arrays.
+ */
+function mergeNestedValues(a: NestedValues, b: NestedValues): NestedValues {
+  const result: NestedValues = {}
+  for (const key of Object.keys(a)) {
+    const aVal = a[key]
+    const bVal = b[key]
+    if (Array.isArray(aVal) && Array.isArray(bVal)) {
+      result[key] = [...aVal, ...bVal]
+    } else if (
+      aVal &&
+      bVal &&
+      !Array.isArray(aVal) &&
+      !Array.isArray(bVal) &&
+      typeof aVal === 'object' &&
+      typeof bVal === 'object'
+    ) {
+      result[key] = mergeNestedValues(
+        aVal as NestedValues,
+        bVal as NestedValues
+      )
+    } else {
+      result[key] = aVal
+    }
+  }
+  // Include keys only in b
+  for (const key of Object.keys(b)) {
+    if (!(key in result)) {
+      result[key] = b[key]
+    }
+  }
+  return result
 }

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -21,7 +21,7 @@ import type {
   TileId,
   RegionRenderState,
 } from './zarr-mode'
-import type { QueryGeometry, QueryResult } from './query/types'
+import type { QueryGeometry, QueryOptions, QueryResult } from './query/types'
 import type {
   LoadingStateCallback,
   MapLike,
@@ -52,11 +52,8 @@ import {
 import type { ZarrRenderer, ShaderProgram } from './zarr-renderer'
 import type { CustomShaderConfig } from './renderer-types'
 import { renderMapboxTile } from './mapbox-tile-renderer'
-import { queryRegionSingleImage } from './query/region-query'
-import {
-  mercatorBoundsToPixel,
-  computePixelBoundsFromGeometry,
-} from './query/query-utils'
+import { queryRegionUntiled } from './query/region-query'
+import { computePixelBoundsFromGeometry } from './query/query-utils'
 import {
   createTransformer,
   createTransformerTo4326,
@@ -65,7 +62,6 @@ import {
   sampleEdgesToMercatorBounds,
 } from './projection-utils'
 import { createHybridMesh } from './mesh-reprojector'
-import { setObjectValues } from './query/selector-utils'
 import { geoToArrayIndex } from './map-utils'
 import {
   type ThrottleState,
@@ -1202,16 +1198,13 @@ export class UntiledMode implements ZarrMode {
       includeSpatialSlices: boolean
       /** If true, track multi-value dimensions for channel packing */
       trackMultiValue: boolean
-      /** Spatial bounds for fetch - point for single pixel, bbox for region subset */
-      spatialBounds?:
-        | { type: 'point'; x: number; y: number }
-        | {
-            type: 'bbox'
-            minX: number
-            maxX: number
-            minY: number
-            maxY: number
-          }
+      /** Spatial bounds for fetch - bbox for region subset */
+      spatialBounds?: {
+        minX: number
+        maxX: number
+        minY: number
+        maxY: number
+      }
     }
   ): Promise<{
     sliceArgs: (number | zarr.Slice)[]
@@ -1244,9 +1237,7 @@ export class UntiledMode implements ZarrMode {
       const dimType = this.classifyDimension(dimName)
 
       if (dimType === 'lon') {
-        if (options.spatialBounds?.type === 'point') {
-          sliceArgs[dimInfo.index] = options.spatialBounds.x
-        } else if (options.spatialBounds?.type === 'bbox') {
+        if (options.spatialBounds) {
           sliceArgs[dimInfo.index] = zarr.slice(
             options.spatialBounds.minX,
             options.spatialBounds.maxX
@@ -1257,9 +1248,7 @@ export class UntiledMode implements ZarrMode {
             : 0
         }
       } else if (dimType === 'lat') {
-        if (options.spatialBounds?.type === 'point') {
-          sliceArgs[dimInfo.index] = options.spatialBounds.y
-        } else if (options.spatialBounds?.type === 'bbox') {
+        if (options.spatialBounds) {
           sliceArgs[dimInfo.index] = zarr.slice(
             options.spatialBounds.minY,
             options.spatialBounds.maxY
@@ -2475,13 +2464,15 @@ export class UntiledMode implements ZarrMode {
    */
   private async fetchQueryData(
     selector: NormalizedSelector,
-    spatialQuery:
-      | { type: 'point'; x: number; y: number }
-      | { type: 'bbox'; minX: number; maxX: number; minY: number; maxY: number }
+    spatialQuery: {
+      minX: number
+      maxX: number
+      minY: number
+      maxY: number
+    },
+    signal?: AbortSignal
   ): Promise<{
-    type: 'point' | 'bbox'
-    values: number[] // For point queries
-    data: Float32Array // For bbox queries
+    data: Float32Array
     width: number
     height: number
     channels: number
@@ -2493,7 +2484,7 @@ export class UntiledMode implements ZarrMode {
     try {
       const { sliceArgs: baseSliceArgs, multiValueDims } =
         await this.buildSliceArgsForSelector(selector, {
-          includeSpatialSlices: spatialQuery.type !== 'bbox',
+          includeSpatialSlices: false,
           trackMultiValue: true,
           spatialBounds: spatialQuery,
         })
@@ -2504,52 +2495,20 @@ export class UntiledMode implements ZarrMode {
       } = this.buildChannelCombinations(multiValueDims)
       const numChannels = channelCombinations.length || 1
       const multiValueDimNames = multiValueDims.map((d) => d.dimName)
+      const getOpts = signal ? { opts: { signal } } : undefined
 
-      // Point query: fetch individual values
-      if (spatialQuery.type === 'point') {
-        const values: number[] = []
-
-        if (numChannels === 1) {
-          const result = await zarr.get(this.zarrArray, baseSliceArgs)
-          const value = this.extractScalarValue(result)
-          if (value === null) return null
-          values.push(value)
-        } else {
-          for (let c = 0; c < numChannels; c++) {
-            const sliceArgs = [...baseSliceArgs]
-            const combo = channelCombinations[c]
-            for (let i = 0; i < multiValueDims.length; i++) {
-              sliceArgs[multiValueDims[i].dimIndex] = combo[i]
-            }
-            const result = await zarr.get(this.zarrArray, sliceArgs)
-            const value = this.extractScalarValue(result)
-            if (value !== null) values.push(value)
-          }
-        }
-
-        return {
-          type: 'point',
-          values,
-          data: new Float32Array(0),
-          width: 1,
-          height: 1,
-          channels: numChannels,
-          channelLabels: channelLabelCombinations,
-          multiValueDimNames,
-        }
-      }
-
-      // Bbox query: fetch region data
       const fetchWidth = spatialQuery.maxX - spatialQuery.minX
       const fetchHeight = spatialQuery.maxY - spatialQuery.minY
 
       if (numChannels === 1) {
-        const result = (await zarr.get(this.zarrArray, baseSliceArgs)) as {
+        const result = (await zarr.get(
+          this.zarrArray,
+          baseSliceArgs,
+          getOpts
+        )) as {
           data: ArrayLike<number>
         }
         return {
-          type: 'bbox',
-          values: [],
           data: new Float32Array(result.data),
           width: fetchWidth,
           height: fetchHeight,
@@ -2569,7 +2528,11 @@ export class UntiledMode implements ZarrMode {
           sliceArgs[multiValueDims[i].dimIndex] = combo[i]
         }
 
-        const bandData = (await zarr.get(this.zarrArray, sliceArgs)) as {
+        const bandData = (await zarr.get(
+          this.zarrArray,
+          sliceArgs,
+          getOpts
+        )) as {
           data: ArrayLike<number>
         }
         for (let pixIdx = 0; pixIdx < fetchWidth * fetchHeight; pixIdx++) {
@@ -2578,8 +2541,6 @@ export class UntiledMode implements ZarrMode {
       }
 
       return {
-        type: 'bbox',
-        values: [],
         data: packedData,
         width: fetchWidth,
         height: fetchHeight,
@@ -2588,25 +2549,10 @@ export class UntiledMode implements ZarrMode {
         multiValueDimNames,
       }
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') throw err
       console.error('Error fetching query data:', err)
       return null
     }
-  }
-
-  /**
-   * Extract a scalar value from zarr.get result (handles various return formats).
-   */
-  private extractScalarValue(result: unknown): number | null {
-    if (result && typeof result === 'object' && 'data' in result) {
-      const data = (result as { data: ArrayLike<number> }).data
-      return data[0] ?? (data as unknown as number)
-    } else if (typeof result === 'number') {
-      return result
-    } else if (ArrayBuffer.isView(result)) {
-      return (result as Float32Array)[0]
-    }
-    console.warn('Unexpected zarr.get result format:', result)
-    return null
   }
 
   /**
@@ -2614,7 +2560,8 @@ export class UntiledMode implements ZarrMode {
    */
   async queryData(
     geometry: QueryGeometry,
-    selector?: Selector
+    selector?: Selector,
+    options?: QueryOptions
   ): Promise<QueryResult> {
     if (!this.mercatorBounds) {
       return {
@@ -2635,137 +2582,6 @@ export class UntiledMode implements ZarrMode {
     const addOffset = currentLevel?.addOffset ?? desc.addOffset
     const fill_value = currentLevel?.fillValue ?? desc.fill_value
 
-    // Point geometries: use optimized single-chunk fetch
-    if (geometry.type === 'Point') {
-      const [lon, lat] = geometry.coordinates
-      const coords = { lat: [lat], lon: [lon] }
-
-      const sourceBounds = this.xyLimits
-        ? ([
-            this.xyLimits.xMin,
-            this.xyLimits.yMin,
-            this.xyLimits.xMax,
-            this.xyLimits.yMax,
-          ] as [number, number, number, number])
-        : null
-      const pixel = mercatorBoundsToPixel(
-        lon,
-        lat,
-        this.mercatorBounds,
-        this.width,
-        this.height,
-        this.crs ?? 'EPSG:4326',
-        this.latIsAscending,
-        this.proj4def,
-        sourceBounds,
-        this.cachedWGS84Transformer ?? undefined
-      )
-
-      if (!pixel) {
-        return {
-          [this.variable]: [],
-          dimensions: ['lat', 'lon'],
-          coordinates: coords,
-        }
-      }
-
-      // Fetch only the chunk(s) containing this point
-      const pointData = await this.fetchQueryData(normalizedSelector, {
-        type: 'point',
-        x: pixel.x,
-        y: pixel.y,
-      })
-
-      if (!pointData) {
-        return {
-          [this.variable]: [],
-          dimensions: ['lat', 'lon'],
-          coordinates: coords,
-        }
-      }
-
-      const { values: rawValues, channelLabels, multiValueDimNames } = pointData
-      const valuesNested = multiValueDimNames.length > 0
-      let values: number[] | Record<string | number, any> = valuesNested
-        ? {}
-        : []
-
-      for (let c = 0; c < rawValues.length; c++) {
-        let value = rawValues[c]
-
-        // Filter invalid values
-        if (value === undefined || value === null || !Number.isFinite(value)) {
-          continue
-        }
-        if (fill_value !== null && value === fill_value) {
-          continue
-        }
-
-        // Apply transforms
-        if (scaleFactor !== 1) value *= scaleFactor
-        if (addOffset !== 0) value += addOffset
-
-        if (valuesNested) {
-          const labels = channelLabels?.[c]
-          if (
-            labels &&
-            multiValueDimNames.length > 0 &&
-            labels.length === multiValueDimNames.length
-          ) {
-            values = setObjectValues(values as any, labels, value) as any
-          } else if (Array.isArray(values)) {
-            values.push(value)
-          }
-        } else if (Array.isArray(values)) {
-          values.push(value)
-        }
-      }
-
-      const dimensions = desc.dimensions
-      const mappedDimensions = dimensions.map((d) => {
-        const dimLower = d.toLowerCase()
-        if (['x', 'lon', 'longitude'].includes(dimLower)) return 'lon'
-        if (['y', 'lat', 'latitude'].includes(dimLower)) return 'lat'
-        return d
-      })
-
-      const outputDimensions = valuesNested ? mappedDimensions : ['lat', 'lon']
-      const resultCoordinates: {
-        lat: number[]
-        lon: number[]
-        [key: string]: (number | string)[]
-      } = {
-        lat: coords.lat,
-        lon: coords.lon,
-      }
-
-      if (valuesNested) {
-        for (const dim of dimensions) {
-          const dimLower = dim.toLowerCase()
-          if (
-            ['x', 'lon', 'longitude', 'y', 'lat', 'latitude'].includes(dimLower)
-          ) {
-            continue
-          }
-          const selSpec = normalizedSelector[dim]
-          if (selSpec && 'selected' in selSpec) {
-            const selected = selSpec.selected
-            const vals = Array.isArray(selected) ? selected : [selected]
-            resultCoordinates[dim] = vals as (number | string)[]
-          } else if (desc.coordinates[dim]) {
-            resultCoordinates[dim] = desc.coordinates[dim]
-          }
-        }
-      }
-
-      return {
-        [this.variable]: values as any,
-        dimensions: outputDimensions,
-        coordinates: resultCoordinates,
-      }
-    }
-
-    // Region queries: calculate pixel bounds and fetch only that subset
     const sourceBounds: [number, number, number, number] | null = this.xyLimits
       ? [
           this.xyLimits.xMin,
@@ -2794,10 +2610,11 @@ export class UntiledMode implements ZarrMode {
       }
     }
 
-    const fetched = await this.fetchQueryData(normalizedSelector, {
-      type: 'bbox',
-      ...pixelBounds,
-    })
+    const fetched = await this.fetchQueryData(
+      normalizedSelector,
+      pixelBounds,
+      options?.signal
+    )
     if (!fetched) {
       return {
         [this.variable]: [],
@@ -2866,7 +2683,7 @@ export class UntiledMode implements ZarrMode {
       ]
     }
 
-    return queryRegionSingleImage(
+    return queryRegionUntiled(
       this.variable,
       geometry,
       normalizedSelector,
@@ -2887,7 +2704,8 @@ export class UntiledMode implements ZarrMode {
         fillValue: fill_value,
       },
       this.proj4def,
-      subsetSourceBounds
+      subsetSourceBounds,
+      options
     )
   }
 }

--- a/src/zarr-layer.ts
+++ b/src/zarr-layer.ts
@@ -38,7 +38,7 @@ import {
   isGlobeProjection as checkGlobeProjection,
 } from './map-utils'
 import { MAPBOX_IDENTITY_MATRIX } from './mapbox-utils'
-import type { QueryGeometry, QueryResult } from './query/types'
+import type { QueryGeometry, QueryOptions, QueryResult } from './query/types'
 import { SPATIAL_DIM_NAMES } from './constants'
 
 type MapboxInternals = {
@@ -922,7 +922,8 @@ export class ZarrLayer {
    */
   async queryData(
     geometry: QueryGeometry,
-    selector?: Selector
+    selector?: Selector,
+    options?: QueryOptions
   ): Promise<QueryResult> {
     if (!this.mode?.queryData) {
       return {
@@ -931,6 +932,6 @@ export class ZarrLayer {
         coordinates: { lat: [], lon: [] },
       }
     }
-    return this.mode.queryData(geometry, selector)
+    return this.mode.queryData(geometry, selector, options)
   }
 }

--- a/src/zarr-layer.ts
+++ b/src/zarr-layer.ts
@@ -928,8 +928,8 @@ export class ZarrLayer {
     if (!this.mode?.queryData) {
       return {
         [this.variable]: [],
-        dimensions: ['lat', 'lon'],
-        coordinates: { lat: [], lon: [] },
+        dimensions: [],
+        coordinates: {},
       }
     }
     return this.mode.queryData(geometry, selector, options)

--- a/src/zarr-mode.ts
+++ b/src/zarr-mode.ts
@@ -14,7 +14,7 @@ import type {
   RendererUniforms,
 } from './renderer-types'
 import type { ZarrRenderer } from './zarr-renderer'
-import type { QueryGeometry, QueryResult } from './query/types'
+import type { QueryGeometry, QueryOptions, QueryResult } from './query/types'
 
 export interface RenderContext {
   gl: WebGL2RenderingContext
@@ -93,5 +93,9 @@ export interface ZarrMode {
   getTiledState?(): TiledRenderState | null
 
   // Query methods (optional)
-  queryData?(geometry: QueryGeometry, selector?: Selector): Promise<QueryResult>
+  queryData?(
+    geometry: QueryGeometry,
+    selector?: Selector,
+    options?: QueryOptions
+  ): Promise<QueryResult>
 }


### PR DESCRIPTION
Addressing #50 

Changes here provide a very noticeable performance improvement.

- Replace per-pixel point-in-polygon checks with center-based scanline rasterization for polygon region queries
- Transform query geometries into pixel space up front instead of doing per-pixel proj4 forward transforms
- Add adaptive edge densification using the same default pixel-error tolerance as mesh reprojection (`0.125px`)
- Add `QueryOptions` with `AbortSignal` for cancellable queries and `includeSpatialCoordinates` to omit spatial coordinates from results
- Return source-CRS coordinates keyed by store spatial axis names (for `proj4` datasets, e.g. `y`/`x`); return WGS84 `lat`/`lon` for non-proj4 datasets
- Handle MultiPolygon with per-member rasterization and interval union to preserve union semantics
- Unify untiled point and polygon queries under the same query pipeline
- Rename `queryRegionSingleImage` to `queryRegionUntiled`

## Breaking changes

- polygon query rasterization is now center-based rather than full pixel-overlap based. this matches defaults in other tools like gdal
- `QueryResult.coordinates` is no longer guaranteed to use `lat`/`lon` keys; `proj4` datasets use store spatial axis names
- `QueryResult.coordinates` type is widened from `{ lat: number[], lon: number[] }` to `{ [key: string]: (number | string)[] }`