### PR TITLE
simplify to route all crs through mesh projection path

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,12 +264,12 @@ const result = await layer.queryData({
 // Returns:
 // {
 //   [variable]: number[],
-//   dimensions: ['<source-y>', '<source-x>'],
-//   coordinates: { '<source-y>': number[], '<source-x>': number[] }
+//   dimensions: ['<store-y-axis>', '<store-x-axis>'],
+//   coordinates: { '<store-y-axis>': number[], '<store-x-axis>': number[] }
 // }
 ```
 
-Spatial query coordinates follow the source data axes when source bounds are available, with keys matching the store's axis names (for example `lat`/`lon` for EPSG:4326 or `y`/`x` for projected data). Query geometries are still supplied as GeoJSON lon/lat coordinates.
+Spatial query result dimensions and coordinate keys use the store's own spatial axis names whenever source bounds are available. `lat`/`lon` are used only when the zarr store literally names its axes that way; otherwise results use whatever names the store provides, such as `y`/`x` or `latitude`/`longitude`. Fallback paths that emit WGS84 coordinates use `lat`/`lon`. Query geometries are still supplied as GeoJSON lon/lat coordinates.
 
 You can pass a third `options` argument to control query behavior:
 

--- a/README.md
+++ b/README.md
@@ -264,12 +264,12 @@ const result = await layer.queryData({
 // Returns:
 // {
 //   [variable]: number[],
-//   dimensions: ['lat', 'lon'],
-//   coordinates: { lat: number[], lon: number[] }
+//   dimensions: ['<source-y>', '<source-x>'],
+//   coordinates: { '<source-y>': number[], '<source-x>': number[] }
 // }
 ```
 
-Datasets using a custom projection (via the `proj4` option) return coordinates in the source coordinate system, with keys matching the store's axis names (e.g. `y`/`x`). All other datasets (EPSG:4326, EPSG:3857) return `lat`/`lon` keys with WGS84 degree values.
+Spatial query coordinates follow the source data axes when source bounds are available, with keys matching the store's axis names (for example `lat`/`lon` for EPSG:4326 or `y`/`x` for projected data). Query geometries are still supplied as GeoJSON lon/lat coordinates.
 
 You can pass a third `options` argument to control query behavior:
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ const result = await layer.queryData({
 // }
 ```
 
-Spatial query result dimensions and coordinate keys use the store's own spatial axis names whenever source bounds are available. `lat`/`lon` are used only when the zarr store literally names its axes that way; otherwise results use whatever names the store provides, such as `y`/`x` or `latitude`/`longitude`. Fallback paths that emit WGS84 coordinates use `lat`/`lon`. Query geometries are still supplied as GeoJSON lon/lat coordinates.
+Spatial query results are returned in the dataset's source CRS, under the store's own spatial axis names. An `EPSG:3857` dataset with `y`/`x` axes returns Web Mercator meters under `y`/`x`; an `EPSG:4326` dataset with `latitude`/`longitude` axes returns degrees under `latitude`/`longitude`; a custom-proj4 dataset returns its source-CRS values under whatever the store calls them. Input geometries are still supplied as GeoJSON lon/lat regardless of the source CRS.
 
 You can pass a third `options` argument to control query behavior:
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,9 +15,6 @@ export const MIN_SUBDIVISIONS = 2
 /** Maximum subdivisions for region geometry tessellation (globe projection) */
 export const MAX_SUBDIVISIONS = 128
 
-/** Subdivisions for flat/mercator projection (simple quad, no curvature needed) */
-export const MERCATOR_SUBDIVISIONS = 1
-
 /** Web Mercator world extent in meters (half of full world width) */
 export const WEB_MERCATOR_EXTENT = 20037508.342789244
 

--- a/src/map-utils.ts
+++ b/src/map-utils.ts
@@ -7,7 +7,7 @@
  * adapted from zarr-cesium/src/map-utils.ts
  */
 
-import { MERCATOR_LAT_LIMIT, WEB_MERCATOR_EXTENT } from './constants'
+import { MERCATOR_LAT_LIMIT } from './constants'
 import { MAPBOX_IDENTITY_MATRIX } from './mapbox-utils'
 import type { ProjectionData, ShaderData } from './shaders'
 import type { MapLike } from './types'
@@ -466,49 +466,6 @@ export function findBestChildTiles<T extends TileDataLike>(
   }
 
   return bestChildren.length > 0 ? bestChildren : null
-}
-
-/**
- * Converts geographic bounds to normalized Web Mercator bounds [0, 1].
- * Handles both EPSG:4326 (lat/lon) and EPSG:3857 (already mercator) coordinate systems.
- * @param xyLimits - Geographic bounds { xMin, xMax, yMin, yMax }.
- * @param crs - Coordinate reference system ('EPSG:4326' or 'EPSG:3857').
- * @returns Normalized mercator bounds { x0, y0, x1, y1 }.
- */
-export function boundsToMercatorNorm(
-  xyLimits: { xMin: number; xMax: number; yMin: number; yMax: number },
-  crs: 'EPSG:4326' | 'EPSG:3857' | null
-): MercatorBounds {
-  if (crs === 'EPSG:3857') {
-    return {
-      x0: (xyLimits.xMin + WEB_MERCATOR_EXTENT) / (2 * WEB_MERCATOR_EXTENT),
-      y0: (WEB_MERCATOR_EXTENT - xyLimits.yMax) / (2 * WEB_MERCATOR_EXTENT),
-      x1: (xyLimits.xMax + WEB_MERCATOR_EXTENT) / (2 * WEB_MERCATOR_EXTENT),
-      y1: (WEB_MERCATOR_EXTENT - xyLimits.yMin) / (2 * WEB_MERCATOR_EXTENT),
-    }
-  }
-
-  let yMin = xyLimits.yMin
-  let yMax = xyLimits.yMax
-  if (yMin > yMax) {
-    ;[yMin, yMax] = [yMax, yMin]
-  }
-
-  const bounds: MercatorBounds = {
-    x0: lonToMercatorNorm(xyLimits.xMin),
-    y0: latToMercatorNorm(yMax),
-    x1: lonToMercatorNorm(xyLimits.xMax),
-    y1: latToMercatorNorm(yMin),
-  }
-
-  if (crs === 'EPSG:4326') {
-    // Preserve original latitude bounds for equirectangular data so callers
-    // can perform linear-latitude calculations when needed (e.g. queries).
-    bounds.latMin = yMin
-    bounds.latMax = yMax
-  }
-
-  return bounds
 }
 
 // === Untiled mode utilities ===

--- a/src/map-utils.ts
+++ b/src/map-utils.ts
@@ -303,11 +303,6 @@ export function mercatorNormToLat(mercY: number): number {
   return (180 / Math.PI) * Math.atan(Math.sinh(t))
 }
 
-/** Convert latitude in degrees to normalized WGS84 Y [0, 1] where -90 → 0, 90 → 1. */
-export function latToWgs84Norm(lat: number): number {
-  return (lat + 90) / 180
-}
-
 export function mercatorNormToLon(mercX: number): number {
   return mercX * 360 - 180
 }
@@ -561,20 +556,6 @@ export function geoToArrayIndex(
   return Math.floor(
     Math.max(0, Math.min(arraySize - 1, normalized * arraySize))
   )
-}
-
-// === Texture coordinate utilities ===
-
-/**
- * Flip texture V coordinates (for EPSG:3857 data with latIsAscending=true).
- */
-export function flipTexCoordV(texCoords: Float32Array): Float32Array {
-  const flipped = new Float32Array(texCoords.length)
-  for (let i = 0; i < texCoords.length; i += 2) {
-    flipped[i] = texCoords[i]
-    flipped[i + 1] = 1 - texCoords[i + 1]
-  }
-  return flipped
 }
 
 // === Projection utilities ===

--- a/src/map-utils.ts
+++ b/src/map-utils.ts
@@ -7,7 +7,7 @@
  * adapted from zarr-cesium/src/map-utils.ts
  */
 
-import { MERCATOR_LAT_LIMIT } from './constants'
+import { MERCATOR_LAT_LIMIT, WEB_MERCATOR_EXTENT } from './constants'
 import { MAPBOX_IDENTITY_MATRIX } from './mapbox-utils'
 import type { ProjectionData, ShaderData } from './shaders'
 import type { MapLike } from './types'
@@ -466,6 +466,78 @@ export function findBestChildTiles<T extends TileDataLike>(
   }
 
   return bestChildren.length > 0 ? bestChildren : null
+}
+
+/**
+ * Converts geographic bounds to normalized Web Mercator bounds [0, 1].
+ * Handles both EPSG:4326 (lat/lon) and EPSG:3857 (already mercator) coordinate systems.
+ * @param xyLimits - Geographic bounds { xMin, xMax, yMin, yMax }.
+ * @param crs - Coordinate reference system ('EPSG:4326' or 'EPSG:3857').
+ * @returns Normalized mercator bounds { x0, y0, x1, y1 }.
+ */
+export function boundsToMercatorNorm(
+  xyLimits: { xMin: number; xMax: number; yMin: number; yMax: number },
+  crs: 'EPSG:4326' | 'EPSG:3857' | null
+): MercatorBounds {
+  if (crs === 'EPSG:3857') {
+    return {
+      x0: (xyLimits.xMin + WEB_MERCATOR_EXTENT) / (2 * WEB_MERCATOR_EXTENT),
+      y0: (WEB_MERCATOR_EXTENT - xyLimits.yMax) / (2 * WEB_MERCATOR_EXTENT),
+      x1: (xyLimits.xMax + WEB_MERCATOR_EXTENT) / (2 * WEB_MERCATOR_EXTENT),
+      y1: (WEB_MERCATOR_EXTENT - xyLimits.yMin) / (2 * WEB_MERCATOR_EXTENT),
+    }
+  }
+
+  let yMin = xyLimits.yMin
+  let yMax = xyLimits.yMax
+  if (yMin > yMax) {
+    ;[yMin, yMax] = [yMax, yMin]
+  }
+
+  let x0: number
+  let x1: number
+  const lonSpan = xyLimits.xMax - xyLimits.xMin
+  if (Math.abs(lonSpan) >= 360) {
+    x0 = 0
+    x1 = 1
+  } else {
+    let lonMin = xyLimits.xMin
+    let lonMax = xyLimits.xMax
+
+    // Keep 0-360-style intervals continuous when they sit entirely outside
+    // [-180, 180]. Intervals that still cross the wrap boundary cannot be
+    // represented as one MercatorBounds X span, so use full-world X bounds.
+    while (lonMin >= 180 && lonMax > 180) {
+      lonMin -= 360
+      lonMax -= 360
+    }
+    while (lonMin < -180 && lonMax <= -180) {
+      lonMin += 360
+      lonMax += 360
+    }
+
+    x0 = lonToMercatorNormWrapped(lonMin)
+    x1 = lonToMercatorNormWrapped(lonMax)
+    if (lonSpan !== 0 && x1 <= x0) {
+      x0 = 0
+      x1 = 1
+    }
+  }
+
+  return {
+    x0,
+    y0: latToMercatorNorm(yMax),
+    x1,
+    y1: latToMercatorNorm(yMin),
+  }
+}
+
+function lonToMercatorNormWrapped(lon: number): number {
+  if (lon >= -180 && lon <= 180) {
+    return lonToMercatorNorm(lon)
+  }
+  const wrapped = ((((lon + 180) % 360) + 360) % 360) - 180
+  return (wrapped + 180) / 360
 }
 
 // === Untiled mode utilities ===

--- a/src/mapbox-tile-renderer.ts
+++ b/src/mapbox-tile-renderer.ts
@@ -7,7 +7,7 @@
  * Mapbox's renderToTile() asks the custom layer to render individual tiles
  * to offscreen textures, requiring:
  * - Tile-specific transformation matrix (not camera matrix)
- * - For EPSG:4326 data: fragment shader reprojection (Mercator → latitude for texture lookup)
+ * - CRS-specific projection handling for tiled and untiled sources.
  */
 
 import {
@@ -200,7 +200,7 @@ function renderRegionsToTile(
   // Determine if we're in globe mode (default true for backwards compatibility)
   const isGlobe = context.isGlobe ?? true
 
-  // Check if any region uses WGS84 (proj4 datasets or EPSG:4326)
+  // Check if any untiled region uses WGS84 vertex positions.
   const useWgs84 = regions.some((r) => !!r.wgs84Bounds)
 
   // Always use Mapbox globe shader for tile rendering - it handles both globe and mercator
@@ -236,9 +236,8 @@ function renderRegionsToTile(
     // per-region extent. (wgs84Bounds may be identity for absolute encoding.)
     if (!boundsIntersect(region.mercatorBounds, tileBounds)) continue
 
-    // For proj4 datasets: use indexed mesh with wgs84Bounds
-    // For EPSG:4326: use subdivided quad (not indexed) with wgs84Bounds
-    // Both use the mapbox-proj4 shader to convert WGS84 → Mercator
+    // Source-projected regions use WGS84 vertex positions and may use an
+    // indexed adaptive mesh.
     const useIndexedMesh = !!region.useIndexedMesh && !!region.indexBuffer
 
     const renderable: RenderableRegion = {
@@ -255,10 +254,10 @@ function renderRegionsToTile(
       bandTexturesConfigured: region.bandTexturesConfigured ?? new Set(),
       width: region.width,
       height: region.height,
-      // Include indexed mesh fields for proj4 datasets
+      // Include indexed mesh fields for adaptive source-projected meshes.
       indexBuffer: useIndexedMesh ? region.indexBuffer : undefined,
       useIndexedMesh: useIndexedMesh,
-      // Include wgs84Bounds for both proj4 and EPSG:4326 datasets
+      // Include wgs84Bounds for WGS84 vertex positioning.
       wgs84Bounds: region.wgs84Bounds,
       latIsAscending: region.latIsAscending,
     }

--- a/src/projection-utils.ts
+++ b/src/projection-utils.ts
@@ -1,7 +1,28 @@
 import proj4 from 'proj4'
 import type { MercatorBounds } from './map-utils'
-import { WEB_MERCATOR_EXTENT } from './constants'
+import { MERCATOR_LAT_LIMIT, WEB_MERCATOR_EXTENT } from './constants'
 import type { Bounds } from './types'
+
+/**
+ * Clamp WGS84 lon/lat to the source CRS's valid input range so a subsequent
+ * proj4 forward doesn't return non-finite values at known singularities.
+ *
+ * Currently only EPSG:3857 (clamped to ±MERCATOR_LAT_LIMIT) — extend this
+ * when EPSG area-of-use metadata becomes available (see #61).
+ */
+export function clampLatLonToProj4def(
+  lon: number,
+  lat: number,
+  proj4def: string
+): [number, number] {
+  if (proj4def === 'EPSG:3857') {
+    return [
+      lon,
+      Math.max(-MERCATOR_LAT_LIMIT, Math.min(MERCATOR_LAT_LIMIT, lat)),
+    ]
+  }
+  return [lon, lat]
+}
 
 /**
  * Formats a proj4 error with helpful context.

--- a/src/query/query-utils.ts
+++ b/src/query/query-utils.ts
@@ -315,7 +315,7 @@ function computeYPixelRange(
 /**
  * Computes pixel bounds from a geometry's bounding box.
  * Returns the pixel range [minX, maxX, minY, maxY] that covers the geometry.
- * Supports custom projections via proj4.
+ * Supports source projections via proj4.
  */
 export function computePixelBoundsFromGeometry(
   geometry: QueryGeometry,
@@ -328,6 +328,39 @@ export function computePixelBoundsFromGeometry(
   sourceBounds?: Bounds | null,
   cachedTransformer?: CachedTransformer
 ): PixelRect | null {
+  if (geometry.type === 'Point') {
+    const [lon, lat] = geometry.coordinates
+    const point = lonLatToPixel(
+      lon,
+      lat,
+      bounds,
+      width,
+      height,
+      crs,
+      latIsAscending,
+      proj4def,
+      sourceBounds,
+      cachedTransformer
+    )
+    if (!point) return null
+
+    const [xPixel, yPixel] = point
+    if (
+      !isFinite(xPixel) ||
+      !isFinite(yPixel) ||
+      xPixel < 0 ||
+      xPixel > width ||
+      yPixel < 0 ||
+      yPixel > height
+    ) {
+      return null
+    }
+
+    const xStart = Math.min(Math.max(0, Math.floor(xPixel)), width - 1)
+    const yStart = Math.min(Math.max(0, Math.floor(yPixel)), height - 1)
+    return { minX: xStart, maxX: xStart + 1, minY: yStart, maxY: yStart + 1 }
+  }
+
   const bbox = computeBoundingBox(geometry)
 
   // If proj4 is provided, use proj4 to transform bbox
@@ -511,8 +544,8 @@ function densifyAndTransformRing(
 
 /**
  * Transform a query geometry from WGS84 lon/lat into pixel-space coordinates.
- * For proj4 projections: forward-transforms vertices, then converts source CRS → pixel.
- * For standard CRS: uses mercator/equirect math → pixel.
+ * For source-projected data: forward-transforms vertices, then converts source
+ * CRS → pixel. Otherwise uses mercator/equirect math → pixel.
  * Densifies edges to preserve curvature under nonlinear projections.
  *
  * Returns a geometry with the same GeoJSON ring structure but in pixel coordinates,
@@ -1293,7 +1326,9 @@ function alignMultiPolygonMembers(members: number[][][][]): number[][][][] {
  * For Polygon/MultiPolygon: normalizes ring longitudes, computes a
  * WrappedBoundingBox, and clips at ±180 if crossing. For Point: returns as-is.
  *
- * Standard CRS only (EPSG:3857, EPSG:4326). Proj4 callers should skip this.
+ * The normalized geometry is only valid for CRSes that share WGS84 wrapped
+ * longitude semantics (EPSG:3857, EPSG:4326). Generic proj4 callers may still
+ * use the returned bbox to detect unsupported crossings.
  */
 export function preprocessQueryGeometry(geometry: QueryGeometry): {
   geometry: QueryGeometry
@@ -1397,8 +1432,8 @@ export function preprocessQueryGeometry(geometry: QueryGeometry): {
  * West strip: [westPx, width)  — covers lon [bbox.west, 180]
  * East strip: [0, eastPx)      — covers lon [-180, bbox.east]
  *
- * Uses standard-CRS floor/ceil/clamp conventions from computePixelBoundsFromGeometry.
- * Only valid for standard CRS (EPSG:3857, EPSG:4326), not proj4.
+ * Uses built-in wrapped-longitude CRS floor/ceil/clamp conventions from
+ * computePixelBoundsFromGeometry. Not valid for explicit custom proj4 data.
  */
 export function wrappedBboxToPixelSpans(
   bbox: WrappedBoundingBox,

--- a/src/query/query-utils.ts
+++ b/src/query/query-utils.ts
@@ -94,7 +94,9 @@ export function pixelToLatLon(
     return { lat, lon }
   }
 
-  // Standard CRS handling
+  // Standard CRS handling. Untiled source-projected queries normally take the
+  // proj4 branch above; this fallback is retained for exported callers and
+  // other internal paths that pass already-mercator-normalized bounds.
   // Guard against zero-dimension cases
   // centerPixel=true: return center of pixel (x+0.5), centerPixel=false: return corner (x)
   const xFrac = width <= 1 ? 0.5 : centerPixel ? (x + 0.5) / width : x / width

--- a/src/query/query-utils.ts
+++ b/src/query/query-utils.ts
@@ -10,18 +10,16 @@ import {
   getTilesAtZoomEquirect,
   latToMercatorNorm,
   lonToMercatorNorm,
-  mercatorNormToLat,
-  mercatorNormToLon,
   type TileTuple,
   type XYLimits,
   type MercatorBounds,
 } from '../map-utils'
+import { WEB_MERCATOR_EXTENT } from '../constants'
 import type { Bounds, CRS } from '../types'
 import type { BoundingBox, QueryGeometry, GeoJSONMultiPolygon } from './types'
 import {
   createWGS84ToSourceTransformer,
   sourceCRSToPixel,
-  pixelToSourceCRS,
 } from '../projection-utils'
 
 /** Pixel rectangle with exclusive max bounds. */
@@ -46,112 +44,10 @@ export function rasterExtentCrossesAntimeridian(
   )
 }
 
-/** Cached transformer type for reuse across multiple pixelToLatLon calls */
+/** Cached WGS84↔source-CRS transformer used by query input geometry transforms. */
 export type CachedTransformer = ReturnType<
   typeof createWGS84ToSourceTransformer
 >
-
-/**
- * Converts pixel coordinates to lat/lon.
- * Handles all CRS types including proj4 reprojection.
- * This is the canonical function for pixel → geographic conversion in queries.
- *
- * @param cachedTransformer - Optional pre-created transformer for performance.
- *   When processing many pixels, create once and reuse to avoid repeated proj4 init.
- */
-export function pixelToLatLon(
-  x: number,
-  y: number,
-  bounds: MercatorBounds,
-  width: number,
-  height: number,
-  crs: CRS,
-  latIsAscending?: boolean,
-  proj4def?: string | null,
-  sourceBounds?: Bounds | null,
-  cachedTransformer?: CachedTransformer,
-  centerPixel: boolean = true
-): { lat: number; lon: number } {
-  // For proj4, convert pixel → source CRS → WGS84
-  if (proj4def && sourceBounds) {
-    const transformer =
-      cachedTransformer ?? createWGS84ToSourceTransformer(proj4def)
-
-    // pixelToSourceCRS uses edge-based model: pixel 0 → xMin, pixel width → xMax
-    // For pixel centers, pass pixel + 0.5; for edges, pass pixel directly
-    const px = centerPixel ? x + 0.5 : x
-    const py = centerPixel ? y + 0.5 : y
-    const [srcX, srcY] = pixelToSourceCRS(
-      px,
-      py,
-      sourceBounds,
-      width,
-      height,
-      latIsAscending
-    )
-
-    const [lon, lat] = transformer.inverse(srcX, srcY)
-    return { lat, lon }
-  }
-
-  // Standard CRS handling. Untiled source-projected queries normally take the
-  // proj4 branch above; this fallback is retained for exported callers and
-  // other internal paths that pass already-mercator-normalized bounds.
-  // Guard against zero-dimension cases
-  // centerPixel=true: return center of pixel (x+0.5), centerPixel=false: return corner (x)
-  const xFrac = width <= 1 ? 0.5 : centerPixel ? (x + 0.5) / width : x / width
-  const yFrac =
-    height <= 1 ? 0.5 : centerPixel ? (y + 0.5) / height : y / height
-  const mercX = bounds.x0 + xFrac * (bounds.x1 - bounds.x0)
-  const mercY = bounds.y0 + yFrac * (bounds.y1 - bounds.y0)
-
-  const lon = mercatorNormToLon(mercX)
-
-  // Guard against zero-range bounds
-  const yRange = bounds.y1 - bounds.y0
-  const yNorm = yRange === 0 ? 0.5 : (mercY - bounds.y0) / yRange
-
-  const lat =
-    crs === 'EPSG:4326' &&
-    bounds.latMin !== undefined &&
-    bounds.latMax !== undefined
-      ? latIsAscending
-        ? bounds.latMin + yNorm * (bounds.latMax - bounds.latMin)
-        : bounds.latMax - yNorm * (bounds.latMax - bounds.latMin)
-      : mercatorNormToLat(mercY)
-
-  return { lat, lon }
-}
-
-/**
- * Converts latitude to tile Y coordinate at a given zoom level (Equirectangular/EPSG:4326).
- */
-function latToTileEquirect(
-  lat: number,
-  zoom: number,
-  xyLimits: XYLimits
-): number {
-  const { yMin, yMax } = xyLimits
-  const z2 = Math.pow(2, zoom)
-  const clamped = Math.max(Math.min(lat, yMax), yMin)
-  const norm = (yMax - clamped) / (yMax - yMin)
-  return Math.floor(norm * z2)
-}
-
-/**
- * Converts longitude to tile X coordinate at a given zoom level (Equirectangular/EPSG:4326).
- */
-function lonToTileEquirect(
-  lon: number,
-  zoom: number,
-  xyLimits: XYLimits
-): number {
-  const { xMin, xMax } = xyLimits
-  const z2 = Math.pow(2, zoom)
-  const clamped = Math.max(Math.min(lon, xMax), xMin)
-  const norm = (clamped - xMin) / (xMax - xMin)
-  return Math.floor(norm * z2)
-}
 
 /**
  * Computes fractional position within a tile for a geographic point.
@@ -192,35 +88,34 @@ function geoToTileFraction(
 }
 
 /**
- * Converts tile pixel position to geographic coordinates.
+ * Converts a tile-pixel position to source-CRS coordinates [x, y].
+ *
+ * EPSG:4326 tile pyramids: returns [lon, lat] in degrees, against xyLimits.
+ * EPSG:3857 tile pyramids: returns [x, y] in Web Mercator meters.
  */
-export function tilePixelToLatLon(
+export function tilePixelToSourceCRS(
   tile: TileTuple,
   pixelX: number,
   pixelY: number,
   tileSize: number,
   crs: CRS,
   xyLimits: XYLimits
-): { lat: number; lon: number } {
+): [number, number] {
   const [z, x, y] = tile
   const z2 = Math.pow(2, z)
-
   const fracX = (x + pixelX / tileSize) / z2
   const fracY = (y + pixelY / tileSize) / z2
 
   if (crs === 'EPSG:4326') {
     const { xMin, xMax, yMin, yMax } = xyLimits
-    const lon = xMin + fracX * (xMax - xMin)
-    const lat = yMax - fracY * (yMax - yMin)
-    return { lat, lon }
+    return [xMin + fracX * (xMax - xMin), yMax - fracY * (yMax - yMin)]
   }
 
-  // EPSG:3857 - invert mercator projection
-  const lon = fracX * 360 - 180
-  const y2 = 180 - fracY * 360
-  const lat = (360 / Math.PI) * Math.atan(Math.exp((y2 * Math.PI) / 180)) - 90
-
-  return { lat, lon }
+  // EPSG:3857: tile fractions map linearly to Web Mercator meters.
+  return [
+    (fracX * 2 - 1) * WEB_MERCATOR_EXTENT,
+    (1 - fracY * 2) * WEB_MERCATOR_EXTENT,
+  ]
 }
 
 /**

--- a/src/query/query-utils.ts
+++ b/src/query/query-utils.ts
@@ -16,6 +16,7 @@ import { WEB_MERCATOR_EXTENT } from '../constants'
 import type { Bounds, CRS } from '../types'
 import type { BoundingBox, QueryGeometry, GeoJSONMultiPolygon } from './types'
 import {
+  clampLatLonToProj4def,
   createWGS84ToSourceTransformer,
   sourceCRSToPixel,
 } from '../projection-utils'
@@ -219,7 +220,8 @@ export function computePixelBoundsFromGeometry(
   let maxY = -Infinity
 
   for (const [lon, lat] of samplePoints) {
-    const [srcX, srcY] = transformer.forward(lon, lat)
+    const [clampedLon, clampedLat] = clampLatLonToProj4def(lon, lat, proj4def)
+    const [srcX, srcY] = transformer.forward(clampedLon, clampedLat)
     if (!isFinite(srcX) || !isFinite(srcY)) continue
 
     const [xPixel, yPixel] = sourceCRSToPixel(
@@ -255,10 +257,7 @@ export function computePixelBoundsFromGeometry(
   return { minX: xStart, maxX: xEnd, minY: yStart, maxY: yEnd }
 }
 
-import {
-  DEFAULT_QUERY_DENSIFY_MAX_ERROR,
-  MERCATOR_LAT_LIMIT,
-} from '../constants'
+import { DEFAULT_QUERY_DENSIFY_MAX_ERROR } from '../constants'
 
 /** Max recursion depth for adaptive subdivision */
 const DENSIFY_MAX_DEPTH = 10
@@ -423,13 +422,9 @@ export function transformGeometryToTilePixelSpace(
   xyLimits: XYLimits
 ): QueryGeometry | null {
   const transformVertex = (lon: number, lat: number): [number, number] => {
-    // Clamp latitude to Mercator limits to avoid infinities at the poles
-    const clampedLat =
-      crs !== 'EPSG:4326'
-        ? Math.max(-MERCATOR_LAT_LIMIT, Math.min(MERCATOR_LAT_LIMIT, lat))
-        : lat
+    const [clampedLon, clampedLat] = clampLatLonToProj4def(lon, lat, crs)
     const { fracX, fracY } = geoToTileFraction(
-      lon,
+      clampedLon,
       clampedLat,
       tile,
       crs,
@@ -498,7 +493,8 @@ function lonLatToPixel(
 ): [number, number] | null {
   const transformer =
     cachedTransformer ?? createWGS84ToSourceTransformer(proj4def)
-  const [srcX, srcY] = transformer.forward(lon, lat)
+  const [clampedLon, clampedLat] = clampLatLonToProj4def(lon, lat, proj4def)
+  const [srcX, srcY] = transformer.forward(clampedLon, clampedLat)
   if (!isFinite(srcX) || !isFinite(srcY)) return null
   return sourceCRSToPixel(
     srcX,
@@ -1185,7 +1181,8 @@ export function wrappedBboxToPixelSpans(
     cachedTransformer ?? createWGS84ToSourceTransformer(proj4def)
 
   const toPixel = (lon: number, lat: number): [number, number] | null => {
-    const [srcX, srcY] = transformer.forward(lon, lat)
+    const [clampedLon, clampedLat] = clampLatLonToProj4def(lon, lat, proj4def)
+    const [srcX, srcY] = transformer.forward(clampedLon, clampedLat)
     if (!isFinite(srcX) || !isFinite(srcY)) return null
     return sourceCRSToPixel(
       srcX,

--- a/src/query/query-utils.ts
+++ b/src/query/query-utils.ts
@@ -8,11 +8,9 @@
 import {
   getTilesAtZoom,
   getTilesAtZoomEquirect,
-  latToMercatorNorm,
   lonToMercatorNorm,
   type TileTuple,
   type XYLimits,
-  type MercatorBounds,
 } from '../map-utils'
 import { WEB_MERCATOR_EXTENT } from '../constants'
 import type { Bounds, CRS } from '../types'
@@ -151,93 +149,34 @@ function computeBoundingBox(geometry: QueryGeometry): BoundingBox {
 }
 
 /**
- * Compute the Y pixel range for a south/north lat extent against raster bounds.
- * Handles both EPSG:4326 (linear latitude) and Mercator (normalized coords).
- * Returns null if no overlap.
- */
-function computeYPixelRange(
-  south: number,
-  north: number,
-  bounds: MercatorBounds,
-  height: number,
-  crs: CRS,
-  latIsAscending?: boolean
-): { yStart: number; yEnd: number } | null {
-  if (
-    crs === 'EPSG:4326' &&
-    bounds.latMin !== undefined &&
-    bounds.latMax !== undefined
-  ) {
-    const latRange = bounds.latMax - bounds.latMin
-    if (latRange === 0) return null
-    const clampedNorth = Math.min(Math.max(north, bounds.latMin), bounds.latMax)
-    const clampedSouth = Math.min(Math.max(south, bounds.latMin), bounds.latMax)
-    const toFrac = (lat: number) =>
-      latIsAscending
-        ? (lat - bounds.latMin!) / latRange
-        : (bounds.latMax! - lat) / latRange
-    const yFracMin = Math.min(toFrac(clampedNorth), toFrac(clampedSouth))
-    const yFracMax = Math.max(toFrac(clampedNorth), toFrac(clampedSouth))
-    const yStart = Math.min(
-      Math.max(0, Math.floor(yFracMin * height)),
-      height - 1
-    )
-    const yEnd = Math.min(
-      height,
-      Math.max(Math.ceil(yFracMax * height), yStart + 1)
-    )
-    if (yEnd <= yStart) return null
-    return { yStart, yEnd }
-  }
-
-  // Mercator
-  const normNorth = latToMercatorNorm(north)
-  const normSouth = latToMercatorNorm(south)
-  const overlapY0 = Math.max(bounds.y0, Math.min(normNorth, normSouth))
-  const overlapY1 = Math.min(bounds.y1, Math.max(normNorth, normSouth))
-  if (overlapY1 < overlapY0) return null
-  const rawMinY = Math.floor(
-    ((overlapY0 - bounds.y0) / (bounds.y1 - bounds.y0)) * height
-  )
-  const rawMaxY = Math.ceil(
-    ((overlapY1 - bounds.y0) / (bounds.y1 - bounds.y0)) * height
-  )
-  if (rawMaxY <= 0 || rawMinY >= height) return null
-  const yStart = Math.min(Math.max(0, rawMinY), height - 1)
-  const yEnd = Math.min(height, Math.max(rawMaxY, yStart + 1))
-  if (yEnd <= yStart) return null
-  return { yStart, yEnd }
-}
-
-/**
- * Computes pixel bounds from a geometry's bounding box.
- * Returns the pixel range [minX, maxX, minY, maxY] that covers the geometry.
- * Supports source projections via proj4.
+ * Compute pixel bounds covering a GeoJSON geometry, in the raster's pixel grid.
+ *
+ * All math goes through the source CRS via the supplied proj4 transformer, so
+ * the mapping is linear in the raster's own coordinate space regardless of CRS.
  */
 export function computePixelBoundsFromGeometry(
   geometry: QueryGeometry,
-  bounds: MercatorBounds,
+  sourceBounds: Bounds,
   width: number,
   height: number,
-  crs: CRS,
+  proj4def: string,
   latIsAscending?: boolean,
-  proj4def?: string | null,
-  sourceBounds?: Bounds | null,
   cachedTransformer?: CachedTransformer
 ): PixelRect | null {
+  const transformer =
+    cachedTransformer ?? createWGS84ToSourceTransformer(proj4def)
+
   if (geometry.type === 'Point') {
     const [lon, lat] = geometry.coordinates
     const point = lonLatToPixel(
       lon,
       lat,
-      bounds,
+      sourceBounds,
       width,
       height,
-      crs,
-      latIsAscending,
       proj4def,
-      sourceBounds,
-      cachedTransformer
+      latIsAscending,
+      transformer
     )
     if (!point) return null
 
@@ -260,97 +199,60 @@ export function computePixelBoundsFromGeometry(
 
   const bbox = computeBoundingBox(geometry)
 
-  // If proj4 is provided, use proj4 to transform bbox
-  if (proj4def && sourceBounds) {
-    const transformer =
-      cachedTransformer ?? createWGS84ToSourceTransformer(proj4def)
-
-    // Sample points along bbox edges to capture curved projections
-    // (corners alone can miss extrema for conic/polar projections)
-    const numSamples = 5
-    const samplePoints: [number, number][] = []
-
-    for (let i = 0; i <= numSamples; i++) {
-      const t = i / numSamples
-      const lon = bbox.west + t * (bbox.east - bbox.west)
-      const lat = bbox.south + t * (bbox.north - bbox.south)
-      samplePoints.push([lon, bbox.south]) // Bottom edge
-      samplePoints.push([lon, bbox.north]) // Top edge
-      samplePoints.push([bbox.west, lat]) // Left edge
-      samplePoints.push([bbox.east, lat]) // Right edge
-    }
-
-    let minX = Infinity
-    let maxX = -Infinity
-    let minY = Infinity
-    let maxY = -Infinity
-
-    for (const [lon, lat] of samplePoints) {
-      const [srcX, srcY] = transformer.forward(lon, lat)
-      if (!isFinite(srcX) || !isFinite(srcY)) continue
-
-      const [xPixel, yPixel] = sourceCRSToPixel(
-        srcX,
-        srcY,
-        sourceBounds,
-        width,
-        height,
-        latIsAscending
-      )
-      minX = Math.min(minX, xPixel)
-      maxX = Math.max(maxX, xPixel)
-      minY = Math.min(minY, yPixel)
-      maxY = Math.max(maxY, yPixel)
-    }
-
-    // Check if any valid samples were found
-    if (
-      !isFinite(minX) ||
-      !isFinite(maxX) ||
-      !isFinite(minY) ||
-      !isFinite(maxY)
-    ) {
-      return null
-    }
-
-    // Clamp to valid range
-    // Use floor + 1 to ensure integer maxX/maxY values include that pixel
-    // Clamp start to last pixel so points on the max edge map to the last pixel
-    const xStart = Math.min(Math.max(0, Math.floor(minX)), width - 1)
-    const xEnd = Math.min(width, Math.max(Math.floor(maxX) + 1, xStart + 1))
-    const yStart = Math.min(Math.max(0, Math.floor(minY)), height - 1)
-    const yEnd = Math.min(height, Math.max(Math.floor(maxY) + 1, yStart + 1))
-
-    if (xEnd <= xStart || yEnd <= yStart) return null
-
-    return { minX: xStart, maxX: xEnd, minY: yStart, maxY: yEnd }
+  // Sample points along bbox edges to capture curved projections
+  // (corners alone can miss extrema for conic/polar projections).
+  const numSamples = 5
+  const samplePoints: [number, number][] = []
+  for (let i = 0; i <= numSamples; i++) {
+    const t = i / numSamples
+    const lon = bbox.west + t * (bbox.east - bbox.west)
+    const lat = bbox.south + t * (bbox.north - bbox.south)
+    samplePoints.push([lon, bbox.south])
+    samplePoints.push([lon, bbox.north])
+    samplePoints.push([bbox.west, lat])
+    samplePoints.push([bbox.east, lat])
   }
 
-  // Y pixel range (shared helper for both CRS types)
-  const yRange = computeYPixelRange(
-    bbox.south,
-    bbox.north,
-    bounds,
-    height,
-    crs,
-    latIsAscending
-  )
-  if (!yRange) return null
+  let minX = Infinity
+  let maxX = -Infinity
+  let minY = Infinity
+  let maxY = -Infinity
 
-  // X pixel range (uses mercator norm for both CRS types)
-  const polyX0 = lonToMercatorNorm(bbox.west)
-  const polyX1 = lonToMercatorNorm(bbox.east)
-  const overlapX0 = Math.max(bounds.x0, Math.min(polyX0, polyX1))
-  const overlapX1 = Math.min(bounds.x1, Math.max(polyX0, polyX1))
-  if (overlapX1 < overlapX0) return null
+  for (const [lon, lat] of samplePoints) {
+    const [srcX, srcY] = transformer.forward(lon, lat)
+    if (!isFinite(srcX) || !isFinite(srcY)) continue
 
-  const rawMinX = ((overlapX0 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
-  const rawMaxX = ((overlapX1 - bounds.x0) / (bounds.x1 - bounds.x0)) * width
-  const xStart = Math.min(Math.max(0, Math.floor(rawMinX)), width - 1)
-  const xEnd = Math.min(width, Math.max(Math.ceil(rawMaxX), xStart + 1))
-  if (xEnd <= xStart) return null
+    const [xPixel, yPixel] = sourceCRSToPixel(
+      srcX,
+      srcY,
+      sourceBounds,
+      width,
+      height,
+      latIsAscending
+    )
+    minX = Math.min(minX, xPixel)
+    maxX = Math.max(maxX, xPixel)
+    minY = Math.min(minY, yPixel)
+    maxY = Math.max(maxY, yPixel)
+  }
 
-  return { minX: xStart, maxX: xEnd, minY: yRange.yStart, maxY: yRange.yEnd }
+  if (
+    !isFinite(minX) ||
+    !isFinite(maxX) ||
+    !isFinite(minY) ||
+    !isFinite(maxY)
+  ) {
+    return null
+  }
+
+  const xStart = Math.min(Math.max(0, Math.floor(minX)), width - 1)
+  const xEnd = Math.min(width, Math.max(Math.floor(maxX) + 1, xStart + 1))
+  const yStart = Math.min(Math.max(0, Math.floor(minY)), height - 1)
+  const yEnd = Math.min(height, Math.max(Math.floor(maxY) + 1, yStart + 1))
+
+  if (xEnd <= xStart || yEnd <= yStart) return null
+
+  return { minX: xStart, maxX: xEnd, minY: yStart, maxY: yEnd }
 }
 
 import {
@@ -450,93 +352,59 @@ function densifyAndTransformRing(
  */
 export function transformGeometryToPixelSpace(
   geometry: QueryGeometry,
-  bounds: MercatorBounds,
+  sourceBounds: Bounds,
   width: number,
   height: number,
-  crs: CRS,
+  proj4def: string,
   latIsAscending?: boolean,
-  proj4def?: string | null,
-  sourceBounds?: Bounds | null,
   cachedTransformer?: CachedTransformer
 ): QueryGeometry | null {
+  const transformer =
+    cachedTransformer ?? createWGS84ToSourceTransformer(proj4def)
+
   if (geometry.type === 'Point') {
     const [lon, lat] = geometry.coordinates
     const px = lonLatToPixel(
       lon,
       lat,
-      bounds,
+      sourceBounds,
       width,
       height,
-      crs,
-      latIsAscending,
       proj4def,
-      sourceBounds,
-      cachedTransformer
+      latIsAscending,
+      transformer
     )
     if (!px) return null
     return { type: 'Point', coordinates: [px[0], px[1]] }
   }
 
-  // Build the vertex transform function
   const transformVertex = (lon: number, lat: number): [number, number] => {
     const px = lonLatToPixel(
       lon,
       lat,
-      bounds,
+      sourceBounds,
       width,
       height,
-      crs,
-      latIsAscending,
       proj4def,
-      sourceBounds,
-      cachedTransformer
+      latIsAscending,
+      transformer
     )
     return px ?? [NaN, NaN]
   }
 
-  // Densify for any nonlinear CRS. EPSG:3857 uses latToMercatorNorm (nonlinear in Y).
-  // EPSG:4326 with lat bounds is linear and doesn't need densification.
-  const isLinear4326 =
-    crs === 'EPSG:4326' &&
-    bounds.latMin !== undefined &&
-    bounds.latMax !== undefined
-  const needsDensification =
-    !!proj4def || (!isLinear4326 && crs !== 'EPSG:4326')
-
-  const transformRing = (ring: number[][]): number[][] => {
-    if (needsDensification) {
-      return densifyAndTransformRing(ring, transformVertex)
-    }
-    // For linear projections, just transform vertices directly
-    const result: number[][] = []
-    for (const [lon, lat] of ring) {
-      const pt = transformVertex(lon, lat)
-      if (isFinite(pt[0]) && isFinite(pt[1])) {
-        result.push(pt as number[])
-      }
-    }
-    // Ensure ring is closed
-    if (
-      result.length > 1 &&
-      (result[0][0] !== result[result.length - 1][0] ||
-        result[0][1] !== result[result.length - 1][1])
-    ) {
-      result.push([result[0][0], result[0][1]])
-    }
-    return result
-  }
+  // Source-CRS forward transforms can be nonlinear, so always densify edges.
+  const transformRing = (ring: number[][]): number[][] =>
+    densifyAndTransformRing(ring, transformVertex)
 
   if (geometry.type === 'Polygon') {
     const coords = geometry.coordinates.map(transformRing)
-    if (coords[0].length < 4) return null // Need at least a triangle
+    if (coords[0].length < 4) return null
     return { type: 'Polygon', coordinates: coords }
   }
 
-  // MultiPolygon
   const coords = geometry.coordinates.map((polygon) =>
     polygon.map(transformRing)
   )
-  // Filter out degenerate polygons
   const valid = coords.filter((poly) => poly[0].length >= 4)
   if (valid.length === 0) return null
   return { type: 'MultiPolygon', coordinates: valid }
@@ -616,59 +484,30 @@ export function transformGeometryToTilePixelSpace(
 }
 
 /**
- * Convert a single lon/lat point to pixel coordinates.
- * Handles proj4, EPSG:4326, and EPSG:3857.
+ * Convert a single WGS84 lon/lat to source-CRS pixel coordinates.
  */
 function lonLatToPixel(
   lon: number,
   lat: number,
-  bounds: MercatorBounds,
+  sourceBounds: Bounds,
   width: number,
   height: number,
-  crs: CRS,
+  proj4def: string,
   latIsAscending?: boolean,
-  proj4def?: string | null,
-  sourceBounds?: Bounds | null,
   cachedTransformer?: CachedTransformer
 ): [number, number] | null {
-  if (proj4def && sourceBounds) {
-    const transformer =
-      cachedTransformer ?? createWGS84ToSourceTransformer(proj4def)
-    const [srcX, srcY] = transformer.forward(lon, lat)
-    if (!isFinite(srcX) || !isFinite(srcY)) return null
-    return sourceCRSToPixel(
-      srcX,
-      srcY,
-      sourceBounds,
-      width,
-      height,
-      latIsAscending
-    )
-  }
-
-  // Standard CRS: convert to mercator normalized, then to pixel.
-  // No bounds clamping — polygon vertices can legitimately lie far outside
-  // the raster extent (e.g. when the polygon fully contains a small raster).
-  const normX = lonToMercatorNorm(lon)
-  const xFrac = (normX - bounds.x0) / (bounds.x1 - bounds.x0)
-
-  let yFrac: number
-  if (
-    crs === 'EPSG:4326' &&
-    bounds.latMin !== undefined &&
-    bounds.latMax !== undefined
-  ) {
-    const latRange = bounds.latMax - bounds.latMin
-    if (latRange === 0) return null
-    yFrac = latIsAscending
-      ? (lat - bounds.latMin) / latRange
-      : (bounds.latMax - lat) / latRange
-  } else {
-    const normY = latToMercatorNorm(lat)
-    yFrac = (normY - bounds.y0) / (bounds.y1 - bounds.y0)
-  }
-
-  return [xFrac * width, yFrac * height]
+  const transformer =
+    cachedTransformer ?? createWGS84ToSourceTransformer(proj4def)
+  const [srcX, srcY] = transformer.forward(lon, lat)
+  if (!isFinite(srcX) || !isFinite(srcY)) return null
+  return sourceCRSToPixel(
+    srcX,
+    srcY,
+    sourceBounds,
+    width,
+    height,
+    latIsAscending
+  )
 }
 
 /**
@@ -1324,46 +1163,67 @@ export function preprocessQueryGeometry(geometry: QueryGeometry): {
 }
 
 /**
- * Derive two pixel rectangles from a crossing WrappedBoundingBox.
+ * Derive two pixel rectangles from an antimeridian-crossing WrappedBoundingBox.
  *
- * West strip: [westPx, width)  — covers lon [bbox.west, 180]
- * East strip: [0, eastPx)      — covers lon [-180, bbox.east]
+ * West strip: covers lon [bbox.west, 180].
+ * East strip: covers lon [-180, bbox.east].
  *
- * Uses built-in wrapped-longitude CRS floor/ceil/clamp conventions from
- * computePixelBoundsFromGeometry. Not valid for explicit custom proj4 data.
+ * Both strips share the same pixel-Y range. All conversions go through the
+ * source CRS via the supplied proj4 transformer, so the math is linear in the
+ * raster's own coordinate space regardless of CRS.
  */
 export function wrappedBboxToPixelSpans(
   bbox: WrappedBoundingBox,
-  bounds: MercatorBounds,
+  sourceBounds: Bounds,
   width: number,
   height: number,
-  crs: CRS,
-  latIsAscending?: boolean
+  proj4def: string,
+  latIsAscending?: boolean,
+  cachedTransformer?: CachedTransformer
 ): { west?: PixelRect; east?: PixelRect } {
-  // Y range shared by both strips
-  const yRange = computeYPixelRange(
-    bbox.south,
-    bbox.north,
-    bounds,
-    height,
-    crs,
-    latIsAscending
-  )
-  if (!yRange) return {}
-  const { yStart, yEnd } = yRange
+  const transformer =
+    cachedTransformer ?? createWGS84ToSourceTransformer(proj4def)
 
-  const xRange = bounds.x1 - bounds.x0
+  const toPixel = (lon: number, lat: number): [number, number] | null => {
+    const [srcX, srcY] = transformer.forward(lon, lat)
+    if (!isFinite(srcX) || !isFinite(srcY)) return null
+    return sourceCRSToPixel(
+      srcX,
+      srcY,
+      sourceBounds,
+      width,
+      height,
+      latIsAscending
+    )
+  }
+
+  // Y range shared by both strips. Sample both lat extremes at lon=0 — for the
+  // CRSes that take this path (EPSG:4326/3857 without a consumer proj4 prop)
+  // the source-CRS Y is independent of lon.
+  const yPixels: number[] = []
+  for (const lat of [bbox.south, bbox.north]) {
+    const px = toPixel(0, lat)
+    if (px) yPixels.push(px[1])
+  }
+  if (yPixels.length === 0) return {}
+  const yMinPx = Math.min(...yPixels)
+  const yMaxPx = Math.max(...yPixels)
+  const yStart = Math.min(Math.max(0, Math.floor(yMinPx)), height - 1)
+  const yEnd = Math.min(height, Math.max(Math.ceil(yMaxPx), yStart + 1))
+  if (yEnd <= yStart) return {}
 
   const computeStrip = (
-    normMin: number,
-    normMax: number
+    lonMin: number,
+    lonMax: number
   ): PixelRect | undefined => {
-    const xFracMin = (normMin - bounds.x0) / xRange
-    const xFracMax = (normMax - bounds.x0) / xRange
-    // Raw pixel range before clamping
-    const rawMinX = Math.floor(xFracMin * width)
-    const rawMaxX = Math.ceil(xFracMax * width)
-    // Check for actual overlap with [0, width) before clamping
+    const xPixels: number[] = []
+    for (const lon of [lonMin, lonMax]) {
+      const px = toPixel(lon, 0)
+      if (px) xPixels.push(px[0])
+    }
+    if (xPixels.length === 0) return undefined
+    const rawMinX = Math.floor(Math.min(...xPixels))
+    const rawMaxX = Math.ceil(Math.max(...xPixels))
     if (rawMaxX <= 0 || rawMinX >= width) return undefined
     const minX = Math.max(0, rawMinX)
     const maxX = Math.min(width, rawMaxX)
@@ -1371,18 +1231,10 @@ export function wrappedBboxToPixelSpans(
     return { minX, maxX, minY: yStart, maxY: yEnd }
   }
 
-  // West strip: [bbox.west, 180]
-  const westNormMin = lonToMercatorNorm(bbox.west)
-  const westNormMax = lonToMercatorNorm(180)
-  // East strip: [-180, bbox.east]
-  const eastNormMin = lonToMercatorNorm(-180)
-  const eastNormMax = lonToMercatorNorm(bbox.east)
-
   const result: { west?: PixelRect; east?: PixelRect } = {}
-
-  const westStrip = computeStrip(westNormMin, westNormMax)
+  const westStrip = computeStrip(bbox.west, 180)
   if (westStrip) result.west = westStrip
-  const eastStrip = computeStrip(eastNormMin, eastNormMax)
+  const eastStrip = computeStrip(-180, bbox.east)
   if (eastStrip) result.east = eastStrip
 
   return result

--- a/src/query/region-query.ts
+++ b/src/query/region-query.ts
@@ -36,18 +36,16 @@ import { SPATIAL_DIMENSION_ALIASES } from '../constants'
 /**
  * Determine spatial coordinate keys for query results.
  *
- * For proj4 data we emit source-CRS values, so keys match the store's
- * original axis names (e.g. 'y'/'x' or 'projection_y_coordinate').
- *
- * For standard CRS the values are always WGS84 lat/lon (from pixelToLatLon),
- * so keys are always 'lat'/'lon' regardless of what the store calls its axes.
+ * When a source CRS projection is active, keys match the store's original axis
+ * names (e.g. 'y'/'x' or 'projection_y_coordinate'). Otherwise values are
+ * WGS84 lat/lon and keys are always 'lat'/'lon'.
  *
  * Uses dimIndices (which incorporates spatialDimensions overrides) when available,
  * falling back to alias matching on the raw dimension names.
  */
 export function findSpatialDimNames(
   dimensions: string[],
-  isProj4: boolean,
+  usesSourceCoordinates: boolean,
   dimIndices?: DimIndicesProps
 ): {
   yDim: string
@@ -61,10 +59,10 @@ export function findSpatialDimNames(
   const yStoreDim = dimIndices?.lat?.name ?? findByAlias(dimensions, 'lat')
   const xStoreDim = dimIndices?.lon?.name ?? findByAlias(dimensions, 'lon')
 
-  if (!isProj4) {
+  if (!usesSourceCoordinates) {
     return { yDim: 'lat', xDim: 'lon', yStoreDim, xStoreDim }
   }
-  // For proj4, emit coordinates under the store's own axis names
+  // Source-CRS coordinates should use the store's own axis names.
   return { yDim: yStoreDim, xDim: xStoreDim, yStoreDim, xStoreDim }
 }
 
@@ -409,7 +407,8 @@ export function queryRegionUntiled(
   proj4def?: string | null,
   sourceBounds?: Bounds | null,
   options?: QueryOptions,
-  dimIndices?: DimIndicesProps
+  dimIndices?: DimIndicesProps,
+  cachedTransformer?: CachedTransformer
 ): QueryResult {
   const { signal, includeSpatialCoordinates = true } = options ?? {}
 
@@ -422,10 +421,11 @@ export function queryRegionUntiled(
   // Determine if results should be nested
   const useNestedResults = resultDim > 2
   let results: QueryDataValues = useNestedResults ? {} : []
+  const usesSourceCoordinates = !!proj4def && !!sourceBounds
 
   const { yDim, xDim, yStoreDim, xStoreDim } = findSpatialDimNames(
     dimensions,
-    !!proj4def,
+    usesSourceCoordinates,
     dimIndices
   )
   const yCoords: number[] = []
@@ -483,8 +483,8 @@ export function queryRegionUntiled(
   checkAborted(signal)
 
   // Create transformer once for all pixels
-  const cachedTransformer: CachedTransformer | undefined = proj4def
-    ? createWGS84ToSourceTransformer(proj4def)
+  const transformer: CachedTransformer | undefined = proj4def
+    ? cachedTransformer ?? createWGS84ToSourceTransformer(proj4def)
     : undefined
 
   // Transform the query polygon into pixel-space coordinates once.
@@ -498,39 +498,41 @@ export function queryRegionUntiled(
     latIsAscending,
     proj4def,
     sourceBounds,
-    cachedTransformer
+    transformer
   )
   if (!pixelGeometry) return buildResult()
 
-  // Emit pixel-center coordinates: source CRS for proj4, lat/lon otherwise.
+  // Emit pixel-center coordinates: source CRS when available, lat/lon otherwise.
   // Both paths use pixel centers (+0.5); pixelToLatLon applies it internally.
-  const emitCoords =
-    proj4def && sourceBounds
-      ? (x: number, y: number) => {
-          const [srcX, srcY] = pixelToSourceCRS(
-            x + 0.5,
-            y + 0.5,
-            sourceBounds,
-            width,
-            height,
-            latIsAscending
-          )
-          yCoords.push(srcY)
-          xCoords.push(srcX)
-        }
-      : (x: number, y: number) => {
-          const { lat, lon } = pixelToLatLon(
-            x,
-            y,
-            bounds,
-            width,
-            height,
-            _crs,
-            latIsAscending
-          )
-          yCoords.push(lat)
-          xCoords.push(lon)
-        }
+  const emitCoords = usesSourceCoordinates
+    ? (x: number, y: number) => {
+        const [srcX, srcY] = pixelToSourceCRS(
+          x + 0.5,
+          y + 0.5,
+          sourceBounds!,
+          width,
+          height,
+          latIsAscending
+        )
+        yCoords.push(srcY)
+        xCoords.push(srcX)
+      }
+    : (x: number, y: number) => {
+        const { lat, lon } = pixelToLatLon(
+          x,
+          y,
+          bounds,
+          width,
+          height,
+          _crs,
+          latIsAscending,
+          proj4def,
+          sourceBounds,
+          transformer
+        )
+        yCoords.push(lat)
+        xCoords.push(lon)
+      }
 
   // Helper to process a single pixel
   const processPixel = (x: number, y: number) => {

--- a/src/query/region-query.ts
+++ b/src/query/region-query.ts
@@ -21,8 +21,7 @@ import type {
 import {
   getTilesForPolygon,
   getTilesForBoundingBox,
-  tilePixelToLatLon,
-  pixelToLatLon,
+  tilePixelToSourceCRS,
   transformGeometryToPixelSpace,
   transformGeometryToTilePixelSpace,
   buildScanlineTable,
@@ -34,36 +33,18 @@ import { setObjectValues, getChunks, getPointValues } from './selector-utils'
 import { SPATIAL_DIMENSION_ALIASES } from '../constants'
 
 /**
- * Determine spatial coordinate keys for query results.
+ * Resolve the store's spatial axis names for query result keys.
  *
- * When a source CRS projection is active, keys match the store's original axis
- * names (e.g. 'y'/'x' or 'projection_y_coordinate'). Otherwise values are
- * WGS84 lat/lon and keys are always 'lat'/'lon'.
- *
- * Uses dimIndices (which incorporates spatialDimensions overrides) when available,
- * falling back to alias matching on the raw dimension names.
+ * Uses dimIndices (which incorporates spatialDimensions overrides) when
+ * available, falling back to alias matching on the raw dimension names.
  */
 export function findSpatialDimNames(
   dimensions: string[],
-  usesSourceCoordinates: boolean,
   dimIndices?: DimIndicesProps
-): {
-  yDim: string
-  xDim: string
-  /** The raw store dimension name for y, used to map resultDimensions */
-  yStoreDim: string
-  /** The raw store dimension name for x, used to map resultDimensions */
-  xStoreDim: string
-} {
-  // Resolve the actual store dimension names from dimIndices if available
-  const yStoreDim = dimIndices?.lat?.name ?? findByAlias(dimensions, 'lat')
-  const xStoreDim = dimIndices?.lon?.name ?? findByAlias(dimensions, 'lon')
-
-  if (!usesSourceCoordinates) {
-    return { yDim: 'lat', xDim: 'lon', yStoreDim, xStoreDim }
-  }
-  // Source-CRS coordinates should use the store's own axis names.
-  return { yDim: yStoreDim, xDim: xStoreDim, yStoreDim, xStoreDim }
+): { yDim: string; xDim: string } {
+  const yDim = dimIndices?.lat?.name ?? findByAlias(dimensions, 'lat')
+  const xDim = dimIndices?.lon?.name ?? findByAlias(dimensions, 'lon')
+  return { yDim, xDim }
 }
 
 function findByAlias(dimensions: string[], axis: 'lat' | 'lon'): string {
@@ -145,20 +126,11 @@ export async function queryRegionTiled(
   const useNestedResults = resultDim > 2
   let results: QueryDataValues = useNestedResults ? {} : []
 
-  const { yDim, xDim, yStoreDim, xStoreDim } = findSpatialDimNames(
-    dimensions,
-    false,
-    desc.dimIndices
-  )
+  const { yDim, xDim } = findSpatialDimNames(dimensions, desc.dimIndices)
   const yCoords: number[] = []
   const xCoords: number[] = []
 
-  // Map spatial dimensions in the result to the emitted coordinate keys
-  const resultDimensions = useNestedResults
-    ? dimensions.map((d) =>
-        d === yStoreDim ? yDim : d === xStoreDim ? xDim : d
-      )
-    : [yDim, xDim]
+  const resultDimensions = useNestedResults ? [...dimensions] : [yDim, xDim]
 
   const buildResultCoordinates = (): Record<string, (number | string)[]> => {
     const coords: Record<string, (number | string)[]> = {
@@ -168,8 +140,7 @@ export async function queryRegionTiled(
 
     if (useNestedResults) {
       for (const dim of dimensions) {
-        // Skip spatial dimensions — they're already emitted as yDim/xDim
-        if (dim === yStoreDim || dim === xStoreDim) continue
+        if (dim === yDim || dim === xDim) continue
 
         const sel = selector[dim]
         let values: (number | string)[] | undefined
@@ -331,7 +302,7 @@ export async function queryRegionTiled(
       if (pixelValues.length === 0) return
 
       if (includeSpatialCoordinates) {
-        const geo = tilePixelToLatLon(
+        const [srcX, srcY] = tilePixelToSourceCRS(
           tileTuple,
           pixelX + 0.5,
           pixelY + 0.5,
@@ -339,8 +310,8 @@ export async function queryRegionTiled(
           crs,
           xyLimits
         )
-        yCoords.push(geo.lat)
-        xCoords.push(geo.lon)
+        yCoords.push(srcY)
+        xCoords.push(srcX)
       }
 
       for (const { keys, value } of pixelValues) {
@@ -399,13 +370,13 @@ export function queryRegionUntiled(
   _crs: CRS,
   dimensions: string[],
   coordinates: Record<string, (string | number)[]>,
+  sourceBounds: Bounds,
   channels: number = 1,
   channelLabels?: (string | number)[][],
   multiValueDimNames?: string[],
   latIsAscending?: boolean,
   transforms?: QueryTransformOptions,
   proj4def?: string | null,
-  sourceBounds?: Bounds | null,
   options?: QueryOptions,
   dimIndices?: DimIndicesProps,
   cachedTransformer?: CachedTransformer
@@ -421,22 +392,12 @@ export function queryRegionUntiled(
   // Determine if results should be nested
   const useNestedResults = resultDim > 2
   let results: QueryDataValues = useNestedResults ? {} : []
-  const usesSourceCoordinates = !!proj4def && !!sourceBounds
 
-  const { yDim, xDim, yStoreDim, xStoreDim } = findSpatialDimNames(
-    dimensions,
-    usesSourceCoordinates,
-    dimIndices
-  )
+  const { yDim, xDim } = findSpatialDimNames(dimensions, dimIndices)
   const yCoords: number[] = []
   const xCoords: number[] = []
 
-  // Map spatial dimensions in the result to the emitted coordinate keys
-  const resultDimensions = useNestedResults
-    ? dimensions.map((d) =>
-        d === yStoreDim ? yDim : d === xStoreDim ? xDim : d
-      )
-    : [yDim, xDim]
+  const resultDimensions = useNestedResults ? [...dimensions] : [yDim, xDim]
 
   const buildResultCoordinates = (): Record<string, (number | string)[]> => {
     const coords: Record<string, (number | string)[]> = {
@@ -446,7 +407,7 @@ export function queryRegionUntiled(
 
     if (useNestedResults) {
       for (const dim of dimensions) {
-        if (dim === yStoreDim || dim === xStoreDim) continue
+        if (dim === yDim || dim === xDim) continue
 
         const sel = selector[dim]
         let values: (number | string)[] | undefined
@@ -502,37 +463,19 @@ export function queryRegionUntiled(
   )
   if (!pixelGeometry) return buildResult()
 
-  // Emit pixel-center coordinates: source CRS when available, lat/lon otherwise.
-  // Both paths use pixel centers (+0.5); pixelToLatLon applies it internally.
-  const emitCoords = usesSourceCoordinates
-    ? (x: number, y: number) => {
-        const [srcX, srcY] = pixelToSourceCRS(
-          x + 0.5,
-          y + 0.5,
-          sourceBounds!,
-          width,
-          height,
-          latIsAscending
-        )
-        yCoords.push(srcY)
-        xCoords.push(srcX)
-      }
-    : (x: number, y: number) => {
-        const { lat, lon } = pixelToLatLon(
-          x,
-          y,
-          bounds,
-          width,
-          height,
-          _crs,
-          latIsAscending,
-          proj4def,
-          sourceBounds,
-          transformer
-        )
-        yCoords.push(lat)
-        xCoords.push(lon)
-      }
+  // Emit pixel-center coordinates in the source CRS.
+  const emitCoords = (x: number, y: number) => {
+    const [srcX, srcY] = pixelToSourceCRS(
+      x + 0.5,
+      y + 0.5,
+      sourceBounds,
+      width,
+      height,
+      latIsAscending
+    )
+    yCoords.push(srcY)
+    xCoords.push(srcX)
+  }
 
   // Helper to process a single pixel
   const processPixel = (x: number, y: number) => {

--- a/src/query/region-query.ts
+++ b/src/query/region-query.ts
@@ -6,7 +6,7 @@
  * Matches carbonplan/maps structure and behavior.
  */
 
-import type { MercatorBounds, XYLimits } from '../map-utils'
+import type { XYLimits } from '../map-utils'
 import { parseLevelZoom, tileToKey } from '../map-utils'
 import type { ZarrStore } from '../zarr-store'
 import type { Bounds, CRS, DimIndicesProps, Selector } from '../types'
@@ -366,17 +366,15 @@ export function queryRegionUntiled(
   data: Float32Array | null,
   width: number,
   height: number,
-  bounds: MercatorBounds,
-  _crs: CRS,
   dimensions: string[],
   coordinates: Record<string, (string | number)[]>,
   sourceBounds: Bounds,
+  proj4def: string,
   channels: number = 1,
   channelLabels?: (string | number)[][],
   multiValueDimNames?: string[],
   latIsAscending?: boolean,
   transforms?: QueryTransformOptions,
-  proj4def?: string | null,
   options?: QueryOptions,
   dimIndices?: DimIndicesProps,
   cachedTransformer?: CachedTransformer
@@ -444,21 +442,18 @@ export function queryRegionUntiled(
   checkAborted(signal)
 
   // Create transformer once for all pixels
-  const transformer: CachedTransformer | undefined = proj4def
-    ? cachedTransformer ?? createWGS84ToSourceTransformer(proj4def)
-    : undefined
+  const transformer: CachedTransformer =
+    cachedTransformer ?? createWGS84ToSourceTransformer(proj4def)
 
   // Transform the query polygon into pixel-space coordinates once.
   // This eliminates per-pixel proj4 calls during the intersection test.
   const pixelGeometry = transformGeometryToPixelSpace(
     geometry,
-    bounds,
+    sourceBounds,
     width,
     height,
-    _crs,
-    latIsAscending,
     proj4def,
-    sourceBounds,
+    latIsAscending,
     transformer
   )
   if (!pixelGeometry) return buildResult()

--- a/src/query/types.ts
+++ b/src/query/types.ts
@@ -18,9 +18,10 @@ export type QueryDataValues = number[] | NestedValues
  * Result from a query (point or region).
  * Matches carbonplan/maps structure: { [variable]: values, dimensions, coordinates }
  *
- * Spatial coordinate keys follow the emitted coordinate space:
+ * Spatial result dimensions and coordinate keys follow the emitted coordinate space:
  * - WGS84 fallback: `lat`/`lon`
- * - Source CRS: the store's spatial axis names (for example `y`/`x`)
+ * - Source CRS: the store's spatial axis names (for example `y`/`x`,
+ *   `lat`/`lon`, or `latitude`/`longitude`)
  */
 export interface QueryResult {
   /** Variable name mapped to its values (flat array or nested based on selector) */
@@ -28,7 +29,7 @@ export interface QueryResult {
     | QueryDataValues
     | string[]
     | { [key: string]: (number | string)[] }
-  /** Dimension names in order (e.g., ['month', 'lat', 'lon'] or ['month', 'y', 'x']) */
+  /** Dimension names in order, using the same spatial keys as coordinates */
   dimensions: string[]
   /** Coordinate arrays for each dimension */
   coordinates: {

--- a/src/query/types.ts
+++ b/src/query/types.ts
@@ -18,9 +18,9 @@ export type QueryDataValues = number[] | NestedValues
  * Result from a query (point or region).
  * Matches carbonplan/maps structure: { [variable]: values, dimensions, coordinates }
  *
- * Spatial coordinate keys depend on the dataset's CRS:
- * - Standard CRS (EPSG:3857/4326): `lat`/`lon`
- * - Projected CRS (proj4): `y`/`x` in the source coordinate system
+ * Spatial coordinate keys follow the emitted coordinate space:
+ * - WGS84 fallback: `lat`/`lon`
+ * - Source CRS: the store's spatial axis names (for example `y`/`x`)
  */
 export interface QueryResult {
   /** Variable name mapped to its values (flat array or nested based on selector) */

--- a/src/query/types.ts
+++ b/src/query/types.ts
@@ -18,10 +18,10 @@ export type QueryDataValues = number[] | NestedValues
  * Result from a query (point or region).
  * Matches carbonplan/maps structure: { [variable]: values, dimensions, coordinates }
  *
- * Spatial result dimensions and coordinate keys follow the emitted coordinate space:
- * - WGS84 fallback: `lat`/`lon`
- * - Source CRS: the store's spatial axis names (for example `y`/`x`,
- *   `lat`/`lon`, or `latitude`/`longitude`)
+ * Spatial result keys are the store's own axis names (e.g. `y`/`x`,
+ * `lat`/`lon`, `latitude`/`longitude`) and the coordinate arrays carry
+ * source-CRS values: Web Mercator meters for EPSG:3857, degrees for
+ * EPSG:4326, source units for custom-proj4 datasets.
  */
 export interface QueryResult {
   /** Variable name mapped to its values (flat array or nested based on selector) */

--- a/src/renderable-region.ts
+++ b/src/renderable-region.ts
@@ -24,11 +24,11 @@ export interface RenderableRegion {
   pixCoordBuffer: WebGLBuffer
   vertexCount: number
 
-  // Indexed mesh support (for adaptive mesh with proj4 datasets)
+  // Indexed mesh support (for adaptive source-projected meshes)
   indexBuffer?: WebGLBuffer | null
   useIndexedMesh?: boolean
 
-  // WGS84 bounds for vertex shader positioning (proj4 datasets, ECEF globe)
+  // WGS84 bounds for vertex shader positioning (source-projected path, ECEF globe)
   wgs84Bounds?: Wgs84Bounds | null
 
   // Data orientation: true = row 0 is south (latitude ascending)

--- a/src/renderable-region.ts
+++ b/src/renderable-region.ts
@@ -37,7 +37,7 @@ export interface RenderableRegion {
 
   // Render-time mode fields (computed in regionToRenderable, not cached on RegionState)
   // Defaults when unset: positionSpace = wgs84Bounds ? 'wgs84' : 'mercator'
-  //                      sampleMode = hasLatBounds && !wgs84Bounds ? 'mercator-invert' : 'linear'
+  //                      sampleMode = 'linear'
   positionSpace?: 'mercator' | 'wgs84' | 'wgs84-ecef'
   sampleMode?: 'linear' | 'mercator-invert' | 'wgs84-lookup'
 
@@ -85,9 +85,7 @@ export function renderRegion(
   const hasLatBounds =
     region.mercatorBounds.latMin !== undefined &&
     region.mercatorBounds.latMax !== undefined
-  const sampMode =
-    region.sampleMode ??
-    (hasLatBounds && !wgs84Bounds ? 'mercator-invert' : 'linear')
+  const sampMode = region.sampleMode ?? 'linear'
 
   // Set position uniforms based on position space
   let scaleX: number, scaleY: number, shiftX: number, shiftY: number

--- a/src/tile-renderer.ts
+++ b/src/tile-renderer.ts
@@ -52,6 +52,9 @@ function tileToRenderable(
   renderTileKey: string,
   latIsAscending: boolean
 ): RenderableRegion {
+  const usesMercatorInvert =
+    bounds.latMin !== undefined && bounds.latMax !== undefined
+
   return {
     mercatorBounds: bounds,
     vertexBuffer: tile.vertexBuffer!,
@@ -69,6 +72,7 @@ function tileToRenderable(
     ensureBandTexture: (bandName) =>
       tileCache.ensureBandTexture(renderTileKey, bandName),
     latIsAscending,
+    sampleMode: usesMercatorInvert ? 'mercator-invert' : 'linear',
   }
 }
 

--- a/src/tiled-mode.ts
+++ b/src/tiled-mode.ts
@@ -5,7 +5,7 @@ import type {
   TiledRenderState,
 } from './zarr-mode'
 import type { QueryGeometry, QueryOptions, QueryResult } from './query/types'
-import { queryRegionTiled } from './query/region-query'
+import { queryRegionTiled, findSpatialDimNames } from './query/region-query'
 import {
   preprocessQueryGeometry,
   rasterExtentCrossesAntimeridian,
@@ -558,17 +558,21 @@ export class TiledMode implements ZarrMode {
     selector?: Selector,
     options?: QueryOptions
   ): Promise<QueryResult> {
+    const desc = this.zarrStore.describe()
     if (!this.tileCache || !this.xyLimits) {
+      const { yDim, xDim } = findSpatialDimNames(
+        desc.dimensions,
+        desc.dimIndices
+      )
       return {
         [this.variable]: [],
         dimensions: [],
-        coordinates: { lat: [], lon: [] },
+        coordinates: { [yDim]: [], [xDim]: [] },
       }
     }
 
     const querySelector = selector ? normalizeSelector(selector) : this.selector
     const level = this.currentLevel ?? this.maxLevelIndex
-    const desc = this.zarrStore.describe()
     const transforms = {
       scaleFactor: desc.scaleFactor,
       addOffset: desc.addOffset,

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -13,7 +13,6 @@ import {
   WEB_MERCATOR_EXTENT,
   MIN_SUBDIVISIONS,
   MAX_SUBDIVISIONS,
-  MERCATOR_SUBDIVISIONS,
 } from './constants'
 import type {
   ZarrMode,
@@ -39,22 +38,12 @@ import type {
 } from './types'
 import { ZarrStore } from './zarr-store'
 import {
-  boundsToMercatorNorm,
-  flipTexCoordV,
-  latToMercatorNorm,
-  latToWgs84Norm,
-  lonToMercatorNorm,
-  mercatorNormToLat,
   type MercatorBounds,
   type XYLimits,
   type Wgs84Bounds,
 } from './map-utils'
 import { loadDimensionValues, normalizeSelector, getBands } from './zarr-utils'
-import {
-  createSubdividedQuad,
-  interleaveBands,
-  normalizeDataForTexture,
-} from './webgl-utils'
+import { interleaveBands, normalizeDataForTexture } from './webgl-utils'
 import type { ZarrRenderer, ShaderProgram } from './zarr-renderer'
 import type { CustomShaderConfig } from './renderer-types'
 import { renderMapboxTile } from './mapbox-tile-renderer'
@@ -127,7 +116,7 @@ interface RegionState {
   bandTextures: Map<string, WebGLTexture>
   bandTexturesUploaded: Set<string>
   bandTexturesConfigured: Set<string>
-  // Level-specific dimensions for correct geometry rebuild across projection changes.
+  // Level-specific dimensions for region geometry bounds.
   // Set from LevelSnapshot during fetch to avoid races with level switching.
   levelMeta: LevelMeta | null
 }
@@ -275,13 +264,8 @@ export class UntiledMode implements ZarrMode {
 
   // Cached WebGL context for use in setSelector
   private cachedGl: WebGL2RenderingContext | null = null
-  // Track current projection for subdivision optimization
+  // Track current projection for Mapbox's direct globe render path.
   private isGlobeProjection: boolean = false
-  // Deferred geometry rebuild: when globe→flat transition starts, onProjectionChange(false)
-  // fires before projectionTransition reaches 0. Rebuilding geometry immediately would drop
-  // subdivisions to 1 while the ECEF shader is still rendering on the globe.
-  // This flag defers the rebuild until projectionTransition reaches 0.
-  private pendingGeometryRebuild: boolean = false
   // Fixed data scale for normalization (set at initialization, passed from ZarrLayer)
   private fixedDataScale: number = 1
 
@@ -364,11 +348,8 @@ export class UntiledMode implements ZarrMode {
       }
 
       if (this.xyLimits) {
-        // For proj4, compute mercator bounds by transforming corners
         if (this.proj4def) {
           this.mercatorBounds = this.computeMercatorBoundsFromProjection()
-        } else {
-          this.mercatorBounds = boundsToMercatorNorm(this.xyLimits, this.crs)
         }
       } else {
         console.warn('UntiledMode: No XY limits found')
@@ -1018,11 +999,7 @@ export class UntiledMode implements ZarrMode {
 
   /**
    * Create geometry (vertex positions and tex coords) for a region.
-   * Uses subdivided geometry for smooth globe rendering.
-   *
-   * Primary geometry path: source-projected adaptive mesh with WGS84 vertices.
-   * The CRS-specific subdivided-quad paths are fallback paths for data that
-   * cannot use the proj4-backed source projection path.
+   * Uses the source-projected adaptive mesh path for all supported untiled CRSes.
    */
   private createRegionGeometry(
     regionX: number,
@@ -1034,124 +1011,61 @@ export class UntiledMode implements ZarrMode {
     if (!region.levelMeta) return
 
     // Defensive reset: wgs84Bounds is only set by the source-projected branch.
-    // Ensures it's not stale after projection toggle or geometry rebuild.
+    // Ensures it's not stale if geometry is recreated.
     region.wgs84Bounds = null
     region.indexArr = null
     region.useIndexedMesh = false
 
+    if (
+      !this.proj4def ||
+      !this.cached4326Transformer ||
+      !this.cachedMercatorTransformer
+    ) {
+      return
+    }
+
     const geoBounds = this.getRegionBounds(regionX, regionY, region.levelMeta)
 
-    // Use cached mercatorBounds if set (from fetchRegion's resampling path),
-    // otherwise compute from geoBounds (for non-resampling cases like EPSG:3857)
-    const mercBounds =
-      region.mercatorBounds ?? boundsToMercatorNorm(geoBounds, this.crs)
-    region.mercatorBounds = mercBounds
-
-    if (this.proj4def && this.cached4326Transformer) {
-      // Source-projected path: compute WGS84 vertex positions via proj4.
-      // CPU: transform vertices from source CRS to WGS84.
-      // GPU: transform WGS84 → Mercator (flat) or WGS84 → ECEF (globe).
-
-      // Calculate subdivisions based on latSpan.
-      // For polar projections, the pole is at the CENTER, not corners, so sample
-      // the center point to get the true latitude span.
-      const centerX = (geoBounds.xMin + geoBounds.xMax) / 2
-      const centerY = (geoBounds.yMin + geoBounds.yMax) / 2
-      const samplePoints = [
-        this.cached4326Transformer.forward(geoBounds.xMin, geoBounds.yMin),
-        this.cached4326Transformer.forward(geoBounds.xMax, geoBounds.yMin),
-        this.cached4326Transformer.forward(geoBounds.xMin, geoBounds.yMax),
-        this.cached4326Transformer.forward(geoBounds.xMax, geoBounds.yMax),
-        this.cached4326Transformer.forward(centerX, centerY), // Center point (pole for polar projections)
-      ]
-      const validLats = samplePoints
-        .map((p) => p[1])
-        .filter((lat) => isFinite(lat))
-      const latSpan =
-        validLats.length > 0
-          ? Math.max(...validLats) - Math.min(...validLats)
-          : 0
-      const meshSubdivisions = Math.max(
-        MIN_SUBDIVISIONS,
-        Math.min(MAX_SUBDIVISIONS, Math.ceil(latSpan))
-      )
-
-      // Always use hybrid mesh (adaptive + uniform grid) for source-projected data.
-      const meshResult = createHybridMesh({
-        geoBounds,
-        width: region.width,
-        height: region.height,
-        subdivisions: meshSubdivisions,
-        transformer: this.cached4326Transformer!,
-        latIsAscending: this.latIsAscending,
-      })
-      region.vertexArr = meshResult.positions
-      region.pixCoordArr = meshResult.texCoords
-      region.indexArr = meshResult.indices
-      region.wgs84Bounds = meshResult.wgs84Bounds
-      region.useIndexedMesh = true
-      region.vertexCount = region.indexArr!.length
-    } else {
-      // Fallback non-proj4 paths.
-      // Compute subdivisions once based on CRS
-
-      // Subdivisions: high for globe (smooth curvature), minimal for mercator (flat)
-      // Use latitude span in degrees - lat is the primary driver of globe curvature
-      let latSpanDegrees: number
-      if (this.crs === 'EPSG:3857') {
-        // 3857 bounds are in meters - convert to degrees
-        const yMinNorm = 0.5 - geoBounds.yMin / (2 * WEB_MERCATOR_EXTENT)
-        const yMaxNorm = 0.5 - geoBounds.yMax / (2 * WEB_MERCATOR_EXTENT)
-        latSpanDegrees = Math.abs(
-          mercatorNormToLat(yMaxNorm) - mercatorNormToLat(yMinNorm)
-        )
-      } else {
-        // 4326 bounds are already in degrees
-        latSpanDegrees = Math.abs(geoBounds.yMax - geoBounds.yMin)
-      }
-      const subdivisions = this.isGlobeProjection
-        ? Math.max(
-            MIN_SUBDIVISIONS,
-            Math.min(MAX_SUBDIVISIONS, Math.ceil(latSpanDegrees))
-          )
-        : MERCATOR_SUBDIVISIONS
-
-      if (this.crs === 'EPSG:4326') {
-        // Fallback EPSG:4326 path: use fragment shader reprojection.
-        // Mesh is in Mercator space, fragment shader inverts Mercator → lat for texture lookup
-        const subdivided = createSubdividedQuad(subdivisions)
-        region.vertexArr = subdivided.vertexArr
-        region.pixCoordArr = subdivided.texCoordArr
-        region.vertexCount = subdivided.vertexArr.length / 2
-
-        // Compute Mercator bounds for vertex positioning
-        // geoBounds for 4326 data: xMin/xMax = lon, yMin/yMax = lat
-        const latMin = geoBounds.yMin
-        const latMax = geoBounds.yMax
-        region.mercatorBounds = {
-          x0: lonToMercatorNorm(geoBounds.xMin),
-          x1: lonToMercatorNorm(geoBounds.xMax),
-          y0: latToMercatorNorm(latMax),
-          y1: latToMercatorNorm(latMin),
-          // Include lat bounds for fragment shader reprojection
-          latMin,
-          latMax,
-        }
-
-        // Store data orientation for fragment shader
-        region.latIsAscending = this.latIsAscending
-      } else {
-        const subdivided = createSubdividedQuad(subdivisions)
-        region.vertexArr = subdivided.vertexArr
-        region.vertexCount = subdivided.vertexArr.length / 2
-
-        // EPSG:3857 and other Mercator-compatible CRS
-        // Texture coords need V-flip if latitude is ascending
-        region.pixCoordArr = this.latIsAscending
-          ? flipTexCoordV(subdivided.texCoordArr)
-          : subdivided.texCoordArr
-      }
+    if (!region.mercatorBounds) {
+      region.mercatorBounds = this.computeRegionMercatorBounds(geoBounds)
     }
+
+    // Compute WGS84 vertex positions via proj4.
+    // CPU: transform vertices from source CRS to WGS84.
+    // GPU: transform WGS84 → Mercator (flat) or WGS84 → ECEF (globe).
+    const centerX = (geoBounds.xMin + geoBounds.xMax) / 2
+    const centerY = (geoBounds.yMin + geoBounds.yMax) / 2
+    const samplePoints = [
+      this.cached4326Transformer.forward(geoBounds.xMin, geoBounds.yMin),
+      this.cached4326Transformer.forward(geoBounds.xMax, geoBounds.yMin),
+      this.cached4326Transformer.forward(geoBounds.xMin, geoBounds.yMax),
+      this.cached4326Transformer.forward(geoBounds.xMax, geoBounds.yMax),
+      this.cached4326Transformer.forward(centerX, centerY),
+    ]
+    const validLats = samplePoints
+      .map((p) => p[1])
+      .filter((lat) => isFinite(lat))
+    const latSpan =
+      validLats.length > 0 ? Math.max(...validLats) - Math.min(...validLats) : 0
+    const meshSubdivisions = Math.max(
+      MIN_SUBDIVISIONS,
+      Math.min(MAX_SUBDIVISIONS, Math.ceil(latSpan))
+    )
+
+    const meshResult = createHybridMesh({
+      geoBounds,
+      width: region.width,
+      height: region.height,
+      subdivisions: meshSubdivisions,
+      transformer: this.cached4326Transformer,
+      latIsAscending: this.latIsAscending,
+    })
+    region.vertexArr = meshResult.positions
+    region.pixCoordArr = meshResult.texCoords
+    region.indexArr = meshResult.indices
+    region.wgs84Bounds = meshResult.wgs84Bounds
+    region.useIndexedMesh = true
+    region.vertexCount = region.indexArr.length
 
     // Create/update buffers
     if (!region.vertexBuffer) {
@@ -1709,7 +1623,7 @@ export class UntiledMode implements ZarrMode {
       region.channels = numChannels
       region.loading = false
 
-      // Store level-specific dimensions from snapshot for geometry rebuild.
+      // Store level-specific dimensions from snapshot for geometry creation.
       // Must use snapshot (not this.*) to avoid races with level switching.
       // Set before createRegionGeometry is called below.
       region.levelMeta = {
@@ -2008,21 +1922,9 @@ export class UntiledMode implements ZarrMode {
     // can momentarily diverge.
     const hasMapboxDirectGlobePath =
       hasMapboxGlobe && context.mapbox?.directGlobePathActive === true
-    const ecefEligible = useWgs84 || this.crs === 'EPSG:4326'
     const useDirectEcef = useMapbox
-      ? hasMapboxDirectGlobePath && ecefEligible
-      : hasMaplibreGlobeTransition && ecefEligible
-
-    // Flush deferred geometry rebuild once transition completes.
-    // Source-projected data uses a projection-independent hybrid mesh.
-    if (this.pendingGeometryRebuild) {
-      if (useWgs84) {
-        this.pendingGeometryRebuild = false
-      } else if (!hasMaplibreGlobeTransition && !hasMapboxGlobe) {
-        this.pendingGeometryRebuild = false
-        this.rebuildAllGeometry()
-      }
-    }
+      ? hasMapboxDirectGlobePath && useWgs84
+      : hasMaplibreGlobeTransition && useWgs84
 
     const shaderProgram = renderer.getProgram(
       context.shaderData,
@@ -2062,9 +1964,9 @@ export class UntiledMode implements ZarrMode {
 
   /**
    * Convert a RegionState to a RenderableRegion for unified rendering.
-   * When useDirectEcef is true, computes WGS84 bounds and sets positionSpace/sampleMode
-   * for the ECEF vertex shader path. These fields are computed at render time,
-   * never cached on RegionState, so projection toggles have no stale state.
+   * When useDirectEcef is true, uses the region's precomputed WGS84 mesh bounds
+   * for the ECEF vertex shader path. Render-only fields are set here instead of
+   * cached on RegionState, so projection toggles have no stale state.
    */
   private regionToRenderable(
     region: RegionState,
@@ -2090,29 +1992,9 @@ export class UntiledMode implements ZarrMode {
       height: region.height,
     }
 
-    // Source-projected meshes already carry WGS84 bounds from createHybridMesh.
     if (useDirectEcef && region.wgs84Bounds) {
       base.positionSpace = 'wgs84-ecef'
       base.sampleMode = 'linear'
-      return base
-    }
-
-    // Fallback ECEF path for legacy EPSG:4326 mercator-space geometry.
-    if (
-      useDirectEcef &&
-      this.crs === 'EPSG:4326' &&
-      region.mercatorBounds?.latMin != null &&
-      region.mercatorBounds?.latMax != null
-    ) {
-      const mb = region.mercatorBounds!
-      base.wgs84Bounds = {
-        lon0: mb.x0, // lon mapping is linear, same as Mercator X
-        lat0: latToWgs84Norm(mb.latMin!),
-        lon1: mb.x1,
-        lat1: latToWgs84Norm(mb.latMax!),
-      }
-      base.positionSpace = 'wgs84-ecef'
-      base.sampleMode = 'wgs84-lookup'
       return base
     }
 
@@ -2170,30 +2052,6 @@ export class UntiledMode implements ZarrMode {
   onProjectionChange(isGlobe: boolean): void {
     if (this.isGlobeProjection === isGlobe) return
     this.isGlobeProjection = isGlobe
-
-    // Source-projected data uses a projection-independent hybrid mesh.
-    if (this.proj4def) return
-
-    if (!isGlobe) {
-      // Globe→flat: defer geometry rebuild until projectionTransition reaches 0.
-      // Rebuilding now would drop subdivisions to 1 while the ECEF shader is still
-      // rendering on the globe, causing severe faceting during the transition.
-      this.pendingGeometryRebuild = true
-      return
-    }
-
-    // Flat→globe: rebuild immediately with high subdivisions for smooth globe rendering
-    this.rebuildAllGeometry()
-  }
-
-  private rebuildAllGeometry(): void {
-    const gl = this.cachedGl
-    if (!gl) return
-    for (const region of this.regionCache.values()) {
-      if (!region.data) continue
-      this.createRegionGeometry(region.regionX, region.regionY, gl, region)
-    }
-    this.invalidate()
   }
 
   getTiledState() {
@@ -2548,17 +2406,15 @@ export class UntiledMode implements ZarrMode {
         ]
       : null
     const usesSourceCoordinates = !!this.proj4def && !!sourceBounds
+    const { yDim: emptyYDim, xDim: emptyXDim } = findSpatialDimNames(
+      desc.dimensions,
+      usesSourceCoordinates,
+      desc.dimIndices
+    )
     const emptyResult = (): QueryResult => ({
       [this.variable]: [],
       dimensions: [],
-      coordinates: (() => {
-        const { yDim, xDim } = findSpatialDimNames(
-          desc.dimensions,
-          usesSourceCoordinates,
-          desc.dimIndices
-        )
-        return { [yDim]: [], [xDim]: [] }
-      })(),
+      coordinates: { [emptyYDim]: [], [emptyXDim]: [] },
     })
 
     const activeLevel = this.activeLevel

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -116,7 +116,7 @@ interface RegionState {
   useIndexedMesh: boolean // Whether to use indexed triangles (adaptive mesh)
   // Mercator bounds for this region (for shader uniforms)
   mercatorBounds: MercatorBounds | null
-  // WGS84 bounds for vertex shader positioning (proj4 datasets, ECEF globe)
+  // WGS84 bounds for vertex shader positioning (source-projected path, ECEF globe)
   wgs84Bounds: Wgs84Bounds | null
   // Data orientation: true = row 0 is south
   latIsAscending: boolean
@@ -1020,10 +1020,9 @@ export class UntiledMode implements ZarrMode {
    * Create geometry (vertex positions and tex coords) for a region.
    * Uses subdivided geometry for smooth globe rendering.
    *
-   * Three geometry paths based on CRS (GPU projection chosen at render time):
-   * - Proj4 datasets: Adaptive mesh with WGS84 vertices (GPU: → Mercator or → ECEF)
-   * - EPSG:4326: Subdivided quad in Mercator space (GPU: fragment reprojection or ECEF direct)
-   * - EPSG:3857: Subdivided quad with linear texture coords (data already in Mercator)
+   * Primary geometry path: source-projected adaptive mesh with WGS84 vertices.
+   * The CRS-specific subdivided-quad paths are fallback paths for data that
+   * cannot use the proj4-backed source projection path.
    */
   private createRegionGeometry(
     regionX: number,
@@ -1034,7 +1033,7 @@ export class UntiledMode implements ZarrMode {
     // Guard: can't create geometry without dimension info
     if (!region.levelMeta) return
 
-    // Defensive reset: wgs84Bounds is only set by the proj4 branch below.
+    // Defensive reset: wgs84Bounds is only set by the source-projected branch.
     // Ensures it's not stale after projection toggle or geometry rebuild.
     region.wgs84Bounds = null
     region.indexArr = null
@@ -1049,7 +1048,7 @@ export class UntiledMode implements ZarrMode {
     region.mercatorBounds = mercBounds
 
     if (this.proj4def && this.cached4326Transformer) {
-      // Proj4 datasets: compute WGS84 vertex positions via proj4.
+      // Source-projected path: compute WGS84 vertex positions via proj4.
       // CPU: transform vertices from source CRS to WGS84.
       // GPU: transform WGS84 → Mercator (flat) or WGS84 → ECEF (globe).
 
@@ -1077,7 +1076,7 @@ export class UntiledMode implements ZarrMode {
         Math.min(MAX_SUBDIVISIONS, Math.ceil(latSpan))
       )
 
-      // Always use hybrid mesh (adaptive + uniform grid) for proj4 data.
+      // Always use hybrid mesh (adaptive + uniform grid) for source-projected data.
       const meshResult = createHybridMesh({
         geoBounds,
         width: region.width,
@@ -1093,7 +1092,7 @@ export class UntiledMode implements ZarrMode {
       region.useIndexedMesh = true
       region.vertexCount = region.indexArr!.length
     } else {
-      // Non-proj4 paths: EPSG:4326 and EPSG:3857
+      // Fallback non-proj4 paths.
       // Compute subdivisions once based on CRS
 
       // Subdivisions: high for globe (smooth curvature), minimal for mercator (flat)
@@ -1118,7 +1117,7 @@ export class UntiledMode implements ZarrMode {
         : MERCATOR_SUBDIVISIONS
 
       if (this.crs === 'EPSG:4326') {
-        // EPSG:4326 datasets: use fragment shader reprojection
+        // Fallback EPSG:4326 path: use fragment shader reprojection.
         // Mesh is in Mercator space, fragment shader inverts Mercator → lat for texture lookup
         const subdivided = createSubdividedQuad(subdivisions)
         region.vertexArr = subdivided.vertexArr
@@ -1636,11 +1635,8 @@ export class UntiledMode implements ZarrMode {
       // Update region's selector version
       region.selectorVersion = fetchSelectorVersion
 
-      // Resample bands to Mercator space if needed (EPSG:4326 or custom projection)
-      // For non-EPSG:3857 datasets: GPU handles reprojection
-      // - Proj4 datasets: adaptive mesh (CRS→4326), GPU projects to Mercator or ECEF
-      // - EPSG:4326 datasets: subdivided quad, GPU reprojects via fragment or ECEF
-      // No CPU resampling needed - mercatorBounds computed in createRegionGeometry
+      // GPU handles reprojection. Source-projected data uses an adaptive mesh
+      // (source CRS → WGS84), then the GPU projects to Mercator or ECEF.
       const needsProj4MercBounds =
         this.proj4def && this.cachedMercatorTransformer
 
@@ -1938,7 +1934,7 @@ export class UntiledMode implements ZarrMode {
     // Calculate what fraction of the world the data covers, accounting for CRS
     let worldFraction: number
     if (this.proj4def && this.cachedMercatorTransformer) {
-      // Custom projection: transform bounds corners to mercator
+      // Source-projected data: transform bounds corners to mercator
       const [minMercX] = this.cachedMercatorTransformer.forward(
         this.xyLimits.xMin,
         this.xyLimits.yMin
@@ -1992,8 +1988,7 @@ export class UntiledMode implements ZarrMode {
 
   render(renderer: ZarrRenderer, context: RenderContext): void {
     const useMapbox = !!context.mapbox
-    // Use wgs84 shader only for proj4 datasets (vertex shader reprojection)
-    // EPSG:4326 uses fragment shader reprojection instead
+    // Use the WGS84 vertex path when the source projection is resolved via proj4.
     const useWgs84 = !!this.proj4def && !!this.cached4326Transformer
 
     // MapLibre globe exposes a projectionTransition value in the shader prelude.
@@ -2019,7 +2014,7 @@ export class UntiledMode implements ZarrMode {
       : hasMaplibreGlobeTransition && ecefEligible
 
     // Flush deferred geometry rebuild once transition completes.
-    // proj4 uses hybrid mesh which is projection-independent, so skip rebuilds.
+    // Source-projected data uses a projection-independent hybrid mesh.
     if (this.pendingGeometryRebuild) {
       if (useWgs84) {
         this.pendingGeometryRebuild = false
@@ -2095,7 +2090,14 @@ export class UntiledMode implements ZarrMode {
       height: region.height,
     }
 
-    // Globe ECEF for EPSG:4326: compute WGS84 bounds on the fly from unclamped lat bounds
+    // Source-projected meshes already carry WGS84 bounds from createHybridMesh.
+    if (useDirectEcef && region.wgs84Bounds) {
+      base.positionSpace = 'wgs84-ecef'
+      base.sampleMode = 'linear'
+      return base
+    }
+
+    // Fallback ECEF path for legacy EPSG:4326 mercator-space geometry.
     if (
       useDirectEcef &&
       this.crs === 'EPSG:4326' &&
@@ -2111,13 +2113,6 @@ export class UntiledMode implements ZarrMode {
       }
       base.positionSpace = 'wgs84-ecef'
       base.sampleMode = 'wgs84-lookup'
-      return base
-    }
-
-    // Globe ECEF for proj4: wgs84Bounds already set by createHybridMesh
-    if (useDirectEcef && region.wgs84Bounds) {
-      base.positionSpace = 'wgs84-ecef'
-      base.sampleMode = 'linear'
       return base
     }
 
@@ -2176,7 +2171,7 @@ export class UntiledMode implements ZarrMode {
     if (this.isGlobeProjection === isGlobe) return
     this.isGlobeProjection = isGlobe
 
-    // proj4 uses hybrid mesh which is projection-independent — no rebuild needed.
+    // Source-projected data uses a projection-independent hybrid mesh.
     if (this.proj4def) return
 
     if (!isGlobe) {
@@ -2543,10 +2538,27 @@ export class UntiledMode implements ZarrMode {
     selector?: Selector,
     options?: QueryOptions
   ): Promise<QueryResult> {
+    const desc = this.zarrStore.describe()
+    const sourceBounds: [number, number, number, number] | null = this.xyLimits
+      ? [
+          this.xyLimits.xMin,
+          this.xyLimits.yMin,
+          this.xyLimits.xMax,
+          this.xyLimits.yMax,
+        ]
+      : null
+    const usesSourceCoordinates = !!this.proj4def && !!sourceBounds
     const emptyResult = (): QueryResult => ({
       [this.variable]: [],
       dimensions: [],
-      coordinates: { lat: [], lon: [] },
+      coordinates: (() => {
+        const { yDim, xDim } = findSpatialDimNames(
+          desc.dimensions,
+          usesSourceCoordinates,
+          desc.dimIndices
+        )
+        return { [yDim]: [], [xDim]: [] }
+      })(),
     })
 
     const activeLevel = this.activeLevel
@@ -2563,21 +2575,12 @@ export class UntiledMode implements ZarrMode {
       ? normalizeSelector(selector)
       : this.selector
 
-    const desc = this.zarrStore.describe()
     const currentLevel = this.levels[level.index]
     const transforms = {
       scaleFactor: currentLevel?.scaleFactor ?? desc.scaleFactor,
       addOffset: currentLevel?.addOffset ?? desc.addOffset,
       fillValue: currentLevel?.fillValue ?? desc.fill_value,
     }
-    const sourceBounds: [number, number, number, number] | null = this.xyLimits
-      ? [
-          this.xyLimits.xMin,
-          this.xyLimits.yMin,
-          this.xyLimits.xMax,
-          this.xyLimits.yMax,
-        ]
-      : null
 
     // Closure for running a single pixel-bounds strip query.
     // Captures request-scoped locals (not instance state) to avoid races
@@ -2643,7 +2646,8 @@ export class UntiledMode implements ZarrMode {
         this.proj4def,
         subsetSourceBounds,
         opts,
-        desc.dimIndices
+        desc.dimIndices,
+        this.cachedWGS84Transformer ?? undefined
       )
     }
 
@@ -2665,30 +2669,27 @@ export class UntiledMode implements ZarrMode {
       return result ?? emptyResult()
     }
 
-    // Proj4: no antimeridian preprocessing, just warn and use original geometry.
-    // Run preprocessQueryGeometry only for the bbox check — it correctly
-    // distinguishes true crossings from explicit-but-non-crossing coords
-    // (e.g., rect(200, 210) canonicalizes to [-160, -150], no crossing).
-    if (this.proj4def) {
-      const { bbox } = preprocessQueryGeometry(geometry)
-      if (bbox.crossesAntimeridian) {
-        if (!this._antimeridianWarnings.has('proj4-crossing')) {
-          this._antimeridianWarnings.add('proj4-crossing')
-          console.warn(
-            'Antimeridian-crossing polygon queries are not supported for proj4 projections; results may be incorrect'
-          )
-        }
-      }
-      return singleFetch(geometry)
-    }
-
-    // Standard CRS: preprocess (normalize, canonicalize, maybe clip)
     const { geometry: processedGeometry, bbox: wrappedBbox } =
       preprocessQueryGeometry(geometry)
 
-    // Non-crossing: use processedGeometry (may be canonicalized, e.g. [200,210] → [-160,-150])
+    const supportsWrappedLongitude =
+      !desc.proj4 && (this.crs === 'EPSG:4326' || this.crs === 'EPSG:3857')
+    const queryGeometry = supportsWrappedLongitude
+      ? processedGeometry
+      : geometry
+
     if (!wrappedBbox.crossesAntimeridian) {
-      return singleFetch(processedGeometry)
+      return singleFetch(queryGeometry)
+    }
+
+    if (!supportsWrappedLongitude) {
+      if (!this._antimeridianWarnings.has('proj4-crossing')) {
+        this._antimeridianWarnings.add('proj4-crossing')
+        console.warn(
+          'Antimeridian-crossing polygon queries are not supported for proj4 projections; results may be incorrect'
+        )
+      }
+      return singleFetch(queryGeometry)
     }
 
     // Crossing: raster extent guard (EPSG:4326 only — 3857 xyLimits are in meters)
@@ -2730,7 +2731,7 @@ export class UntiledMode implements ZarrMode {
 
     const { yDim, xDim } = findSpatialDimNames(
       desc.dimensions,
-      false,
+      usesSourceCoordinates,
       desc.dimIndices
     )
     return mergeQueryResults(westResult, eastResult, this.variable, yDim, xDim)

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -134,7 +134,7 @@ type LevelMeta = {
   // add xyLimits here and store per-region.
 }
 
-type ProjectionKind = 'epsg4326' | 'epsg3857' | 'custom-proj4' | 'unsupported'
+type ProjectionKind = 'epsg4326' | 'epsg3857' | 'custom-proj4'
 
 /** Maximum number of regions to keep in cache (LRU eviction) */
 const MAX_CACHED_REGIONS = 128
@@ -338,12 +338,6 @@ export class UntiledMode implements ZarrMode {
         this.cached4326Transformer = createTransformerTo4326(
           this.proj4def,
           bounds
-        )
-      }
-
-      if (this.projectionKind === 'unsupported') {
-        console.warn(
-          `Unsupported CRS "${this.crs}" without a proj4 definition - rendering may be incorrect. Supported built-ins: EPSG:4326, EPSG:3857`
         )
       }
 
@@ -2600,7 +2594,7 @@ function normalizeBuiltinProjectionDef(
 }
 
 function resolveProjectionKind(
-  crs: string,
+  crs: CRS,
   proj4def: string | null
 ): ProjectionKind {
   const builtinProj4Def = normalizeBuiltinProjectionDef(proj4def)
@@ -2610,22 +2604,15 @@ function resolveProjectionKind(
   if (proj4def?.trim()) {
     return 'custom-proj4'
   }
-  const builtinCrs = normalizeBuiltinProjectionDef(crs)
-  if (builtinCrs) {
-    return builtinCrs === 'EPSG:3857' ? 'epsg3857' : 'epsg4326'
-  }
-  return 'unsupported'
+  return crs === 'EPSG:3857' ? 'epsg3857' : 'epsg4326'
 }
 
-function resolveProjectionDef(
-  crs: string,
-  proj4def: string | null
-): string | null {
+function resolveProjectionDef(crs: CRS, proj4def: string | null): string {
   const builtinProj4Def = normalizeBuiltinProjectionDef(proj4def)
   if (builtinProj4Def) return builtinProj4Def
   const trimmedProj4Def = proj4def?.trim()
   if (trimmedProj4Def) return trimmedProj4Def
-  return normalizeBuiltinProjectionDef(crs)
+  return crs
 }
 
 function longitudeWorldFraction(bounds: {

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -2354,42 +2354,6 @@ export class UntiledMode implements ZarrMode {
   }
 
   /**
-   * Compute subset bounds from pixel bounds against the full mercator bounds.
-   */
-  private computeSubsetBounds(
-    pixelBounds: PixelRect,
-    level: QueryLevelSnapshot
-  ): MercatorBounds {
-    const { minX, maxX, minY, maxY } = pixelBounds
-    const xRange = this.mercatorBounds!.x1 - this.mercatorBounds!.x0
-    const yRange = this.mercatorBounds!.y1 - this.mercatorBounds!.y0
-    const subsetBounds: MercatorBounds = {
-      x0: this.mercatorBounds!.x0 + (minX / level.width) * xRange,
-      x1: this.mercatorBounds!.x0 + (maxX / level.width) * xRange,
-      y0: this.mercatorBounds!.y0 + (minY / level.height) * yRange,
-      y1: this.mercatorBounds!.y0 + (maxY / level.height) * yRange,
-    }
-    if (
-      this.mercatorBounds!.latMin !== undefined &&
-      this.mercatorBounds!.latMax !== undefined
-    ) {
-      const latRange = this.mercatorBounds!.latMax - this.mercatorBounds!.latMin
-      if (this.latIsAscending) {
-        subsetBounds.latMin =
-          this.mercatorBounds!.latMin + (minY / level.height) * latRange
-        subsetBounds.latMax =
-          this.mercatorBounds!.latMin + (maxY / level.height) * latRange
-      } else {
-        subsetBounds.latMax =
-          this.mercatorBounds!.latMax - (minY / level.height) * latRange
-        subsetBounds.latMin =
-          this.mercatorBounds!.latMax - (maxY / level.height) * latRange
-      }
-    }
-    return subsetBounds
-  }
-
-  /**
    * Query data for point or region geometries.
    */
   async queryData(
@@ -2455,8 +2419,6 @@ export class UntiledMode implements ZarrMode {
       )
       if (!fetched) return null
 
-      const subsetBounds = this.computeSubsetBounds(pixelBounds, level)
-
       const { minX, minY, maxX, maxY } = pixelBounds
       const [xMin0, yMin0] = pixelToSourceCRS(
         minX,
@@ -2488,34 +2450,29 @@ export class UntiledMode implements ZarrMode {
         fetched.data,
         fetched.width,
         fetched.height,
-        subsetBounds,
-        this.crs ?? 'EPSG:4326',
         desc.dimensions,
         desc.coordinates,
         subsetSourceBounds,
+        this.proj4def!,
         fetched.channels,
         fetched.channelLabels,
         fetched.multiValueDimNames,
         this.latIsAscending,
         transforms,
-        this.proj4def,
         opts,
         desc.dimIndices,
         this.cachedWGS84Transformer ?? undefined
       )
     }
 
-    // Helper for the single-fetch path shared by proj4 and non-crossing cases
     const singleFetch = async (geom: QueryGeometry): Promise<QueryResult> => {
       const pixelBounds = computePixelBoundsFromGeometry(
         geom,
-        this.mercatorBounds!,
+        sourceBounds,
         level.width,
         level.height,
-        this.crs ?? 'EPSG:4326',
+        this.proj4def!,
         this.latIsAscending,
-        this.proj4def,
-        sourceBounds,
         this.cachedWGS84Transformer ?? undefined
       )
       if (!pixelBounds) return emptyResult()
@@ -2562,11 +2519,12 @@ export class UntiledMode implements ZarrMode {
     // Crossing: two-strip fetch
     const spans = wrappedBboxToPixelSpans(
       wrappedBbox,
-      this.mercatorBounds,
+      sourceBounds,
       level.width,
       level.height,
-      this.crs ?? 'EPSG:4326',
-      this.latIsAscending
+      this.proj4def!,
+      this.latIsAscending,
+      this.cachedWGS84Transformer ?? undefined
     )
 
     const westResult = spans.west

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -13,6 +13,7 @@ import {
   WEB_MERCATOR_EXTENT,
   MIN_SUBDIVISIONS,
   MAX_SUBDIVISIONS,
+  MERCATOR_LAT_LIMIT,
 } from './constants'
 import type {
   ZarrMode,
@@ -311,10 +312,25 @@ export class UntiledMode implements ZarrMode {
           this.xyLimits.xMax,
           this.xyLimits.yMax,
         ]
-        this.cachedMercatorTransformer = createTransformer(
-          this.proj4def,
-          bounds
-        )
+        const rawMercatorTransformer = createTransformer(this.proj4def, bounds)
+        // Wrap the source→3857 forward so lat=±90° inputs (common for global
+        // EPSG:4326 rasters) are clamped to ±MERCATOR_LAT_LIMIT before proj4
+        // sees them. Without this, `sampleEdgesToMercatorBounds` silently
+        // drops the polar edge samples and produces too-tight mercator bounds.
+        this.cachedMercatorTransformer =
+          this.crs === 'EPSG:4326'
+            ? {
+                ...rawMercatorTransformer,
+                forward: (x, y) =>
+                  rawMercatorTransformer.forward(
+                    x,
+                    Math.max(
+                      -MERCATOR_LAT_LIMIT,
+                      Math.min(MERCATOR_LAT_LIMIT, y)
+                    )
+                  ),
+              }
+            : rawMercatorTransformer
         this.cachedWGS84Transformer = createWGS84ToSourceTransformer(
           this.proj4def
         )

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -40,6 +40,7 @@ import type {
 } from './types'
 import { ZarrStore } from './zarr-store'
 import {
+  boundsToMercatorNorm,
   type MercatorBounds,
   type XYLimits,
   type Wgs84Bounds,
@@ -221,6 +222,7 @@ export class UntiledMode implements ZarrMode {
   private levels: UntiledLevel[] = []
   private levelMetadataFetched: Set<number> = new Set() // Tracks which levels have had metadata fetched
   private proj4def: string | null = null
+  private isNativeEpsg4326: boolean = true
 
   // Cached transformers for proj4 reprojection (created once, reused everywhere)
   private cachedMercatorTransformer: ReturnType<
@@ -303,6 +305,9 @@ export class UntiledMode implements ZarrMode {
       const proj4jsHasBuiltinDef =
         desc.crs === 'EPSG:4326' || desc.crs === 'EPSG:3857'
       this.proj4def = desc.proj4 ?? (proj4jsHasBuiltinDef ? desc.crs : null)
+      const isBuiltinEpsg4326Def =
+        !desc.proj4 || desc.proj4.trim().toUpperCase() === 'EPSG:4326'
+      this.isNativeEpsg4326 = this.crs === 'EPSG:4326' && isBuiltinEpsg4326Def
 
       // Cache transformers once for reuse (major performance optimization)
       if (this.proj4def && this.xyLimits) {
@@ -317,20 +322,16 @@ export class UntiledMode implements ZarrMode {
         // EPSG:4326 rasters) are clamped to ±MERCATOR_LAT_LIMIT before proj4
         // sees them. Without this, `sampleEdgesToMercatorBounds` silently
         // drops the polar edge samples and produces too-tight mercator bounds.
-        this.cachedMercatorTransformer =
-          this.crs === 'EPSG:4326'
-            ? {
-                ...rawMercatorTransformer,
-                forward: (x, y) =>
-                  rawMercatorTransformer.forward(
-                    x,
-                    Math.max(
-                      -MERCATOR_LAT_LIMIT,
-                      Math.min(MERCATOR_LAT_LIMIT, y)
-                    )
-                  ),
-              }
-            : rawMercatorTransformer
+        this.cachedMercatorTransformer = this.isNativeEpsg4326
+          ? {
+              ...rawMercatorTransformer,
+              forward: (x, y) =>
+                rawMercatorTransformer.forward(
+                  x,
+                  Math.max(-MERCATOR_LAT_LIMIT, Math.min(MERCATOR_LAT_LIMIT, y))
+                ),
+            }
+          : rawMercatorTransformer
         this.cachedWGS84Transformer = createWGS84ToSourceTransformer(
           this.proj4def
         )
@@ -1864,7 +1865,15 @@ export class UntiledMode implements ZarrMode {
 
     // Calculate what fraction of the world the data covers, accounting for CRS
     let worldFraction: number
-    if (this.proj4def && this.cachedMercatorTransformer) {
+    if (this.isNativeEpsg4326) {
+      // proj4's adjust_lon folds inputs outside [-180, 180] back into range
+      // (e.g. forward(360,·)→0, forward(190,·)→-170), which collapses or
+      // distorts the width for 0-360° stores and antimeridian-crossing
+      // extents. Use the source longitude span for level selection because
+      // render bounds may conservatively expand antimeridian-crossing regions
+      // to full-world X for tile intersection.
+      worldFraction = longitudeWorldFraction(this.xyLimits)
+    } else if (this.proj4def && this.cachedMercatorTransformer) {
       // Source-projected data: transform bounds corners to mercator
       const [minMercX] = this.cachedMercatorTransformer.forward(
         this.xyLimits.xMin,
@@ -1883,7 +1892,6 @@ export class UntiledMode implements ZarrMode {
       const fullWorldMeters = 2 * WEB_MERCATOR_EXTENT
       worldFraction = dataWidth / fullWorldMeters
     } else {
-      // EPSG:4326: full world is 360 degrees
       const dataWidth = this.xyLimits.xMax - this.xyLimits.xMin
       worldFraction = dataWidth / 360
     }
@@ -2137,7 +2145,13 @@ export class UntiledMode implements ZarrMode {
    * Compute mercator bounds from proj4 by sampling edge points.
    */
   private computeMercatorBoundsFromProjection(): MercatorBounds {
-    if (!this.proj4def || !this.xyLimits || !this.cachedMercatorTransformer) {
+    if (!this.xyLimits) {
+      return { x0: 0, y0: 0, x1: 1, y1: 1 }
+    }
+    if (this.isNativeEpsg4326) {
+      return boundsToMercatorNorm(this.xyLimits, 'EPSG:4326')
+    }
+    if (!this.proj4def || !this.cachedMercatorTransformer) {
       return { x0: 0, y0: 0, x1: 1, y1: 1 }
     }
     const result = sampleEdgesToMercatorBounds(
@@ -2163,6 +2177,9 @@ export class UntiledMode implements ZarrMode {
     yMin: number
     yMax: number
   }): MercatorBounds {
+    if (this.isNativeEpsg4326) {
+      return boundsToMercatorNorm(bounds, 'EPSG:4326')
+    }
     if (!this.proj4def || !this.cachedMercatorTransformer) {
       return { x0: 0, y0: 0, x1: 1, y1: 1 }
     }
@@ -2560,6 +2577,21 @@ export class UntiledMode implements ZarrMode {
     const { yDim, xDim } = findSpatialDimNames(desc.dimensions, desc.dimIndices)
     return mergeQueryResults(westResult, eastResult, this.variable, yDim, xDim)
   }
+}
+
+function longitudeWorldFraction(bounds: {
+  xMin: number
+  xMax: number
+}): number {
+  const rawSpan = bounds.xMax - bounds.xMin
+  if (!Number.isFinite(rawSpan) || rawSpan === 0) {
+    return 1
+  }
+  if (Math.abs(rawSpan) >= 360) {
+    return 1
+  }
+  const span = rawSpan > 0 ? rawSpan : rawSpan + 360
+  return Math.max(span / 360, Number.EPSILON)
 }
 
 /**

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -134,6 +134,8 @@ type LevelMeta = {
   // add xyLimits here and store per-region.
 }
 
+type ProjectionKind = 'epsg4326' | 'epsg3857' | 'custom-proj4' | 'unsupported'
+
 /** Maximum number of regions to keep in cache (LRU eviction) */
 const MAX_CACHED_REGIONS = 128
 /** Snapshot of level state captured at fetch start to prevent race conditions */
@@ -221,8 +223,9 @@ export class UntiledMode implements ZarrMode {
   // Multi-level support
   private levels: UntiledLevel[] = []
   private levelMetadataFetched: Set<number> = new Set() // Tracks which levels have had metadata fetched
+  private projectionKind: ProjectionKind = 'epsg4326'
+  // Transformer definition: EPSG code for built-ins, supplied string for custom proj4.
   private proj4def: string | null = null
-  private isNativeEpsg4326: boolean = true
 
   // Cached transformers for proj4 reprojection (created once, reused everywhere)
   private cachedMercatorTransformer: ReturnType<
@@ -298,16 +301,8 @@ export class UntiledMode implements ZarrMode {
       this.crs = desc.crs
       this.xyLimits = desc.xyLimits
       this.latIsAscending = desc.latIsAscending
-      // proj4js ships with EPSG:4326 and EPSG:3857 pre-registered, so we
-      // can pass the EPSG code itself as a proj4 def for those CRSes when
-      // the consumer didn't supply a string. Lets `getVisibleRegions` use
-      // the proj4-aware path uniformly for supported CRSes. (#59)
-      const proj4jsHasBuiltinDef =
-        desc.crs === 'EPSG:4326' || desc.crs === 'EPSG:3857'
-      this.proj4def = desc.proj4 ?? (proj4jsHasBuiltinDef ? desc.crs : null)
-      const isBuiltinEpsg4326Def =
-        !desc.proj4 || desc.proj4.trim().toUpperCase() === 'EPSG:4326'
-      this.isNativeEpsg4326 = this.crs === 'EPSG:4326' && isBuiltinEpsg4326Def
+      this.projectionKind = resolveProjectionKind(desc.crs, desc.proj4)
+      this.proj4def = resolveProjectionDef(desc.crs, desc.proj4)
 
       // Cache transformers once for reuse (major performance optimization)
       if (this.proj4def && this.xyLimits) {
@@ -322,16 +317,20 @@ export class UntiledMode implements ZarrMode {
         // EPSG:4326 rasters) are clamped to ±MERCATOR_LAT_LIMIT before proj4
         // sees them. Without this, `sampleEdgesToMercatorBounds` silently
         // drops the polar edge samples and produces too-tight mercator bounds.
-        this.cachedMercatorTransformer = this.isNativeEpsg4326
-          ? {
-              ...rawMercatorTransformer,
-              forward: (x, y) =>
-                rawMercatorTransformer.forward(
-                  x,
-                  Math.max(-MERCATOR_LAT_LIMIT, Math.min(MERCATOR_LAT_LIMIT, y))
-                ),
-            }
-          : rawMercatorTransformer
+        this.cachedMercatorTransformer =
+          this.projectionKind === 'epsg4326'
+            ? {
+                ...rawMercatorTransformer,
+                forward: (x, y) =>
+                  rawMercatorTransformer.forward(
+                    x,
+                    Math.max(
+                      -MERCATOR_LAT_LIMIT,
+                      Math.min(MERCATOR_LAT_LIMIT, y)
+                    )
+                  ),
+              }
+            : rawMercatorTransformer
         this.cachedWGS84Transformer = createWGS84ToSourceTransformer(
           this.proj4def
         )
@@ -342,9 +341,9 @@ export class UntiledMode implements ZarrMode {
         )
       }
 
-      if (this.crs !== 'EPSG:4326' && this.crs !== 'EPSG:3857') {
+      if (this.projectionKind === 'unsupported') {
         console.warn(
-          `Unsupported CRS "${this.crs}" - rendering may be incorrect. Supported: EPSG:4326, EPSG:3857`
+          `Unsupported CRS "${this.crs}" without a proj4 definition - rendering may be incorrect. Supported built-ins: EPSG:4326, EPSG:3857`
         )
       }
 
@@ -1865,7 +1864,7 @@ export class UntiledMode implements ZarrMode {
 
     // Calculate what fraction of the world the data covers, accounting for CRS
     let worldFraction: number
-    if (this.isNativeEpsg4326) {
+    if (this.projectionKind === 'epsg4326') {
       // proj4's adjust_lon folds inputs outside [-180, 180] back into range
       // (e.g. forward(360,·)→0, forward(190,·)→-170), which collapses or
       // distorts the width for 0-360° stores and antimeridian-crossing
@@ -1873,6 +1872,11 @@ export class UntiledMode implements ZarrMode {
       // render bounds may conservatively expand antimeridian-crossing regions
       // to full-world X for tile intersection.
       worldFraction = longitudeWorldFraction(this.xyLimits)
+    } else if (this.projectionKind === 'epsg3857') {
+      // Web Mercator: full world is ~40,075,016 meters
+      const dataWidth = this.xyLimits.xMax - this.xyLimits.xMin
+      const fullWorldMeters = 2 * WEB_MERCATOR_EXTENT
+      worldFraction = dataWidth / fullWorldMeters
     } else if (this.proj4def && this.cachedMercatorTransformer) {
       // Source-projected data: transform bounds corners to mercator
       const [minMercX] = this.cachedMercatorTransformer.forward(
@@ -1886,11 +1890,6 @@ export class UntiledMode implements ZarrMode {
       const dataWidthMeters = Math.abs(maxMercX - minMercX)
       const fullWorldMeters = 2 * WEB_MERCATOR_EXTENT
       worldFraction = dataWidthMeters / fullWorldMeters
-    } else if (this.crs === 'EPSG:3857') {
-      // Web Mercator: full world is ~40,075,016 meters
-      const dataWidth = this.xyLimits.xMax - this.xyLimits.xMin
-      const fullWorldMeters = 2 * WEB_MERCATOR_EXTENT
-      worldFraction = dataWidth / fullWorldMeters
     } else {
       const dataWidth = this.xyLimits.xMax - this.xyLimits.xMin
       worldFraction = dataWidth / 360
@@ -2148,8 +2147,11 @@ export class UntiledMode implements ZarrMode {
     if (!this.xyLimits) {
       return { x0: 0, y0: 0, x1: 1, y1: 1 }
     }
-    if (this.isNativeEpsg4326) {
+    if (this.projectionKind === 'epsg4326') {
       return boundsToMercatorNorm(this.xyLimits, 'EPSG:4326')
+    }
+    if (this.projectionKind === 'epsg3857') {
+      return boundsToMercatorNorm(this.xyLimits, 'EPSG:3857')
     }
     if (!this.proj4def || !this.cachedMercatorTransformer) {
       return { x0: 0, y0: 0, x1: 1, y1: 1 }
@@ -2177,8 +2179,11 @@ export class UntiledMode implements ZarrMode {
     yMin: number
     yMax: number
   }): MercatorBounds {
-    if (this.isNativeEpsg4326) {
+    if (this.projectionKind === 'epsg4326') {
       return boundsToMercatorNorm(bounds, 'EPSG:4326')
+    }
+    if (this.projectionKind === 'epsg3857') {
+      return boundsToMercatorNorm(bounds, 'EPSG:3857')
     }
     if (!this.proj4def || !this.cachedMercatorTransformer) {
       return { x0: 0, y0: 0, x1: 1, y1: 1 }
@@ -2417,6 +2422,10 @@ export class UntiledMode implements ZarrMode {
     if (!this.mercatorBounds || !activeLevel || !sourceBounds) {
       return emptyResult()
     }
+    const projectionDef = this.proj4def
+    if (!projectionDef) {
+      return emptyResult()
+    }
 
     const level: QueryLevelSnapshot = {
       index: activeLevel.index,
@@ -2486,7 +2495,7 @@ export class UntiledMode implements ZarrMode {
         desc.dimensions,
         desc.coordinates,
         subsetSourceBounds,
-        this.proj4def!,
+        projectionDef,
         fetched.channels,
         fetched.channelLabels,
         fetched.multiValueDimNames,
@@ -2504,7 +2513,7 @@ export class UntiledMode implements ZarrMode {
         sourceBounds,
         level.width,
         level.height,
-        this.proj4def!,
+        projectionDef,
         this.latIsAscending,
         this.cachedWGS84Transformer ?? undefined
       )
@@ -2517,7 +2526,7 @@ export class UntiledMode implements ZarrMode {
       preprocessQueryGeometry(geometry)
 
     const supportsWrappedLongitude =
-      !desc.proj4 && (this.crs === 'EPSG:4326' || this.crs === 'EPSG:3857')
+      this.projectionKind === 'epsg4326' || this.projectionKind === 'epsg3857'
     const queryGeometry = supportsWrappedLongitude
       ? processedGeometry
       : geometry
@@ -2538,7 +2547,8 @@ export class UntiledMode implements ZarrMode {
 
     // Crossing: raster extent guard (EPSG:4326 only — 3857 xyLimits are in meters)
     if (
-      rasterExtentCrossesAntimeridian(this.crs ?? 'EPSG:4326', this.xyLimits)
+      this.projectionKind === 'epsg4326' &&
+      rasterExtentCrossesAntimeridian('EPSG:4326', this.xyLimits)
     ) {
       if (!this._antimeridianWarnings.has('raster-extent-crossing')) {
         this._antimeridianWarnings.add('raster-extent-crossing')
@@ -2555,7 +2565,7 @@ export class UntiledMode implements ZarrMode {
       sourceBounds,
       level.width,
       level.height,
-      this.proj4def!,
+      projectionDef,
       this.latIsAscending,
       this.cachedWGS84Transformer ?? undefined
     )
@@ -2577,6 +2587,45 @@ export class UntiledMode implements ZarrMode {
     const { yDim, xDim } = findSpatialDimNames(desc.dimensions, desc.dimIndices)
     return mergeQueryResults(westResult, eastResult, this.variable, yDim, xDim)
   }
+}
+
+function normalizeBuiltinProjectionDef(
+  def: string | null | undefined
+): CRS | null {
+  if (!def) return null
+  const normalized = def.trim().toUpperCase()
+  return normalized === 'EPSG:4326' || normalized === 'EPSG:3857'
+    ? normalized
+    : null
+}
+
+function resolveProjectionKind(
+  crs: string,
+  proj4def: string | null
+): ProjectionKind {
+  const builtinProj4Def = normalizeBuiltinProjectionDef(proj4def)
+  if (builtinProj4Def) {
+    return builtinProj4Def === 'EPSG:3857' ? 'epsg3857' : 'epsg4326'
+  }
+  if (proj4def?.trim()) {
+    return 'custom-proj4'
+  }
+  const builtinCrs = normalizeBuiltinProjectionDef(crs)
+  if (builtinCrs) {
+    return builtinCrs === 'EPSG:3857' ? 'epsg3857' : 'epsg4326'
+  }
+  return 'unsupported'
+}
+
+function resolveProjectionDef(
+  crs: string,
+  proj4def: string | null
+): string | null {
+  const builtinProj4Def = normalizeBuiltinProjectionDef(proj4def)
+  if (builtinProj4Def) return builtinProj4Def
+  const trimmedProj4Def = proj4def?.trim()
+  if (trimmedProj4Def) return trimmedProj4Def
+  return normalizeBuiltinProjectionDef(crs)
 }
 
 function longitudeWorldFraction(bounds: {

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -33,6 +33,7 @@ import type {
   NormalizedSelector,
   Selector,
   CRS,
+  Bounds,
   DimIndicesProps,
   UntiledLevel,
 } from './types'
@@ -2405,10 +2406,8 @@ export class UntiledMode implements ZarrMode {
           this.xyLimits.yMax,
         ]
       : null
-    const usesSourceCoordinates = !!this.proj4def && !!sourceBounds
     const { yDim: emptyYDim, xDim: emptyXDim } = findSpatialDimNames(
       desc.dimensions,
-      usesSourceCoordinates,
       desc.dimIndices
     )
     const emptyResult = (): QueryResult => ({
@@ -2418,7 +2417,9 @@ export class UntiledMode implements ZarrMode {
     })
 
     const activeLevel = this.activeLevel
-    if (!this.mercatorBounds || !activeLevel) return emptyResult()
+    if (!this.mercatorBounds || !activeLevel || !sourceBounds) {
+      return emptyResult()
+    }
 
     const level: QueryLevelSnapshot = {
       index: activeLevel.index,
@@ -2456,32 +2457,29 @@ export class UntiledMode implements ZarrMode {
 
       const subsetBounds = this.computeSubsetBounds(pixelBounds, level)
 
-      let subsetSourceBounds: [number, number, number, number] | null = null
-      if (this.proj4def && sourceBounds) {
-        const { minX, minY, maxX, maxY } = pixelBounds
-        const [xMin, yMin] = pixelToSourceCRS(
-          minX,
-          minY,
-          sourceBounds,
-          level.width,
-          level.height,
-          this.latIsAscending
-        )
-        const [xMax, yMax] = pixelToSourceCRS(
-          maxX,
-          maxY,
-          sourceBounds,
-          level.width,
-          level.height,
-          this.latIsAscending
-        )
-        subsetSourceBounds = [
-          Math.min(xMin, xMax),
-          Math.min(yMin, yMax),
-          Math.max(xMin, xMax),
-          Math.max(yMin, yMax),
-        ]
-      }
+      const { minX, minY, maxX, maxY } = pixelBounds
+      const [xMin0, yMin0] = pixelToSourceCRS(
+        minX,
+        minY,
+        sourceBounds,
+        level.width,
+        level.height,
+        this.latIsAscending
+      )
+      const [xMax0, yMax0] = pixelToSourceCRS(
+        maxX,
+        maxY,
+        sourceBounds,
+        level.width,
+        level.height,
+        this.latIsAscending
+      )
+      const subsetSourceBounds: Bounds = [
+        Math.min(xMin0, xMax0),
+        Math.min(yMin0, yMax0),
+        Math.max(xMin0, xMax0),
+        Math.max(yMin0, yMax0),
+      ]
 
       return queryRegionUntiled(
         this.variable,
@@ -2494,13 +2492,13 @@ export class UntiledMode implements ZarrMode {
         this.crs ?? 'EPSG:4326',
         desc.dimensions,
         desc.coordinates,
+        subsetSourceBounds,
         fetched.channels,
         fetched.channelLabels,
         fetched.multiValueDimNames,
         this.latIsAscending,
         transforms,
         this.proj4def,
-        subsetSourceBounds,
         opts,
         desc.dimIndices,
         this.cachedWGS84Transformer ?? undefined
@@ -2585,11 +2583,7 @@ export class UntiledMode implements ZarrMode {
     if (!westResult && !eastResult) return emptyResult()
     if (!westResult || !eastResult) return (westResult ?? eastResult)!
 
-    const { yDim, xDim } = findSpatialDimNames(
-      desc.dimensions,
-      usesSourceCoordinates,
-      desc.dimIndices
-    )
+    const { yDim, xDim } = findSpatialDimNames(desc.dimensions, desc.dimIndices)
     return mergeQueryResults(westResult, eastResult, this.variable, yDim, xDim)
   }
 }

--- a/src/zarr-mode.ts
+++ b/src/zarr-mode.ts
@@ -62,7 +62,7 @@ export interface RegionRenderState {
   bandTextures?: Map<string, WebGLTexture>
   bandTexturesUploaded?: Set<string>
   bandTexturesConfigured?: Set<string>
-  /** Index buffer for adaptive mesh (proj4 datasets) */
+  /** Index buffer for adaptive source-projected meshes */
   indexBuffer?: WebGLBuffer
   /** Number of vertices/indices to draw */
   vertexCount?: number

--- a/src/zarr-utils.ts
+++ b/src/zarr-utils.ts
@@ -68,6 +68,19 @@ export function identifyDimensionIndices(
   spatialDimensions?: SpatialDimensions,
   coordinates?: CoordinatesMap
 ): DimIndicesProps {
+  // Validate explicit overrides
+  const lowerDimNames = dimNames.map((d) => d.toLowerCase())
+  for (const axis of ['lat', 'lon'] as const) {
+    const requested = spatialDimensions?.[axis]
+    if (requested && !lowerDimNames.includes(requested.toLowerCase())) {
+      throw new Error(
+        `spatialDimensions.${axis} = '${requested}' does not match any store dimension. Available: [${dimNames.join(
+          ', '
+        )}]`
+      )
+    }
+  }
+
   const aliases: Record<'lat' | 'lon', string[]> = {
     lat: [...SPATIAL_DIMENSION_ALIASES.lat],
     lon: [...SPATIAL_DIMENSION_ALIASES.lon],


### PR DESCRIPTION
Follow-on to #60. routes all CRS through the shared mesh reprojection path.

- Fix query output for source-projected / built-in CRS data
- Keep point queries on a fast path
- Document that query result axes follow the store's spatial dimension names
- Remove the old untiled fragment shader path now that supported CRS data uses the shared mesh path