### PR TITLE
fix: re-normalize cached tiles when setClim moves orders of magnitude off the locked data scale

### DIFF
--- a/src/tiled-mode.ts
+++ b/src/tiled-mode.ts
@@ -374,6 +374,17 @@ export class TiledMode implements ZarrMode {
     this.invalidate()
   }
 
+  setDataScale(scale: number): void {
+    if (scale === this.fixedDataScale) return
+    this.fixedDataScale = scale
+    if (this.tileCache) {
+      this.tileCache.setDataScale(scale)
+      this.selectorVersion++
+      this.tileCache.invalidateAll(this.selectorVersion)
+    }
+    this.invalidate()
+  }
+
   private updateGeometryForProjection(isGlobe: boolean) {
     // Subdivisions are only needed for globe projections (sphere curvature)
     // EPSG:4326 in Mercator view uses fragment shader reprojection (per-pixel)

--- a/src/tiles.ts
+++ b/src/tiles.ts
@@ -593,6 +593,24 @@ export class Tiles {
     }
   }
 
+  /** Adopt a new texture-normalization scale for subsequent tile loads. */
+  setDataScale(scale: number): void {
+    this.fixedDataScale = scale
+  }
+
+  /**
+   * Mark every cached tile stale (e.g. after a data-scale change — unlike a
+   * selector change the selector hash stays the same, so this must cover
+   * off-screen tiles too). `updateTiles` refetches via the decoded-chunk
+   * cache and re-normalizes with the current fixedDataScale.
+   */
+  invalidateAll(version: number): void {
+    for (const tile of this.tiles.values()) {
+      tile.selectorHash = null
+      tile.selectorVersion = version
+    }
+  }
+
   async fetchTile(
     tileTuple: TileTuple,
     selectorHash: string,

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -2242,6 +2242,19 @@ export class UntiledMode implements ZarrMode {
     this.invalidate()
   }
 
+  /**
+   * Adopt a new texture-normalization scale. Bumping selectorVersion marks
+   * every cached region stale (updateVisibleRegions refetches regions whose
+   * selectorVersion doesn't match), so texture data is re-normalized.
+   */
+  setDataScale(scale: number): void {
+    if (scale === this.fixedDataScale) return
+    this.fixedDataScale = scale
+    this.selectorVersion++
+    this.lastViewportHash = ''
+    this.invalidate()
+  }
+
   private emitLoadingState(): void {
     emitLoadingStateUtil(this.loadingManager)
   }

--- a/src/zarr-layer.ts
+++ b/src/zarr-layer.ts
@@ -55,6 +55,13 @@ type MapboxInternals = {
   }
 }
 
+/** Scale-mismatch ratio beyond which a locked fixedDataScale is re-derived
+ *  from the clim and cached tiles are re-normalized. Conservative: float32
+ *  texture data only truly degrades several more orders of magnitude out,
+ *  but refetches go through the decoded-chunk cache so an eager threshold
+ *  costs little. */
+const DATA_SCALE_REFRESH_RATIO = 1e6
+
 /** Extract Mapbox's internal expandedFarZ projection matrix and worldSize.
  *  Falls back per-field: transform may exist without the expanded matrix,
  *  while painter.transform carries it (or vice versa across Mapbox versions). */
@@ -386,9 +393,23 @@ export class ZarrLayer {
 
   setClim(clim: [number, number]) {
     this.clim = clim
+    const nextScale = Math.max(Math.abs(clim[0]), Math.abs(clim[1]), 1)
     // Allow fixedDataScale to update until mode captures it
     if (!this.dataScaleLocked) {
-      this.fixedDataScale = Math.max(Math.abs(clim[0]), Math.abs(clim[1]), 1)
+      this.fixedDataScale = nextScale
+    } else if (
+      nextScale * DATA_SCALE_REFRESH_RATIO < this.fixedDataScale ||
+      this.fixedDataScale * DATA_SCALE_REFRESH_RATIO < nextScale
+    ) {
+      // Texture data is normalized by fixedDataScale at upload. When the
+      // locked scale is orders of magnitude off the new clim (e.g. the layer
+      // was created with a dtype-range clim like ±3.4e38 before the caller
+      // knew the data range), normalized values underflow float32 and the
+      // data can never render correctly again. Adopt the new scale and
+      // refetch cached tiles through the decoded-chunk cache so textures
+      // are re-normalized.
+      this.fixedDataScale = nextScale
+      this.mode?.setDataScale(nextScale)
     }
     this.invalidate()
   }

--- a/src/zarr-mode.ts
+++ b/src/zarr-mode.ts
@@ -84,6 +84,11 @@ export interface ZarrMode {
   ): boolean
   dispose(gl: WebGL2RenderingContext | WebGLRenderingContext): void
   setSelector(selector: NormalizedSelector): Promise<void>
+  /**
+   * Adopt a new texture-normalization scale and re-normalize cached data
+   * (by marking it stale so it refetches via the decoded-chunk cache).
+   */
+  setDataScale(scale: number): void
   onProjectionChange(isGlobe: boolean): void
   setLoadingCallback(callback: LoadingStateCallback | undefined): void
   getCRS(): CRS


### PR DESCRIPTION
## Problem

`fixedDataScale` is derived from the clim at construction (`max(|clim[0]|, |clim[1]|, 1)`), baked into every texture upload (`normalizeDataForTexture` divides by it), and locked once the mode initializes. If a layer is created with a clim far from the data's magnitude — e.g. a host app that doesn't yet know the data range and passes a float32 dtype-range clim of ±3.4e38 — small data values are normalized into the float32 subnormal range and flushed to zero (in storage for very small values, and on most GPUs at sample time for the rest).

`setClim()` only updates the uniform, so once this happens **no subsequent clim change can ever produce a correct render**; the layer has to be recreated. We hit this in production with soil-moisture data (values 0.002–0.05): the layer rendered blank, and editing the color limits to the correct range did nothing until a full page refresh.

## Fix

When `setClim` is called with the scale locked and the clim implies a scale ≥1e6× away from the locked one, re-derive `fixedDataScale` and re-normalize via a new `ZarrMode.setDataScale(scale)`:

- **TiledMode**: updates the `Tiles` cache scale, bumps `selectorVersion`, and invalidates **all** cached tiles via a new `Tiles.invalidateAll` (the selector hash doesn't change on a scale change, so `invalidateSelector`'s visible-only sweep would leave stale off-screen tiles). Refetches go through the decoded-chunk cache, so this is cheap.
- **UntiledMode**: bumps `selectorVersion` and resets the viewport hash — the existing region staleness check (`region.selectorVersion !== this.selectorVersion`) handles the refetch.

In-flight fetches are safe: normalization reads the live scale when the fetch completes, and the existing version guards discard stale commits. Ordinary clim edits (within the 1e6 ratio) keep the current no-refetch behavior.

The threshold is conservative — float32 only truly degrades much further out — but refetching from the decoded-chunk cache is cheap enough that an eager threshold seemed preferable to reasoning about exactly where precision dies.

## Testing

`npm run typecheck` and `npm run build` pass. Downstream (wherobots-gl) we applied the same change as a patch to the 0.5.0 dist and validated it with a browser e2e test: a store with ~1e-8 values created at clim ±3.4e38 renders blank; after `setClim([1e-8, 1e-7])` the data renders correctly with this fix and stays blank without it. Happy to adapt anything about the approach (e.g. moving the threshold to a constant elsewhere, or making it configurable).