### PR TITLE
fix: fetch both sides when viewport crosses antimeridian in untiled mode

### DIFF
--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -661,25 +661,47 @@ export class UntiledMode implements ZarrMode {
       yNorthIdx = height - 1 - yNorthIdx
     }
 
-    // Convert pixel indices to region indices
-    const regionXMin = Math.floor(Math.min(xMinIdx, xMaxIdx) / regionW)
-    const regionXMax = Math.floor(Math.max(xMinIdx, xMaxIdx) / regionW)
     const regionYMin = Math.floor(Math.min(ySouthIdx, yNorthIdx) / regionH)
     const regionYMax = Math.floor(Math.max(ySouthIdx, yNorthIdx) / regionH)
-
-    // Clamp to valid range
     const numRegionsX = Math.ceil(width / regionW)
     const numRegionsY = Math.ceil(height / regionH)
-    const clampedXMin = Math.max(0, regionXMin)
-    const clampedXMax = Math.min(numRegionsX - 1, regionXMax)
     const clampedYMin = Math.max(0, regionYMin)
     const clampedYMax = Math.min(numRegionsY - 1, regionYMax)
 
-    // Build list of visible region coordinates
     const regions: Array<{ regionX: number; regionY: number }> = []
-    for (let ry = clampedYMin; ry <= clampedYMax; ry++) {
-      for (let rx = clampedXMin; rx <= clampedXMax; rx++) {
-        regions.push({ regionX: rx, regionY: ry })
+
+    if (east > xMax || west < xMin) {
+      // Viewport crosses the antimeridian. geoToArrayIndex clamps coordinates to
+      // the dataset edges, so a single index range would span the entire dataset
+      // width instead of just the two narrow strips that are actually visible.
+      // Fetch each strip separately by wrapping the overflowed coordinate back
+      // into the dataset's extent.
+      if (east > xMax) {
+        const asiaXMin = Math.max(0, Math.floor(xMinIdx / regionW))
+        const wrappedEastIdx = geoToArrayIndex(east - (xMax - xMin), xMin, xMax, width)
+        const alaskaXMax = Math.min(numRegionsX - 1, Math.floor(wrappedEastIdx / regionW))
+        for (let ry = clampedYMin; ry <= clampedYMax; ry++) {
+          for (let rx = asiaXMin; rx < numRegionsX; rx++) regions.push({ regionX: rx, regionY: ry })
+          for (let rx = 0; rx <= alaskaXMax; rx++) regions.push({ regionX: rx, regionY: ry })
+        }
+      } else {
+        const wrappedWestIdx = geoToArrayIndex(west + (xMax - xMin), xMin, xMax, width)
+        const asiaXMin = Math.max(0, Math.floor(wrappedWestIdx / regionW))
+        const alaskaXMax = Math.min(numRegionsX - 1, Math.floor(xMaxIdx / regionW))
+        for (let ry = clampedYMin; ry <= clampedYMax; ry++) {
+          for (let rx = asiaXMin; rx < numRegionsX; rx++) regions.push({ regionX: rx, regionY: ry })
+          for (let rx = 0; rx <= alaskaXMax; rx++) regions.push({ regionX: rx, regionY: ry })
+        }
+      }
+    } else {
+      const regionXMin = Math.floor(Math.min(xMinIdx, xMaxIdx) / regionW)
+      const regionXMax = Math.floor(Math.max(xMinIdx, xMaxIdx) / regionW)
+      const clampedXMin = Math.max(0, regionXMin)
+      const clampedXMax = Math.min(numRegionsX - 1, regionXMax)
+      for (let ry = clampedYMin; ry <= clampedYMax; ry++) {
+        for (let rx = clampedXMin; rx <= clampedXMax; rx++) {
+          regions.push({ regionX: rx, regionY: ry })
+        }
       }
     }
 

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -2000,9 +2000,25 @@ export class UntiledMode implements ZarrMode {
         this.xyLimits.xMax,
         this.xyLimits.yMax
       )
-      const dataWidthMeters = Math.abs(maxMercX - minMercX)
+      let dataWidthMeters = Math.abs(maxMercX - minMercX)
       const fullWorldMeters = 2 * WEB_MERCATOR_EXTENT
-      worldFraction = dataWidthMeters / fullWorldMeters
+      // worldFraction > 1 indicates the corner projection failed — this happens for
+      // projections like MODIS sinusoidal where the rectangular bounding box corners
+      // are outside the valid CRS domain (near-polar latitudes give out-of-domain λ).
+      // Fall back to the equatorial strip (y=0), which is always in-domain for any
+      // cylindrical-like projection and gives the correct horizontal extent.
+      if (!isFinite(dataWidthMeters) || dataWidthMeters > fullWorldMeters) {
+        const [eqMinX] = this.cachedMercatorTransformer.forward(
+          this.xyLimits.xMin,
+          0
+        )
+        const [eqMaxX] = this.cachedMercatorTransformer.forward(
+          this.xyLimits.xMax,
+          0
+        )
+        dataWidthMeters = Math.abs(eqMaxX - eqMinX)
+      }
+      worldFraction = Math.min(1, dataWidthMeters / fullWorldMeters)
     } else if (this.crs === 'EPSG:3857') {
       // Web Mercator: full world is ~40,075,016 meters
       const dataWidth = this.xyLimits.xMax - this.xyLimits.xMin


### PR DESCRIPTION
Fixes #64 

Hoping this fixes data missing on one side of the antimeridian in both Globe and Mercator projections for untiled datasets. When the viewport extends past 180 degrees, geoToArrayIndex clamps coords to the dataset edge, so the region range only covers the side of the antimeridian already in view. The other side is never fetched.

Here we detect the crossing with east > xMax || west < xMin and fetch two narrow strips instead: the trailing edge of the dataset and the leading edge on the wrapped side. The wrapped coordinate is found by subtracting or adding the full longitudinal extent before passing to geoToArrayIndex. 

Seems to be working on my side!!