### PR TITLE
fix: match PROJ null-datum semantics for CRS definitions with no declared datum

### DIFF
--- a/src/projection-utils.ts
+++ b/src/projection-utils.ts
@@ -52,9 +52,16 @@ function formatProj4Error(proj4def: string, err: unknown): string {
  *
  * Registering the definition under itself lets the proj4(def, ...) calls in
  * the factories below pick up the mutated datumCode; 'none' selects proj4js's
- * PJD_NODATUM path, which skips the geocentric round-trip. Definitions that
- * name a real datum (e.g. NAD83) or carry explicit transform parameters are
- * left untouched.
+ * PJD_NODATUM path, which skips the geocentric round-trip.
+ *
+ * The trigger is the absence of a datum transform, not the datum's *name*: an
+ * unknown datum carries no datum_params/nadgrids whatever it's called (GDAL
+ * names HRRR's sphere datum "unknown_based_on_a_sphere_with_radius_6371229_m",
+ * not "unknown"). proj4js resolves a known datum's params from its internal
+ * table at instantiation rather than at defs() time, so instantiate once
+ * before inspecting — otherwise a real datum (NAD83, …) would look paramless
+ * and be wrongly rewritten. Known datums and explicit towgs84/nadgrids keep
+ * their params and are left untouched; WGS84 is already the target.
  */
 function applyNullDatumSemantics(proj4def: string): void {
   try {
@@ -62,9 +69,11 @@ function applyNullDatumSemantics(proj4def: string): void {
     const def = proj4.defs(proj4def) as
       | { datumCode?: string; datum_params?: unknown; nadgrids?: unknown }
       | undefined
-    if (!def || def.datum_params || def.nadgrids) return
-    const code = (def.datumCode ?? '').toLowerCase()
-    if (code === '' || code === 'unknown') def.datumCode = 'none'
+    if (!def) return
+    proj4(proj4def) // resolve a named datum's params from proj4js's table
+    if (def.datum_params || def.nadgrids) return
+    if ((def.datumCode ?? '').toLowerCase() === 'wgs84') return
+    def.datumCode = 'none'
   } catch {
     // Unparseable def — let the factories' own error handling report it.
   }

--- a/src/projection-utils.ts
+++ b/src/projection-utils.ts
@@ -38,6 +38,39 @@ function formatProj4Error(proj4def: string, err: unknown): string {
 }
 
 /**
+ * Match PROJ's null-transformation semantics for CRS definitions that declare
+ * no datum.
+ *
+ * For a CRS with an unknown/unnamed datum and no explicit transform
+ * (towgs84/nadgrids), PROJ — and therefore the GDAL/rioxarray toolchain that
+ * typically computed the dataset's bounds — applies a null ("ballpark")
+ * transformation to WGS84, passing latitude through unchanged. proj4js
+ * instead round-trips geocentrically between the two ellipsoids, which
+ * reinterprets the latitude: for sphere-based NWP grids (e.g. HRRR's Lambert
+ * Conformal Conic on R=6371229) that places the data ~0.18° (~20 km) north
+ * of where every PROJ-based tool puts it.
+ *
+ * Registering the definition under itself lets the proj4(def, ...) calls in
+ * the factories below pick up the mutated datumCode; 'none' selects proj4js's
+ * PJD_NODATUM path, which skips the geocentric round-trip. Definitions that
+ * name a real datum (e.g. NAD83) or carry explicit transform parameters are
+ * left untouched.
+ */
+function applyNullDatumSemantics(proj4def: string): void {
+  try {
+    if (!proj4.defs(proj4def)) proj4.defs(proj4def, proj4def)
+    const def = proj4.defs(proj4def) as
+      | { datumCode?: string; datum_params?: unknown; nadgrids?: unknown }
+      | undefined
+    if (!def || def.datum_params || def.nadgrids) return
+    const code = (def.datumCode ?? '').toLowerCase()
+    if (code === '' || code === 'unknown') def.datumCode = 'none'
+  } catch {
+    // Unparseable def — let the factories' own error handling report it.
+  }
+}
+
+/**
  * A transformer for converting coordinates between source CRS and Web Mercator.
  */
 export interface ProjectionTransformer {
@@ -56,6 +89,7 @@ export function createTransformer(
   proj4def: string,
   bounds: Bounds
 ): ProjectionTransformer {
+  applyNullDatumSemantics(proj4def)
   let converter: proj4.Converter
   try {
     converter = proj4(proj4def, 'EPSG:3857')
@@ -92,6 +126,7 @@ export function createTransformerTo4326(
   proj4def: string,
   bounds: Bounds
 ): Wgs84Transformer {
+  applyNullDatumSemantics(proj4def)
   let converter: proj4.Converter
   try {
     converter = proj4(proj4def, 'EPSG:4326')
@@ -209,6 +244,7 @@ export function createWGS84ToSourceTransformer(proj4def: string): {
   forward: (lon: number, lat: number) => [number, number]
   inverse: (x: number, y: number) => [number, number]
 } {
+  applyNullDatumSemantics(proj4def)
   let converter: proj4.Converter
   try {
     converter = proj4('EPSG:4326', proj4def)


### PR DESCRIPTION
## Problem

For a CRS with an unknown/unnamed datum and no explicit transform (`towgs84`/`nadgrids`), the relationship to WGS84 is formally undefined, and the two ecosystems fill the gap differently:

- **PROJ/pyproj/GDAL** apply a null ("ballpark") transformation — latitude passes through unchanged. This is what computed the bounds in essentially every dataset's metadata, and it's what sphere-based NWP grids mean (the sphere is a computational convention, not a physical datum).
- **proj4js** round-trips geocentrically between the two ellipsoids, reinterpreting the latitude.

For HRRR's native Lambert Conformal Conic (sphere, R=6371229), the difference is `(e²/2)·sin(2φ)` ≈ **0.18° ≈ 20 km northward** at 35.7°N — the layer renders 20 km away from where GDAL, rasterio, or xarray put the same data, and away from its own metadata bounds. Longitude is unaffected, so it presents as a pure vertical offset against EPSG-backed layers.

Reproduction (proj4js vs pyproj, HRRR WKT2 from `CRS.from_proj4('+proj=lcc +lat_0=38.5 +lon_0=-97.5 +lat_1=38.5 +lat_2=38.5 +R=6371229').to_wkt()`):

```
lcc(-1887075, -96967) -> proj4js [-118.550000, 35.862515]
                         pyproj  [-118.550000, 35.680000]   Δ ≈ +20.3 km N
```

## Fix

`applyNullDatumSemantics(proj4def)` in `projection-utils`, called by the three transformer factories: register the definition under itself in `proj4.defs`, and when the parsed def declares no datum (`datumCode` missing or `'unknown'`, no `datum_params`/`nadgrids`), set `datumCode: 'none'` — proj4js's PJD_NODATUM path, which skips the geocentric round-trip and matches PROJ. Since `proj4(def, …)` checks `defs` before parsing, the existing factory calls pick up the mutation with no signature changes.

Definitions naming a real datum (NAD83 etc.) or carrying explicit transform parameters are untouched, as is `+nadgrids=@null` (proj4js already parses that to `'none'` itself).

## Testing

`npm run typecheck` and `npm run build` pass. Downstream (wherobots-gl) we applied the same change as a patch to the 0.5.0 dist with unit tests pinning proj4js output to pyproj ground truth at 6 decimals, plus a browser e2e golden of a rendered HRRR-like LCC store — reverting the change shifts the render and fails at a 34% pixel diff.