### PR TITLE
Render proj4 datasets in clip-space-relative-to-eye coords

### DIFF
--- a/src/map-utils.ts
+++ b/src/map-utils.ts
@@ -60,15 +60,40 @@ export interface MercatorBounds {
  * lon: -180 → 0, 180 → 1
  * lat: -90 → 0, 90 → 1
  */
+/**
+ * Bounds for the wgs84 inputSpace shader. Two flavours:
+ *
+ * - **Legacy / wgs84-direct**: `lon0`/`lon1`/`lat0`/`lat1` in [0, 1] world
+ *   coords (`-180° → 0`, `180° → 1` for lon; `-90° → 0`, `90° → 1` for lat).
+ *   Linear in lat.
+ *
+ * - **Eye-coords (proj4)**: `mercX0`/`mercX1`/`mercY0`/`mercY1` in [0, 1]
+ *   world coords (mercator-normalized). `mercX` matches `lon` (linear), but
+ *   `mercY` is non-linear in lat — `mercY = (1 − ln(tan(π/4 + φ/2)) / π) / 2`.
+ *
+ * Producers populate one or the other set; the render path resolves whichever
+ * is present with `?? lon0`/`?? lat0` fallbacks. Keeping the eye-coords keys
+ * distinct prevents downstream code from accidentally passing mercator y
+ * through a geographic transform (e.g. lat → mercY) and silently producing
+ * garbage.
+ */
 export interface Wgs84Bounds {
   /** Min longitude normalized [0, 1] where -180 → 0, 180 → 1 */
-  lon0: number
+  lon0?: number
   /** Min latitude normalized [0, 1] where -90 → 0, 90 → 1 */
-  lat0: number
+  lat0?: number
   /** Max longitude normalized [0, 1] */
-  lon1: number
+  lon1?: number
   /** Max latitude normalized [0, 1] */
-  lat1: number
+  lat1?: number
+  /** Min mercator x normalized [0, 1] (eye-coords path; linear in lon) */
+  mercX0?: number
+  /** Max mercator x normalized [0, 1] (eye-coords path; linear in lon) */
+  mercX1?: number
+  /** Min mercator y normalized [0, 1] (eye-coords path; non-linear in lat) */
+  mercY0?: number
+  /** Max mercator y normalized [0, 1] (eye-coords path; non-linear in lat) */
+  mercY1?: number
   /** True if bounds cross the antimeridian (lon0 > lon1 in degrees) */
   crossesAntimeridian?: boolean
 }

--- a/src/mesh-reprojector.ts
+++ b/src/mesh-reprojector.ts
@@ -660,6 +660,17 @@ export function createHybridMesh(
       crossesAntimeridian,
       a
     )
+    // NOTE: in the eye-coords path the lon0/lon1/lat0/lat1 fields actually
+    // hold mercator x/y bounds in [0, 1] world coords. lat0/lat1 carry mercY
+    // values, NOT geographic latitude (mercY is non-linear in lat). The render
+    // path consumes these numerically to derive scale_x/scale_y/shift_x/shift_y
+    // uniforms; both the original and eye-coords encoding produce mathematically
+    // correct uniforms. shift_x/shift_y are unused by the eye-coords vertex
+    // shader path — only scale_x/scale_y feed `mercDelta = vertex.xy * scale`.
+    // We reuse the existing field instead of introducing a discriminated-union
+    // type to keep the surface small; if a future caller wants to interpret
+    // `lat0`/`lat1` as degrees, they should branch on whether the layer is
+    // proj4 (this branch) vs Mercator/WGS84.
     wgs84Bounds = {
       lon0: a.x - a.halfX,
       lon1: a.x + a.halfX,

--- a/src/mesh-reprojector.ts
+++ b/src/mesh-reprojector.ts
@@ -61,6 +61,25 @@ interface HybridMeshOptions {
   transformer: ProjectionTransformer
   latIsAscending: boolean
   maxError?: number
+  /**
+   * Layer-level mercator anchor (Float64) shared by every chunk of the layer.
+   * When provided, vertices are pre-projected to mercator in JS Float64 and
+   * encoded as `(mercX − anchor.x, mercY − anchor.y) / anchor.halfXY` chunk-
+   * local-in-layer in [-1, 1]; the returned `wgs84Bounds` describes the same
+   * anchor + half-extent so the renderer's `scale_x`/`shift_x` uniforms come
+   * out identical for every chunk. Pair this with the eye-coords vertex shader
+   * path (see VERTEX_TO_WGS84_TO_MERCATOR in shaders.ts) to avoid forming
+   * absolute world coords in Float32 — which otherwise quantize to ~1 m at lat
+   * 38, ~4 viewport pixels of jitter at z ≈ 19.
+   *
+   * Omit (or pass null) for the original absolute-world-coord encoding.
+   */
+  layerMercAnchor?: {
+    x: number
+    y: number
+    halfX: number
+    halfY: number
+  } | null
 }
 
 // ============================================================================
@@ -162,6 +181,73 @@ function encodeAbsoluteWgs84(
     // Absolute WGS84 [0,1] encoded as [-1,1]
     encoded[i * 2] = ((lon + 180) / 360) * 2 - 1
     encoded[i * 2 + 1] = ((lat + 90) / 180) * 2 - 1
+  }
+
+  return encoded
+}
+
+/**
+ * Mercator y for a given latitude in degrees, clamped to the standard Mercator
+ * limits and returned in normalized [0, 1] world coords (y=0 at the north
+ * limit, y=1 at the south).
+ */
+const MERC_LAT_LIMIT_RAD = (85.05112878 * Math.PI) / 180
+function lonLatToMerc(lon: number, lat: number): [number, number] {
+  const mercX = (lon + 180) / 360
+  const phi = Math.max(
+    -MERC_LAT_LIMIT_RAD,
+    Math.min(MERC_LAT_LIMIT_RAD, (lat * Math.PI) / 180)
+  )
+  const mercY_raw = Math.log(Math.tan(Math.PI / 4 + phi / 2))
+  const mercY = (1 - mercY_raw / Math.PI) / 2
+  return [mercX, mercY]
+}
+
+/**
+ * Encode WGS84 lon/lat positions as chunk-local-in-layer mercator deltas in
+ * [-1, 1] for the eye-coords precision path.
+ *
+ * `layerMercAnchor.{x, y}` are the layer's mercator center (Float64);
+ * `halfX`/`halfY` are half-extents in mercator. Each vertex's WGS84 lon/lat is
+ * pre-projected to mercator (Float64) and stored as
+ * `(mercX − anchor.x) / halfX`, etc. Adjacent chunks share corners with
+ * deterministically equal Float64 mercator values, so their Float32-cast
+ * encoded vertex values are exactly equal — and since every chunk of a layer
+ * uses the same `scale_x`/`shift_x` uniforms (derived from `wgs84Bounds`
+ * = anchor ± half), the shader reconstructs shared edges identically across
+ * chunks. No boundary gaps.
+ *
+ * Pair with `VERTEX_TO_WGS84_TO_MERCATOR` (eye-coords variant) and the
+ * per-frame `u_anchor_clip` upload in `applyCommonUniforms`.
+ */
+function encodeMercDeltaInLayer(
+  positions: ArrayLike<number>,
+  minLon: number,
+  crossesAntimeridian: boolean,
+  anchor: { x: number; y: number; halfX: number; halfY: number }
+): Float32Array {
+  const numVerts = positions.length / 2
+  const encoded = new Float32Array(numVerts * 2)
+  const safeHalfX = anchor.halfX > 0 ? anchor.halfX : 0.5
+  const safeHalfY = anchor.halfY > 0 ? anchor.halfY : 0.5
+
+  for (let i = 0; i < numVerts; i++) {
+    let lon = normalizeLon180(positions[i * 2])
+    const lat = positions[i * 2 + 1]
+
+    if (crossesAntimeridian && lon < minLon) {
+      lon += 360
+    }
+
+    if (!isFinite(lon) || !isFinite(lat)) {
+      encoded[i * 2] = NaN
+      encoded[i * 2 + 1] = NaN
+      continue
+    }
+
+    const [mercX, mercY] = lonLatToMerc(lon, lat)
+    encoded[i * 2] = (mercX - anchor.x) / safeHalfX
+    encoded[i * 2 + 1] = (mercY - anchor.y) / safeHalfY
   }
 
   return encoded
@@ -555,16 +641,44 @@ export function createHybridMesh(
     canCrossAntimeridian
   )
 
-  // Encode as absolute WGS84 coordinates so that shared-edge vertices between
-  // adjacent regions produce identical Float32 values (eliminates seams).
-  const positions = encodeAbsoluteWgs84(
-    splitResult.positions,
-    minLon,
-    crossesAntimeridian
-  )
-
-  // Identity bounds: shader maps [-1,1] → [0,1] via vertex * 0.5 + 0.5
-  const wgs84Bounds: Wgs84Bounds = { lon0: 0, lat0: 0, lon1: 1, lat1: 1 }
+  // Eye-coords path: pre-project each vertex to mercator (Float64) and encode
+  // as a chunk-local-in-layer mercator delta. Returned `wgs84Bounds` describes
+  // the layer anchor + half-extent so every chunk's `scale_x`/`shift_x`
+  // uniforms come out identical → shared-edge vertices reconstruct identically.
+  // See `encodeMercDeltaInLayer` and `VERTEX_TO_WGS84_TO_MERCATOR` for context.
+  let positions: Float32Array
+  let wgs84Bounds: Wgs84Bounds
+  if (
+    options.layerMercAnchor &&
+    options.layerMercAnchor.halfX > 0 &&
+    options.layerMercAnchor.halfY > 0
+  ) {
+    const a = options.layerMercAnchor
+    positions = encodeMercDeltaInLayer(
+      splitResult.positions,
+      minLon,
+      crossesAntimeridian,
+      a
+    )
+    wgs84Bounds = {
+      lon0: a.x - a.halfX,
+      lon1: a.x + a.halfX,
+      lat0: a.y - a.halfY,
+      lat1: a.y + a.halfY,
+    }
+  } else {
+    // Fallback: original absolute WGS84 [-1, 1] encoding. Shared-edge vertices
+    // between adjacent regions produce identical Float32 values (no seams) but
+    // the shader will form an absolute world coord in Float32 → ~1m vertex
+    // quantization at lat 38, ~4 viewport pixels at z ≈ 19.
+    positions = encodeAbsoluteWgs84(
+      splitResult.positions,
+      minLon,
+      crossesAntimeridian
+    )
+    // Identity bounds: shader maps [-1,1] → [0,1] via vertex * 0.5 + 0.5
+    wgs84Bounds = { lon0: 0, lat0: 0, lon1: 1, lat1: 1 }
+  }
 
   return {
     positions,

--- a/src/mesh-reprojector.ts
+++ b/src/mesh-reprojector.ts
@@ -660,22 +660,16 @@ export function createHybridMesh(
       crossesAntimeridian,
       a
     )
-    // NOTE: in the eye-coords path the lon0/lon1/lat0/lat1 fields actually
-    // hold mercator x/y bounds in [0, 1] world coords. lat0/lat1 carry mercY
-    // values, NOT geographic latitude (mercY is non-linear in lat). The render
-    // path consumes these numerically to derive scale_x/scale_y/shift_x/shift_y
-    // uniforms; both the original and eye-coords encoding produce mathematically
-    // correct uniforms. shift_x/shift_y are unused by the eye-coords vertex
-    // shader path — only scale_x/scale_y feed `mercDelta = vertex.xy * scale`.
-    // We reuse the existing field instead of introducing a discriminated-union
-    // type to keep the surface small; if a future caller wants to interpret
-    // `lat0`/`lat1` as degrees, they should branch on whether the layer is
-    // proj4 (this branch) vs Mercator/WGS84.
+    // Eye-coords path bounds are in normalized mercator [0, 1] world coords,
+    // not geographic lat/lon. Use mercX0/mercX1/mercY0/mercY1 keys so
+    // downstream code can't accidentally pass these through a geographic
+    // transform (e.g. lat → mercY) and silently produce garbage. The render
+    // path resolves either name set with `?? lon0` / `?? lat0` fallbacks.
     wgs84Bounds = {
-      lon0: a.x - a.halfX,
-      lon1: a.x + a.halfX,
-      lat0: a.y - a.halfY,
-      lat1: a.y + a.halfY,
+      mercX0: a.x - a.halfX,
+      mercX1: a.x + a.halfX,
+      mercY0: a.y - a.halfY,
+      mercY1: a.y + a.halfY,
     }
   } else {
     // Fallback: original absolute WGS84 [-1, 1] encoding. Shared-edge vertices

--- a/src/renderable-region.ts
+++ b/src/renderable-region.ts
@@ -97,12 +97,29 @@ export function renderRegion(
     shiftX = (region.mercatorBounds.x0 + region.mercatorBounds.x1) / 2
     shiftY = (region.mercatorBounds.y0 + region.mercatorBounds.y1) / 2
   } else {
-    // 'wgs84' and 'wgs84-ecef' both use wgs84Bounds for scale/shift
+    // 'wgs84' and 'wgs84-ecef' both use wgs84Bounds for scale/shift.
+    //
+    // Eye-coords path returns mercX0/mercX1/mercY0/mercY1 (mercator [0, 1]
+    // world coords); the legacy / ECEF path returns lon0/lon1/lat0/lat1
+    // (lat/lon-derived [0, 1]). The math here is identical for either set,
+    // so we resolve whichever the producer populated.
     if (!wgs84Bounds) return false
-    scaleX = (wgs84Bounds.lon1 - wgs84Bounds.lon0) / 2
-    scaleY = (wgs84Bounds.lat1 - wgs84Bounds.lat0) / 2
-    shiftX = (wgs84Bounds.lon0 + wgs84Bounds.lon1) / 2
-    shiftY = (wgs84Bounds.lat0 + wgs84Bounds.lat1) / 2
+    const x0 = wgs84Bounds.mercX0 ?? wgs84Bounds.lon0
+    const x1 = wgs84Bounds.mercX1 ?? wgs84Bounds.lon1
+    const y0 = wgs84Bounds.mercY0 ?? wgs84Bounds.lat0
+    const y1 = wgs84Bounds.mercY1 ?? wgs84Bounds.lat1
+    if (
+      x0 === undefined ||
+      x1 === undefined ||
+      y0 === undefined ||
+      y1 === undefined
+    ) {
+      return false
+    }
+    scaleX = (x1 - x0) / 2
+    scaleY = (y1 - y0) / 2
+    shiftX = (x0 + x1) / 2
+    shiftY = (y0 + y1) / 2
   }
 
   gl.uniform1f(shaderProgram.scaleLoc, 0)

--- a/src/renderer-types.ts
+++ b/src/renderer-types.ts
@@ -5,6 +5,16 @@ export interface RendererUniforms {
   scaleFactor: number
   offset: number
   fixedDataScale: number
+  /**
+   * Layer-level mercator anchor used by the eye-coords (render-relative-to-eye)
+   * path for proj4 datasets. When set, applyCommonUniforms uploads
+   * `u_eye_matrix` (= matrix) and `u_anchor_clip` (= matrix · vec4(anchor, 0, 1),
+   * computed in JS Float64) so the shader can avoid forming an absolute
+   * world-coord Float32. See VERTEX_TO_WGS84_TO_MERCATOR.
+   *
+   * `x` and `y` are in normalized mercator [0, 1] world coords.
+   */
+  eyeAnchorMerc?: { x: number; y: number } | null
 }
 
 export interface CustomShaderConfig {

--- a/src/shader-program.ts
+++ b/src/shader-program.ts
@@ -26,6 +26,10 @@ export interface ShaderProgram {
   shiftYLoc: WebGLUniformLocation
   worldXOffsetLoc: WebGLUniformLocation
   matrixLoc: WebGLUniformLocation | null
+  // Eye-coords uniforms — only the wgs84 (proj4) inputSpace shader uses them.
+  // For other shaders these will resolve to null and uploads no-op.
+  eyeMatrixLoc: WebGLUniformLocation | null
+  anchorClipLoc: WebGLUniformLocation | null
   projMatrixLoc: WebGLUniformLocation | null
   fallbackMatrixLoc: WebGLUniformLocation | null
   tileMercatorCoordsLoc: WebGLUniformLocation | null
@@ -218,6 +222,11 @@ export function createShaderProgram(
     matrixLoc: needsMaplibre
       ? null
       : mustGetUniformLocation(gl, program, 'matrix'),
+    // Eye-coords path is only used by the wgs84 inputSpace shader (proj4
+    // datasets); for other shaders the optimizer will drop these uniforms,
+    // so use the non-throwing lookup.
+    eyeMatrixLoc: gl.getUniformLocation(program, 'u_eye_matrix'),
+    anchorClipLoc: gl.getUniformLocation(program, 'u_anchor_clip'),
     projMatrixLoc: maplibreUniform('u_projection_matrix'),
     fallbackMatrixLoc: maplibreUniform('u_projection_fallback_matrix'),
     tileMercatorCoordsLoc: maplibreUniform('u_projection_tile_mercator_coords'),

--- a/src/shaders.ts
+++ b/src/shaders.ts
@@ -88,6 +88,13 @@ const VERTEX_TO_MERCATOR = `
  * (also small in clip space) keeps the final `gl_Position` small in Float32 →
  * sub-pixel precision even at high zoom.
  *
+ * `u_worldXOffset` is the renderer's world-wrap offset (±1.0 in mercator x for
+ * wrapped tile copies, 0 otherwise). It can't be folded into `u_anchor_clip`
+ * (per-frame, per-layer; offset varies per draw call) or into `mercDelta` in
+ * Float32 (delta ≈ 1e-7 vs offset ≈ 1 → small term gets washed out), so it
+ * goes through the matrix as a separate small clip-space delta. Zero cost
+ * when offset is 0.
+ *
  * Caller responsibilities (see UntiledMode + createHybridMesh):
  *   1. Pre-project each vertex's WGS84 (lon, lat) to mercator [0, 1] in JS
  *      Float64, encode as `(mercX − anchorX, mercY − anchorY) / layerHalfXY`,
@@ -102,12 +109,11 @@ const VERTEX_TO_MERCATOR = `
  *
  * `merc` is reconstructed at low precision purely for fragment-shader
  * varyings (`v_mercatorPos`); its precision doesn't affect `gl_Position`.
- * Reconstructing it also keeps `shift_x`, `shift_y`, and `u_worldXOffset`
- * referenced so the shader compiler doesn't drop those uniforms.
  */
 const VERTEX_TO_WGS84_TO_MERCATOR = `
   vec2 mercDelta = vec2(vertex.x * sx, vertex.y * sy);
   vec4 deltaClip = u_eye_matrix * vec4(mercDelta, 0.0, 0.0);
+  vec4 wrapClip = u_eye_matrix * vec4(u_worldXOffset, 0.0, 0.0, 0.0);
   vec2 merc = vec2(
     shift_x + mercDelta.x + u_worldXOffset,
     shift_y + mercDelta.y
@@ -312,11 +318,12 @@ export function createVertexShader(options: VertexShaderOptions): string {
     projectionOutput = PROJECT_MAPLIBRE_ECEF
   } else if (inputSpace === 'wgs84') {
     // Eye-coords path: VERTEX_TO_WGS84_TO_MERCATOR already produced `deltaClip`
-    // (matrix · vec4(mercDelta, 0, 0)); adding the precomputed `u_anchor_clip`
-    // gives gl_Position with sub-pixel Float32 precision. Skip the standard
-    // projectTile/matrix path so we don't lose precision routing through
-    // absolute world coords.
-    projectionOutput = `  gl_Position = u_anchor_clip + deltaClip;`
+    // (matrix · vec4(mercDelta, 0, 0)) and `wrapClip` (matrix · vec4(offset, 0, 0, 0)
+    // for world-wrapped tile copies; zero when not wrapping). Adding both to
+    // the precomputed `u_anchor_clip` gives gl_Position with sub-pixel Float32
+    // precision. Skip the standard projectTile/matrix path so we don't lose
+    // precision routing through absolute world coords.
+    projectionOutput = `  gl_Position = u_anchor_clip + deltaClip + wrapClip;`
   } else if (projection === 'maplibre') {
     projectionOutput = PROJECT_MAPLIBRE_GLOBE
   } else {

--- a/src/shaders.ts
+++ b/src/shaders.ts
@@ -34,7 +34,18 @@ uniform float scale_x;
 uniform float scale_y;
 uniform float shift_x;
 uniform float shift_y;
-uniform float u_worldXOffset;`
+uniform float u_worldXOffset;
+// Eye-coords uniforms used by the wgs84 inputSpace shader for proj4 datasets.
+// u_eye_matrix is the projection matrix (MapLibre mainMatrix or Mapbox matrix).
+// u_anchor_clip is precomputed in JS Float64 each frame as
+// u_eye_matrix · vec4(layerAnchorMerc, 0, 1); cast to Float32 it lands near
+// origin in clip space at typical viewports, so its ULP is essentially zero.
+// Together with chunk-local mercator-delta vertex encoding, these let the
+// shader avoid forming an absolute world coord in Float32 — which would
+// otherwise quantize to ~1 m at lat 38 and become ~4 viewport pixels of
+// jitter per vertex at z ≈ 19 once amplified by the matrix scale columns.
+uniform mat4 u_eye_matrix;
+uniform vec4 u_anchor_clip;`
 
 /** Additional uniforms for Mapbox globe projection */
 const UNIFORMS_MAPBOX_GLOBE = `
@@ -61,29 +72,46 @@ const SCALE_HANDLING = `
 const VERTEX_TO_MERCATOR = `
   vec2 merc = vec2(vertex.x * sx + shift_x + u_worldXOffset, -vertex.y * sy + shift_y);`
 
-/** Transform vertex from local space to normalized WGS84, then to Mercator */
+/**
+ * Transform vertex from chunk-local mercator-delta space to clip space using
+ * the eye-coordinate (render-relative-to-eye) decomposition:
+ *
+ *     matrix · vec4(anchor + delta, 0, 1)
+ *       ≡ matrix · vec4(anchor, 0, 1)  +  matrix · vec4(delta, 0, 0)
+ *       ≡ anchorClip                   +  deltaClip
+ *
+ * The shader receives `vertex.xy` as a pre-projected mercator delta from the
+ * layer's anchor, encoded chunk-local-in-layer in [-1, 1]. Multiplying by
+ * `vec4(delta, 0, 0)` (note `w = 0`) means the matrix's translation column is
+ * ignored — only the scale/rotation columns multiply the small delta, so the
+ * product stays small in clip space. Adding the precomputed `u_anchor_clip`
+ * (also small in clip space) keeps the final `gl_Position` small in Float32 →
+ * sub-pixel precision even at high zoom.
+ *
+ * Caller responsibilities (see UntiledMode + createHybridMesh):
+ *   1. Pre-project each vertex's WGS84 (lon, lat) to mercator [0, 1] in JS
+ *      Float64, encode as `(mercX − anchorX, mercY − anchorY) / layerHalfXY`,
+ *      pack Float32.
+ *   2. Set `wgs84Bounds` so the render path computes
+ *      `scale_x = layerHalfX`, `shift_x = layerAnchorX` (same uniforms for
+ *      every chunk of the layer → shared edges remain Float32-equal across
+ *      chunks → no boundary gaps).
+ *   3. Each frame, set `u_eye_matrix` = matrix and
+ *      `u_anchor_clip` = matrix · vec4(layerAnchorMerc, 0, 1) (Float64 in JS,
+ *      Float32 to GPU).
+ *
+ * `merc` is reconstructed at low precision purely for fragment-shader
+ * varyings (`v_mercatorPos`); its precision doesn't affect `gl_Position`.
+ * Reconstructing it also keeps `shift_x`, `shift_y`, and `u_worldXOffset`
+ * referenced so the shader compiler doesn't drop those uniforms.
+ */
 const VERTEX_TO_WGS84_TO_MERCATOR = `
-  // vertex.xy are in local [-1, 1] space for this region
-  // scale/shift transform to absolute normalized 4326 [0,1] on world
-  float normLon = vertex.x * sx + shift_x + u_worldXOffset;
-  float normLat = vertex.y * sy + shift_y;
-
-  // Convert normalized [0,1] to degrees
-  float lon = normLon * 360.0 - 180.0;
-  float lat = normLat * 180.0 - 90.0;
-
-  // Clamp latitude to Mercator limits to avoid infinity at poles
-  lat = clamp(lat, -MERCATOR_LAT_LIMIT, MERCATOR_LAT_LIMIT);
-
-  // Mercator projection
-  float lambda = radians(lon);
-  float phi = radians(lat);
-  float mercY_raw = log(tan((PI / 2.0 + phi) / 2.0));
-
-  // Normalize mercator output to [0,1]
-  float mercX = (lambda / PI + 1.0) / 2.0;
-  float mercY = (1.0 - mercY_raw / PI) / 2.0;
-  vec2 merc = vec2(mercX, mercY);`
+  vec2 mercDelta = vec2(vertex.x * sx, vertex.y * sy);
+  vec4 deltaClip = u_eye_matrix * vec4(mercDelta, 0.0, 0.0);
+  vec2 merc = vec2(
+    shift_x + mercDelta.x + u_worldXOffset,
+    shift_y + mercDelta.y
+  );`
 
 /** Individual shader constants (composed as needed) */
 const CONST_PI = `const float PI = 3.14159265358979323846;`
@@ -282,6 +310,13 @@ export function createVertexShader(options: VertexShaderOptions): string {
     projectionOutput = PROJECT_MAPBOX_ECEF
   } else if (isDirectEcef) {
     projectionOutput = PROJECT_MAPLIBRE_ECEF
+  } else if (inputSpace === 'wgs84') {
+    // Eye-coords path: VERTEX_TO_WGS84_TO_MERCATOR already produced `deltaClip`
+    // (matrix · vec4(mercDelta, 0, 0)); adding the precomputed `u_anchor_clip`
+    // gives gl_Position with sub-pixel Float32 precision. Skip the standard
+    // projectTile/matrix path so we don't lose precision routing through
+    // absolute world coords.
+    projectionOutput = `  gl_Position = u_anchor_clip + deltaClip;`
   } else if (projection === 'maplibre') {
     projectionOutput = PROJECT_MAPLIBRE_GLOBE
   } else {

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -244,6 +244,18 @@ export class UntiledMode implements ZarrMode {
     typeof createTransformerTo4326
   > | null = null
 
+  // Layer-level mercator anchor (Float64) for the eye-coords precision path.
+  // Only set for proj4 datasets. Sourced from `mercatorBounds`; passed to
+  // `createHybridMesh` (so vertices encode mercator deltas relative to it) and
+  // exposed via `getUniformsForRender` (so the renderer can compute
+  // `u_anchor_clip = matrix · vec4(anchor, 0, 1)` per frame).
+  private layerMercAnchor: {
+    x: number
+    y: number
+    halfX: number
+    halfY: number
+  } | null = null
+
   // Loading state
   private isRemoved: boolean = false
   private _antimeridianWarnings: Set<string> = new Set()
@@ -364,6 +376,22 @@ export class UntiledMode implements ZarrMode {
           this.mercatorBounds = this.computeMercatorBoundsFromProjection()
         } else {
           this.mercatorBounds = boundsToMercatorNorm(this.xyLimits, this.crs)
+        }
+        // Cache the layer's mercator center + half-extent (Float64) for the
+        // eye-coords precision path used by the proj4 vertex shader. All chunks
+        // of the layer share these values, so chunk corners that are
+        // deterministically Float64-equal at projection time stay Float32-equal
+        // in the shader (no boundary gaps). Only set for proj4 datasets;
+        // EPSG:3857 / EPSG:4326 paths render via different shaders that don't
+        // need eye-coords.
+        if (this.proj4def && this.mercatorBounds) {
+          const mb = this.mercatorBounds
+          this.layerMercAnchor = {
+            x: (mb.x0 + mb.x1) / 2,
+            y: (mb.y0 + mb.y1) / 2,
+            halfX: Math.max((mb.x1 - mb.x0) / 2, 1e-12),
+            halfY: Math.max(Math.abs(mb.y1 - mb.y0) / 2, 1e-12),
+          }
         }
       } else {
         console.warn('UntiledMode: No XY limits found')
@@ -783,6 +811,10 @@ export class UntiledMode implements ZarrMode {
       ...contextUniforms,
       scaleFactor: 1.0,
       offset: 0.0,
+      // Forwarded to applyCommonUniforms; null for non-proj4 datasets.
+      eyeAnchorMerc: this.layerMercAnchor
+        ? { x: this.layerMercAnchor.x, y: this.layerMercAnchor.y }
+        : null,
     }
   }
 
@@ -1109,6 +1141,10 @@ export class UntiledMode implements ZarrMode {
       )
 
       // Always use hybrid mesh (adaptive + uniform grid) for proj4 data.
+      // Pass the layer's mercator anchor so vertices encode chunk-local-in-layer
+      // mercator deltas. The shader's eye-coords path consumes these deltas
+      // together with `u_anchor_clip` (computed in JS Float64 each frame) for
+      // sub-pixel-precise gl_Position. See VERTEX_TO_WGS84_TO_MERCATOR.
       const meshResult = createHybridMesh({
         geoBounds,
         width: region.width,
@@ -1116,6 +1152,7 @@ export class UntiledMode implements ZarrMode {
         subdivisions: meshSubdivisions,
         transformer: this.cached4326Transformer!,
         latIsAscending: this.latIsAscending,
+        layerMercAnchor: this.layerMercAnchor,
       })
       region.vertexArr = meshResult.positions
       region.pixCoordArr = meshResult.texCoords

--- a/src/zarr-renderer.ts
+++ b/src/zarr-renderer.ts
@@ -182,18 +182,28 @@ export class ZarrRenderer {
         shaderProgram.projectionMode === 'maplibre-ecef'
       const eyeMatrix = isMaplibreProj ? projectionData?.mainMatrix : matrix
       if (eyeMatrix && eyeMatrix.length >= 16) {
-        gl.uniformMatrix4fv(
-          shaderProgram.eyeMatrixLoc,
-          false,
+        // Both the GPU upload and the JS anchor multiply must use the SAME
+        // matrix representation. If we computed anchor_clip against the
+        // possibly-Float64 source while uploading a Float32-quantized copy to
+        // the shader, the eye-coords identity
+        //   anchor_clip + matrix · delta  ≡  matrix · (anchor + delta)
+        // would hold only up to the matrix-element ULP — at z ≈ 19 the matrix
+        // scale columns are ~3×10⁵, so 1 Float32 ULP ≈ 3×10⁻² in clip space.
+        // Anchor magnitude ~0.5 → several viewport pixels of per-frame
+        // inconsistency, which is exactly what the eye-coords decomposition
+        // was meant to recover. Cast once and use the same Float32 array on
+        // both sides.
+        const eyeMatrixF32 =
           eyeMatrix instanceof Float32Array
             ? eyeMatrix
             : new Float32Array(eyeMatrix)
-        )
-        // Column-major: result[i] = m[0+i]*x + m[4+i]*y + m[8+i]*0 + m[12+i]*1.
-        // JS arithmetic is Float64; only the final 4 values lose precision in
-        // the cast to Float32. Each component lands near zero in clip space
-        // for typical viewports → Float32 ULP near zero.
-        const m = eyeMatrix
+        gl.uniformMatrix4fv(shaderProgram.eyeMatrixLoc, false, eyeMatrixF32)
+        // anchor_clip = eyeMatrixF32 · vec4(anchor.x, anchor.y, 0, 1).
+        // JS reads Float32Array elements as Float64-promoted values, so the
+        // multiply-add runs in Float64 against the same Float32 inputs the
+        // shader will see, then uniform4f casts the four results back to
+        // Float32. Column-major: result[i] = m[i]*x + m[4+i]*y + m[12+i].
+        const m = eyeMatrixF32
         const ax = uniforms.eyeAnchorMerc.x
         const ay = uniforms.eyeAnchorMerc.y
         const cx = m[0] * ax + m[4] * ay + m[12]

--- a/src/zarr-renderer.ts
+++ b/src/zarr-renderer.ts
@@ -164,6 +164,45 @@ export class ZarrRenderer {
         isGlobeTileRender
       )
     }
+
+    // Eye-coords path (proj4 / wgs84 inputSpace). Compute u_anchor_clip in JS
+    // Float64 from the layer's mercator anchor and the projection matrix; near
+    // the camera at typical viewports this lands near origin in clip space, so
+    // its Float32 representation is essentially exact. Sum with the small
+    // matrix·delta computed in the vertex shader → sub-pixel-precise gl_Position
+    // even at z ≈ 19. See VERTEX_TO_WGS84_TO_MERCATOR for the math.
+    if (
+      uniforms.eyeAnchorMerc &&
+      shaderProgram.eyeMatrixLoc &&
+      shaderProgram.anchorClipLoc
+    ) {
+      const isMaplibreProj =
+        shaderProgram.projectionMode === 'maplibre' ||
+        shaderProgram.projectionMode === 'maplibre-proj4' ||
+        shaderProgram.projectionMode === 'maplibre-ecef'
+      const eyeMatrix = isMaplibreProj ? projectionData?.mainMatrix : matrix
+      if (eyeMatrix && eyeMatrix.length >= 16) {
+        gl.uniformMatrix4fv(
+          shaderProgram.eyeMatrixLoc,
+          false,
+          eyeMatrix instanceof Float32Array
+            ? eyeMatrix
+            : new Float32Array(eyeMatrix)
+        )
+        // Column-major: result[i] = m[0+i]*x + m[4+i]*y + m[8+i]*0 + m[12+i]*1.
+        // JS arithmetic is Float64; only the final 4 values lose precision in
+        // the cast to Float32. Each component lands near zero in clip space
+        // for typical viewports → Float32 ULP near zero.
+        const m = eyeMatrix
+        const ax = uniforms.eyeAnchorMerc.x
+        const ay = uniforms.eyeAnchorMerc.y
+        const cx = m[0] * ax + m[4] * ay + m[12]
+        const cy = m[1] * ax + m[5] * ay + m[13]
+        const cz = m[2] * ax + m[6] * ay + m[14]
+        const cw = m[3] * ax + m[7] * ay + m[15]
+        gl.uniform4f(shaderProgram.anchorClipLoc, cx, cy, cz, cw)
+      }
+    }
   }
 
   renderTiles(


### PR DESCRIPTION
Closes #62.

## What

Eliminates multi-pixel vertex jitter when rendering non-Mercator/non-WGS84 datasets at high zoom (z ≈ 18–20). Reproduced on KY State Plane (EPSG:3089, LCC) imagery zarr; symptom is continuous wavy distortion of straight features (building edges, parking-lot stripes, basin grids).

Full RCA, math, and screenshots in #62.

## How

Eye-coordinate ("render-relative-to-eye") decomposition. Avoid ever forming an absolute world coord in Float32 in the shader:

```
matrix · vec4(anchor + delta, 0, 1)
  ≡ matrix · vec4(anchor, 0, 1)  +  matrix · vec4(delta, 0, 0)
  ≡ anchorClip                   +  deltaClip
```

- `anchorClip`: precomputed each frame in JS Float64 as `matrix · vec4(layerAnchorMerc, 0, 1)`, cast to Float32. At typical viewports it lands near origin in clip space → Float32 ULP ≈ 0.
- `deltaClip`: computed in the shader. Each vertex stores `(mercX − anchorX, mercY − anchorY)` pre-projected to mercator in JS Float64 and encoded as a chunk-local-in-layer Float32 delta (small magnitude → ULP sub-mm). Multiplying by the matrix's scale columns with `w = 0` ignores the translation column → small clip-space contribution.
- Sum of two small Float32s stays small Float32 with full precision → sub-pixel.

A single layer-level anchor is shared across every chunk so chunk corners that are deterministically Float64-equal at projection time stay Float32-equal in the shader (no boundary gaps). Per-chunk anchors would let each uniform round independently and produce visible chunk seams.

## Surface

| File | Change |
| --- | --- |
| `src/shaders.ts` | Add `u_eye_matrix` and `u_anchor_clip` uniforms; rewrite `VERTEX_TO_WGS84_TO_MERCATOR` to compute `mercDelta` + `deltaClip` and reconstruct `merc` only for fragment varyings; for `inputSpace === "wgs84"` set `gl_Position = u_anchor_clip + deltaClip` directly (skip `projectTile`/matrix). |
| `src/shader-program.ts` | Look up `eyeMatrixLoc` and `anchorClipLoc` via the non-throwing `gl.getUniformLocation` (non-wgs84 shaders drop these). |
| `src/zarr-renderer.ts` | In `applyCommonUniforms`, when `uniforms.eyeAnchorMerc` is set, upload `u_eye_matrix` (mainMatrix for MapLibre, mapboxMatrix for Mapbox) and compute `u_anchor_clip` in JS Float64. |
| `src/renderer-types.ts` | Extend `RendererUniforms` with optional `eyeAnchorMerc`. |
| `src/untiled-mode.ts` | Cache `layerMercAnchor` from `mercatorBounds` after the proj4 transformer is set up; expose via `getUniformsForRender`; pass to `createHybridMesh`. |
| `src/mesh-reprojector.ts` | When `layerMercAnchor` is provided, encode each vertex via `lonLatToMerc` + chunk-local-in-layer normalization (Float32 small magnitude); return `wgs84Bounds` = anchor ± half so the renderer's `scale_x` / `shift_x` uniforms come out identical for every chunk of the layer. Original `encodeAbsoluteWgs84` path is preserved as a fallback for non-proj4 datasets. |

## Tested

- Verified at z = 18.9 over a KY ortho zarr (EPSG:3089) — multi-pixel jitter is gone; straight features render straight; no chunk-boundary regressions.
- `npm run typecheck` clean.
- `npm run build` clean (`tsup` → 276 KB ESM).
- `npm run format` applied.
- Other CRSes unaffected (different shader paths — `mercator` and `wgs84-direct` inputSpaces, plus the Mapbox globe variants — don't touch any of the modified shader strings).

## Notes

- Globe view at high zoom isn't covered by this change. The existing `wgs84-direct` (ECEF) path goes through different shader code and isn't affected; the planar-MapLibre `wgs84` proj4 path is the one that had the issue.
- The eye-coords math depends on the projection matrix being a linear map from world coords to clip space. That holds for both flat MapLibre (`mainMatrix`) and Mapbox planar; it doesn't hold for sphere/globe projection, which is why this stays scoped to the wgs84 inputSpace shader.