### PR TITLE
fix: default proj4def to CRS code for built-in projections

### DIFF
--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -74,7 +74,6 @@ import {
   sampleEdgesToMercatorBounds,
 } from './projection-utils'
 import { createHybridMesh } from './mesh-reprojector'
-import { geoToArrayIndex } from './map-utils'
 import {
   type RequestCanceller,
   type LoadingManager,
@@ -311,7 +310,13 @@ export class UntiledMode implements ZarrMode {
       this.crs = desc.crs
       this.xyLimits = desc.xyLimits
       this.latIsAscending = desc.latIsAscending
-      this.proj4def = desc.proj4 ?? null
+      // proj4js ships with EPSG:4326 and EPSG:3857 pre-registered, so we
+      // can pass the EPSG code itself as a proj4 def for those CRSes when
+      // the consumer didn't supply a string. Lets `getVisibleRegions` use
+      // the proj4-aware path uniformly for supported CRSes. (#59)
+      const proj4jsHasBuiltinDef =
+        desc.crs === 'EPSG:4326' || desc.crs === 'EPSG:3857'
+      this.proj4def = desc.proj4 ?? (proj4jsHasBuiltinDef ? desc.crs : null)
 
       // Cache transformers once for reuse (major performance optimization)
       if (this.proj4def && this.xyLimits) {
@@ -562,124 +567,88 @@ export class UntiledMode implements ZarrMode {
   ): Array<{ regionX: number; regionY: number }> {
     const bounds = map.getBounds?.()?.toArray?.()
     if (!bounds || !this.xyLimits || !this.activeLevel) return []
+    if (!this.proj4def || !this.cachedWGS84Transformer) {
+      // No proj4 transformer was set up — either because the CRS isn't
+      // one proj4js handles natively and no `proj4` prop was supplied
+      // (constructor warned), or because proj4 init threw on a malformed
+      // string. Either way, computing region indices here would be wrong;
+      // skip rather than render a misleading partial result.
+      return []
+    }
 
     const { width, height, regionSize } = this.activeLevel
     const [[west, south], [east, north]] = bounds
-    const { xMin, xMax, yMin, yMax } = this.xyLimits
     const [regionH, regionW] = regionSize
 
-    if (this.proj4def && this.cachedWGS84Transformer) {
-      // For projected data, use a two-pass approach:
-      // 1. Forward-transform viewport edges to source CRS to find candidate regions
-      //    via index math (O(1) proj4 cost, may include false positives for non-
-      //    bijective projections like UTM outside their zone)
-      // 2. Inverse-transform candidate region bounds to WGS84 for precise overlap
-      const transformer = this.cachedWGS84Transformer
-      const numRegionsX = Math.ceil(width / regionW)
-      const numRegionsY = Math.ceil(height / regionH)
-
-      const candidates = this.getCandidateRegions(
-        west,
-        south,
-        east,
-        north,
-        transformer,
-        numRegionsX,
-        numRegionsY,
-        regionW,
-        regionH,
-        width,
-        height
-      )
-
-      // Verify candidates via inverse transform to WGS84 for precise overlap.
-      // This handles non-bijective projections where forward transforms can
-      // produce false positives.
-      const regions: Array<{ regionX: number; regionY: number }> = []
-      for (const { regionX, regionY } of candidates) {
-        const regBounds = this.getRegionBounds(regionX, regionY, {
-          width,
-          height,
-          regionSize,
-        })
-        const xMid = (regBounds.xMin + regBounds.xMax) / 2
-        const yMid = (regBounds.yMin + regBounds.yMax) / 2
-
-        const samplePoints = [
-          transformer.inverse(regBounds.xMin, regBounds.yMin),
-          transformer.inverse(regBounds.xMax, regBounds.yMin),
-          transformer.inverse(regBounds.xMax, regBounds.yMax),
-          transformer.inverse(regBounds.xMin, regBounds.yMax),
-          transformer.inverse(xMid, regBounds.yMin),
-          transformer.inverse(xMid, regBounds.yMax),
-          transformer.inverse(regBounds.xMin, yMid),
-          transformer.inverse(regBounds.xMax, yMid),
-        ]
-
-        let regWest = Infinity
-        let regEast = -Infinity
-        let regSouth = Infinity
-        let regNorth = -Infinity
-        let hasValid = false
-        for (const [lon, lat] of samplePoints) {
-          if (!isFinite(lon) || !isFinite(lat)) continue
-          hasValid = true
-          if (lon < regWest) regWest = lon
-          if (lon > regEast) regEast = lon
-          if (lat < regSouth) regSouth = lat
-          if (lat > regNorth) regNorth = lat
-        }
-        if (!hasValid) continue
-
-        if (
-          regEast >= west &&
-          regWest <= east &&
-          regNorth >= south &&
-          regSouth <= north
-        ) {
-          regions.push({ regionX, regionY })
-        }
-      }
-
-      return regions
-    }
-
-    // Standard case: viewport bounds are in same CRS as xyLimits
-    const xMinIdx = geoToArrayIndex(west, xMin, xMax, width)
-    const xMaxIdx = geoToArrayIndex(east, xMin, xMax, width)
-
-    // For Y axis, geoToArrayIndex assumes yMin maps to row 0.
-    // But if latIsAscending=false (row 0 = north = yMax), we need to invert.
-    let ySouthIdx = geoToArrayIndex(south, yMin, yMax, height)
-    let yNorthIdx = geoToArrayIndex(north, yMin, yMax, height)
-
-    // Only invert if we explicitly know latIsAscending is false
-    // If null/undefined, assume ascending (yMin at row 0) as default
-    if (this.latIsAscending === false) {
-      // Invert Y indices: row 0 = north (yMax), row height-1 = south (yMin)
-      ySouthIdx = height - 1 - ySouthIdx
-      yNorthIdx = height - 1 - yNorthIdx
-    }
-
-    // Convert pixel indices to region indices
-    const regionXMin = Math.floor(Math.min(xMinIdx, xMaxIdx) / regionW)
-    const regionXMax = Math.floor(Math.max(xMinIdx, xMaxIdx) / regionW)
-    const regionYMin = Math.floor(Math.min(ySouthIdx, yNorthIdx) / regionH)
-    const regionYMax = Math.floor(Math.max(ySouthIdx, yNorthIdx) / regionH)
-
-    // Clamp to valid range
+    // For projected data, use a two-pass approach:
+    // 1. Forward-transform viewport edges to source CRS to find candidate
+    //    regions via index math (O(1) proj4 cost, may include false
+    //    positives for non-bijective projections like UTM outside their zone)
+    // 2. Inverse-transform candidate region bounds to WGS84 for precise overlap
+    const transformer = this.cachedWGS84Transformer
     const numRegionsX = Math.ceil(width / regionW)
     const numRegionsY = Math.ceil(height / regionH)
-    const clampedXMin = Math.max(0, regionXMin)
-    const clampedXMax = Math.min(numRegionsX - 1, regionXMax)
-    const clampedYMin = Math.max(0, regionYMin)
-    const clampedYMax = Math.min(numRegionsY - 1, regionYMax)
 
-    // Build list of visible region coordinates
+    const candidates = this.getCandidateRegions(
+      west,
+      south,
+      east,
+      north,
+      transformer,
+      numRegionsX,
+      numRegionsY,
+      regionW,
+      regionH,
+      width,
+      height
+    )
+
+    // Verify candidates via inverse transform to WGS84 for precise overlap.
+    // This handles non-bijective projections where forward transforms can
+    // produce false positives.
     const regions: Array<{ regionX: number; regionY: number }> = []
-    for (let ry = clampedYMin; ry <= clampedYMax; ry++) {
-      for (let rx = clampedXMin; rx <= clampedXMax; rx++) {
-        regions.push({ regionX: rx, regionY: ry })
+    for (const { regionX, regionY } of candidates) {
+      const regBounds = this.getRegionBounds(regionX, regionY, {
+        width,
+        height,
+        regionSize,
+      })
+      const xMid = (regBounds.xMin + regBounds.xMax) / 2
+      const yMid = (regBounds.yMin + regBounds.yMax) / 2
+
+      const samplePoints = [
+        transformer.inverse(regBounds.xMin, regBounds.yMin),
+        transformer.inverse(regBounds.xMax, regBounds.yMin),
+        transformer.inverse(regBounds.xMax, regBounds.yMax),
+        transformer.inverse(regBounds.xMin, regBounds.yMax),
+        transformer.inverse(xMid, regBounds.yMin),
+        transformer.inverse(xMid, regBounds.yMax),
+        transformer.inverse(regBounds.xMin, yMid),
+        transformer.inverse(regBounds.xMax, yMid),
+      ]
+
+      let regWest = Infinity
+      let regEast = -Infinity
+      let regSouth = Infinity
+      let regNorth = -Infinity
+      let hasValid = false
+      for (const [lon, lat] of samplePoints) {
+        if (!isFinite(lon) || !isFinite(lat)) continue
+        hasValid = true
+        if (lon < regWest) regWest = lon
+        if (lon > regEast) regEast = lon
+        if (lat < regSouth) regSouth = lat
+        if (lat > regNorth) regNorth = lat
+      }
+      if (!hasValid) continue
+
+      if (
+        regEast >= west &&
+        regWest <= east &&
+        regNorth >= south &&
+        regSouth <= north
+      ) {
+        regions.push({ regionX, regionY })
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes #59. Defaults `proj4def` to the CRS code itself when the consumer didn't supply a `proj4` prop and the CRS is one proj4js handles natively (`EPSG:4326` or `EPSG:3857`). proj4js accepts those EPSG codes directly as the first argument of `proj4()` for built-ins, so the proj4-aware path in `untiled-mode.ts` works without callers having to provide a literal proj4 string.

With both built-ins now always going through the proj4-aware path, the no-transformer fallback in `getVisibleRegions` is dead code for the supported CRSes — deleted. That fallback's math compared viewport bounds (degrees, from `map.getBounds()`) against `xyLimits` in the source CRS. For EPSG:4326 that worked because both are degrees; for EPSG:3857 the viewport-in-degrees vs xyLimits-in-Mercator-meters mismatch caused `geoToArrayIndex`'s clamp to pin every region index to one extreme of the array — **which extreme depended on the layer's hemisphere and `latIsAscending`** (Western-hemisphere data clamped to the easternmost column; Eastern-hemisphere to the westernmost; etc.). Net effect: at any zoom only one corner region of the layer ever rendered.

`getVisibleRegions` now bails with empty regions when no proj4 transformer is set up, which can happen when:

- the CRS isn't one proj4js handles natively and the consumer didn't supply a `proj4` string (constructor already warns `Unsupported CRS — rendering may be incorrect`), or
- proj4 init threw on a malformed string (rare, but the guard is honest about it).

Either way, computing region indices in those cases would be wrong; better to skip than to render a misleading partial result.

### Note on the `crs` prop's role

Before this PR, `crs` was a strict 2-value enum (`EPSG:4326` / `EPSG:3857`, anything else dropped) that drove a few hardcoded code paths:

- `boundsToMercatorNorm` picks between "already in meters, normalize" vs "lon/lat, apply Mercator in JS";
- shader/vertex transforms branch on whether the source is WGS84 or Web Mercator;
- ECEF (globe) eligibility uses it directly;
- the unsupported-CRS warning fires off it.

It was **never** passed to proj4js; proj4js was only consulted via the explicit `proj4` prop for non-built-in CRSes. This PR widens `crs`'s job slightly: when the consumer didn't supply a `proj4` string and `crs` is one of the two values proj4js already has registered, we use `crs` as the proj4def. Strict equality on the existing enum, so non-built-in `desc.crs` values (e.g. WKT smuggled through metadata) won't accidentally be forwarded to proj4.

## Repro

Any v3 multiscale zarr in `EPSG:3857` with no `proj4` prop will trigger this. A public example you can curl:

```
https://wherobots-examples.s3.us-west-2.amazonaws.com/rasterflow/mosaics/marion_county_optimized.zarr/zarr.json
```

Root attrs include `proj:code: EPSG:3857`, `multiscales.layout` with 12 levels, `spatial:bbox: [-13712415.16, 5571900.58, -13551293.95, 5666515.45]` (Web Mercator meters covering Marion County, OR).

Minimum layer config that surfaces the bug — no `proj4` prop, EPSG:3857 with bounds in meters:

```ts
new ZarrLayer({
  source: 'https://wherobots-examples.s3.us-west-2.amazonaws.com/rasterflow/mosaics/marion_county_optimized.zarr',
  variable: 'variables',
  crs: 'EPSG:3857',
  bounds: [-13712415.16, 5571900.58, -13551293.95, 5666515.45],
})
```

**Before this patch:** at any zoom only a single corner-region of the layer renders (which corner depends on hemisphere + `latIsAscending`); the rest is empty. For Marion County the patch lands in the south-east.

**After:** the full layer extent renders end-to-end.

## Test plan

- [x] `npm run typecheck` — clean against a fresh `npm install` (a stale `node_modules` will surface unrelated zarrita type drift; rebuild your install if you see those).
- [x] `npm run build` — clean.
- [x] Manual verification against a downstream consumer with the public repro URL above — full layer renders correctly with no consumer-side proj4 string passed.

## Performance note

`EPSG:4326` layers used to take a fast index-math path (no proj4 calls per `getVisibleRegions`); now they take the proj4-aware path with identity transformers. Per call that's ~32 forward + ~8×N inverse identity transforms (basically function-call overhead). Sub-ms for typical viewports, almost certainly imperceptible — but if benchmarks turn it up later, easy to add an `EPSG:4326`-specific fast path back.

## Notes for reviewers

- **Suggestion 2 from #59** ("accept WKT in the `proj4` prop") is already implicitly supported today — proj4js accepts WKT in the same position the prop is forwarded to. Worth a docs note but no code change required.
- **Auto-resolve any EPSG code** via `@developmentseed/epsg` (so consumers never need to pass `proj4` for any EPSG-coded zarr) is tracked separately in #61. That's a bigger architectural call and intentionally out of scope here — happy to PR if you want to land it.
- The behavior change for unsupported-CRS-without-`proj4` (now returns empty regions instead of rendering one wrong corner) is a small UX shift — the constructor's `Unsupported CRS — rendering may be incorrect` warning still fires, but consumers who relied on the lenient half-broken render will now see nothing. I think that's the right call (fail loud rather than silently wrong) but happy to soften if you prefer.
- The dead-code removal (`getVisibleRegions` no-transformer branch + the now-unused `geoToArrayIndex` import in this file) can be split off as a separate PR if you'd rather review the default-proj4def behavioral change in isolation.

## Follow-up worth tracking

`this.proj4def` is still typed `string | null` because the "no proj4 transformer" case above (unsupported CRS without a `proj4` prop, or malformed proj4 string) keeps it nullable. ~14 sites null-check `proj4def` for that case. After #61 (auto-resolve EPSG codes via `@developmentseed/epsg`), the only remaining case would be "consumer passed a custom non-EPSG projection that proj4 couldn't parse" — narrow enough to consider throwing at construction and tightening the type to `string`. Mentioned here for visibility; not in scope for this PR.
