### PR TITLE
Fix high zoom distortions

### DIFF
--- a/src/map-utils.ts
+++ b/src/map-utils.ts
@@ -55,21 +55,15 @@ export interface MercatorBounds {
 }
 
 /**
- * Bounds in EPSG:4326 (WGS84) normalized to [0, 1].
- * Used for the two-stage reprojection pipeline.
- * lon: -180 → 0, 180 → 1
- * lat: -90 → 0, 90 → 1
+ * Bounds for the source-projected ("wgs84" inputSpace) mesh path, in normalized
+ * Web Mercator [0, 1] world coords. `y` can exceed [0, 1] for near-polar
+ * vertices. The renderer derives its scale/shift uniforms from these.
  */
 export interface Wgs84Bounds {
-  /** Min longitude normalized [0, 1] where -180 → 0, 180 → 1 */
-  lon0: number
-  /** Min latitude normalized [0, 1] where -90 → 0, 90 → 1 */
-  lat0: number
-  /** Max longitude normalized [0, 1] */
-  lon1: number
-  /** Max latitude normalized [0, 1] */
-  lat1: number
-  /** True if bounds cross the antimeridian (lon0 > lon1 in degrees) */
+  x0: number
+  y0: number
+  x1: number
+  y1: number
   crossesAntimeridian?: boolean
 }
 

--- a/src/map-utils.ts
+++ b/src/map-utils.ts
@@ -64,7 +64,6 @@ export interface Wgs84Bounds {
   y0: number
   x1: number
   y1: number
-  crossesAntimeridian?: boolean
 }
 
 /**

--- a/src/mapbox-tile-renderer.ts
+++ b/src/mapbox-tile-renderer.ts
@@ -267,7 +267,8 @@ function renderRegionsToTile(
       shaderProgram,
       renderable,
       [0], // Globe tiles don't need world wrapping
-      customShaderConfig
+      customShaderConfig,
+      useWgs84 ? tileMatrix : null
     )
     if (!rendered) {
       // renderRegion returns false when band data is missing

--- a/src/mapbox-tile-renderer.ts
+++ b/src/mapbox-tile-renderer.ts
@@ -200,7 +200,7 @@ function renderRegionsToTile(
   // Determine if we're in globe mode (default true for backwards compatibility)
   const isGlobe = context.isGlobe ?? true
 
-  // Check if any untiled region uses WGS84 vertex positions.
+  // Check if any untiled region uses source-projected mesh positions.
   const useWgs84 = regions.some((r) => !!r.wgs84Bounds)
 
   // Always use Mapbox globe shader for tile rendering - it handles both globe and mercator
@@ -232,12 +232,11 @@ function renderRegionsToTile(
 
   let needsMoreData = false
   for (const region of regions) {
-    // Use mercatorBounds for tile intersection — always set and has accurate
-    // per-region extent. (wgs84Bounds may be identity for absolute encoding.)
+    // Use mercatorBounds for tile intersection — always set and has the actual
+    // per-region extent. wgs84Bounds carries the source-projected mesh anchor.
     if (!boundsIntersect(region.mercatorBounds, tileBounds)) continue
 
-    // Source-projected regions use WGS84 vertex positions and may use an
-    // indexed adaptive mesh.
+    // Source-projected regions may use an indexed adaptive mesh.
     const useIndexedMesh = !!region.useIndexedMesh && !!region.indexBuffer
 
     const renderable: RenderableRegion = {
@@ -257,7 +256,7 @@ function renderRegionsToTile(
       // Include indexed mesh fields for adaptive source-projected meshes.
       indexBuffer: useIndexedMesh ? region.indexBuffer : undefined,
       useIndexedMesh: useIndexedMesh,
-      // Include wgs84Bounds for WGS84 vertex positioning.
+      // Include wgs84Bounds for source-projected mesh scale/anchor uniforms.
       wgs84Bounds: region.wgs84Bounds,
       latIsAscending: region.latIsAscending,
     }

--- a/src/mesh-reprojector.ts
+++ b/src/mesh-reprojector.ts
@@ -57,7 +57,7 @@ interface ReprojectorConfig {
 }
 
 interface AdaptiveMeshResult {
-  positions: Float32Array // Normalized 4326 coords [-1,1] for shader
+  positions: Float32Array // Region-local Mercator deltas for shader
   texCoords: Float32Array // UVs for texture sampling
   indices: Uint32Array // Triangle indices
   wgs84Bounds: Wgs84Bounds

--- a/src/mesh-reprojector.ts
+++ b/src/mesh-reprojector.ts
@@ -215,30 +215,60 @@ function createReprojector(config: ReprojectorConfig): RasterReprojector {
 }
 
 /**
- * Encode WGS84 lon/lat positions as absolute normalized coordinates in [-1, 1].
+ * Mercator-normalized [0,1] coords for a lon/lat in degrees.
  *
- * Uses global WGS84 range (lon: [-180,180] → [0,1], lat: [-90,90] → [0,1])
- * then maps [0,1] to [-1,1] for the shader's scale/shift convention.
- *
- * This ensures adjacent regions' shared-edge vertices produce identical Float32
- * values, eliminating seams caused by per-region bounding box normalization.
- * The companion identity wgs84Bounds ({0,0,1,1}) maps [-1,1] back to [0,1]
- * in the shader via vertex * 0.5 + 0.5.
+ * Unlike `latToMercatorNorm` in map-utils (which clamps to ±85.05°, the Web
+ * Mercator *tile* limit), this clamps only just shy of the singular pole to keep
+ * mercY finite (mercY → ±∞ exactly at ±90°). Latitudes between 85° and ~90°
+ * therefore map to mercY values outside [0,1] — which is correct: on a flat map
+ * they project off-screen, and on the globe the ECEF shader inverts mercY back
+ * to the true latitude, preserving polar coverage. The residual gap at the exact
+ * pole is ~0.1 m, well below a pixel at any globe zoom.
  */
-function encodeAbsoluteWgs84(
+const MERC_POLE_LIMIT_RAD = (89.999999 * Math.PI) / 180
+function lonLatToMerc(lon: number, lat: number): [number, number] {
+  const mercX = (lon + 180) / 360
+  const phi = Math.max(
+    -MERC_POLE_LIMIT_RAD,
+    Math.min(MERC_POLE_LIMIT_RAD, (lat * Math.PI) / 180)
+  )
+  const mercY = (1 - Math.log(Math.tan(Math.PI / 4 + phi / 2)) / Math.PI) / 2
+  return [mercX, mercY]
+}
+
+/**
+ * Encode WGS84 lon/lat vertex positions as region-local mercator deltas:
+ * `(mercX − anchor.x) / anchor.halfX`, `(mercY − anchor.y) / anchor.halfY`.
+ *
+ * Each vertex is pre-projected to mercator in Float64 and the region origin is
+ * subtracted BEFORE the Float32 cast, so the stored delta keeps full precision
+ * even where the absolute mercator coordinate would not (the fix for high-zoom
+ * vertex jitter — see VERTEX_TO_WGS84_TO_MERCATOR). Adjacent regions sharing a
+ * corner produce deterministically equal mercator values; even though each uses
+ * its own origin, the shader's per-region Float64 anchor_clip reconstructs the
+ * shared corner to the same sub-pixel clip position → no boundary seams.
+ *
+ * Values may fall outside [-1, 1] for vertices beyond the region's nominal
+ * extent (e.g. polar data past the 85° flat limit); that is intentional and
+ * round-trips exactly through the shader's `vertex * scale + shift`.
+ */
+function encodeMercDelta(
   positions: ArrayLike<number>,
   minLon: number,
-  crossesAntimeridian: boolean
+  crossesAntimeridian: boolean,
+  anchor: { x: number; y: number; halfX: number; halfY: number }
 ): Float32Array {
   const numVerts = positions.length / 2
   const encoded = new Float32Array(numVerts * 2)
+  const safeHalfX = anchor.halfX > 0 ? anchor.halfX : 0.5
+  const safeHalfY = anchor.halfY > 0 ? anchor.halfY : 0.5
 
   for (let i = 0; i < numVerts; i++) {
     let lon = normalizeLon180(positions[i * 2])
     const lat = positions[i * 2 + 1]
 
-    // For antimeridian crossing, shift negative longitudes up by 360
-    // so they're in a continuous range with positive longitudes
+    // For antimeridian crossing, shift negative longitudes up by 360 so they're
+    // in a continuous range with positive longitudes (mercX may exceed 1).
     if (crossesAntimeridian && lon < minLon) {
       lon += 360
     }
@@ -249,12 +279,47 @@ function encodeAbsoluteWgs84(
       continue
     }
 
-    // Absolute WGS84 [0,1] encoded as [-1,1]
-    encoded[i * 2] = ((lon + 180) / 360) * 2 - 1
-    encoded[i * 2 + 1] = ((lat + 90) / 180) * 2 - 1
+    const [mercX, mercY] = lonLatToMerc(lon, lat)
+    encoded[i * 2] = (mercX - anchor.x) / safeHalfX
+    encoded[i * 2 + 1] = (mercY - anchor.y) / safeHalfY
   }
 
   return encoded
+}
+
+/**
+ * Per-region mercator origin: center + half-extent of this mesh's own mercator
+ * extent. Vertices are encoded as deltas from it (encodeMercDelta); the shader's
+ * per-region Float64 anchor_clip keeps shared edges between regions seam-free.
+ */
+function deriveLocalMercAnchor(
+  positions: ArrayLike<number>,
+  minLon: number,
+  crossesAntimeridian: boolean
+): { x: number; y: number; halfX: number; halfY: number } {
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  const n = positions.length / 2
+  for (let i = 0; i < n; i++) {
+    let lon = normalizeLon180(positions[i * 2])
+    const lat = positions[i * 2 + 1]
+    if (crossesAntimeridian && lon < minLon) lon += 360
+    if (!isFinite(lon) || !isFinite(lat)) continue
+    const [mx, my] = lonLatToMerc(lon, lat)
+    minX = Math.min(minX, mx)
+    maxX = Math.max(maxX, mx)
+    minY = Math.min(minY, my)
+    maxY = Math.max(maxY, my)
+  }
+  if (!isFinite(minX)) return { x: 0.5, y: 0.5, halfX: 0.5, halfY: 0.5 }
+  return {
+    x: (minX + maxX) / 2,
+    y: (minY + maxY) / 2,
+    halfX: Math.max((maxX - minX) / 2, 1e-12),
+    halfY: Math.max((maxY - minY) / 2, 1e-12),
+  }
 }
 
 // ============================================================================
@@ -676,16 +741,35 @@ export function createHybridMesh(
     allowUnwrappedLongitudes
   )
 
-  // Encode as absolute WGS84 coordinates so that shared-edge vertices between
-  // adjacent regions produce identical Float32 values (eliminates seams).
-  const positions = encodeAbsoluteWgs84(
+  // Eye-coords path: encode each vertex as a region-local mercator delta
+  // (Float64 → Float32) relative to this region's own mercator origin. A visible
+  // region is near the camera, so the matching per-region anchor_clip computed
+  // in renderRegion stays small in clip space → sub-pixel precision at high zoom
+  // with no pan/zoom jitter. Shared edges between regions stay gapless because
+  // each region's Float64 anchor_clip reproduces the exact world→clip map and
+  // the small magnitudes keep the residual well below a pixel. See
+  // VERTEX_TO_WGS84_TO_MERCATOR and the ECEF transforms.
+  const anchor = deriveLocalMercAnchor(
     splitResult.positions,
     minLon,
     crossesAntimeridian
   )
 
-  // Identity bounds: shader maps [-1,1] → [0,1] via vertex * 0.5 + 0.5
-  const wgs84Bounds: Wgs84Bounds = { lon0: 0, lat0: 0, lon1: 1, lat1: 1 }
+  const positions = encodeMercDelta(
+    splitResult.positions,
+    minLon,
+    crossesAntimeridian,
+    anchor
+  )
+
+  // Mercator anchor +/- half-extent (normalized mercator world coords); the
+  // renderer derives scale/shift from these. See the Wgs84Bounds doc in map-utils.
+  const wgs84Bounds: Wgs84Bounds = {
+    x0: anchor.x - anchor.halfX,
+    y0: anchor.y - anchor.halfY,
+    x1: anchor.x + anchor.halfX,
+    y1: anchor.y + anchor.halfY,
+  }
 
   return {
     positions,

--- a/src/mesh-reprojector.ts
+++ b/src/mesh-reprojector.ts
@@ -246,7 +246,18 @@ function lonLatToMerc(lon: number, lat: number): [number, number] {
  * vertex jitter — see VERTEX_TO_WGS84_TO_MERCATOR). Adjacent regions sharing a
  * corner produce deterministically equal mercator values; even though each uses
  * its own origin, the shader's per-region Float64 anchor_clip reconstructs the
- * shared corner to the same sub-pixel clip position → no boundary seams.
+ * shared corner to the same sub-pixel clip position → sub-pixel boundary
+ * alignment (with a bounded residual; see below).
+ *
+ * Residual seam: the shared corner matches only to Float32 precision after the
+ * delta cast, so a boundary gap of `≈ 6e-8 × chunk_onscreen_px` survives. It is
+ * sub-pixel on any real dataset (512px / sub-meter chunks measure ~0.0002px)
+ * and only becomes visible under pathological over-zoom — e.g. a 2000 km/pixel
+ * custom-CRS (LCC) store at z24 yields ~1px. If a visible seam is ever reported
+ * on real data, the proportionate fix is to subdivide the untiled mesh by
+ * on-screen extent (extend subdivisionsForSpan in untiled-mode.ts) so each
+ * region's rendered size — and thus the gap — stays bounded. The tiled path's
+ * updateGeometryForProjection subdivision does NOT cover this (untiled) path.
  *
  * Values may fall outside [-1, 1] for vertices beyond the region's nominal
  * extent (e.g. polar data past the 85° flat limit); that is intentional and

--- a/src/mesh-reprojector.ts
+++ b/src/mesh-reprojector.ts
@@ -302,11 +302,17 @@ function encodeMercDelta(
  * Per-region mercator origin: center + half-extent of this mesh's own mercator
  * extent. Vertices are encoded as deltas from it (encodeMercDelta); the shader's
  * per-region Float64 anchor_clip keeps shared edges between regions seam-free.
+ *
+ * Only renderable vertices contribute, or culled proj4-singularity vertices left
+ * in `positions` would inflate the half-extent and cost the valid ones Float32
+ * precision. Filter the RAW longitude (before normalizeLon180 wraps it into
+ * range) to match how splitAntimeridianTriangles classifies the same vertices.
  */
 function deriveLocalMercAnchor(
   positions: ArrayLike<number>,
   minLon: number,
-  crossesAntimeridian: boolean
+  crossesAntimeridian: boolean,
+  allowUnwrappedLongitudes: boolean
 ): { x: number; y: number; halfX: number; halfY: number } {
   let minX = Infinity
   let minY = Infinity
@@ -314,10 +320,13 @@ function deriveLocalMercAnchor(
   let maxY = -Infinity
   const n = positions.length / 2
   for (let i = 0; i < n; i++) {
-    let lon = normalizeLon180(positions[i * 2])
+    const rawLon = positions[i * 2]
     const lat = positions[i * 2 + 1]
+    if (!isRenderableWgs84Position(rawLon, lat, allowUnwrappedLongitudes)) {
+      continue
+    }
+    let lon = normalizeLon180(rawLon)
     if (crossesAntimeridian && lon < minLon) lon += 360
-    if (!isFinite(lon) || !isFinite(lat)) continue
     const [mx, my] = lonLatToMerc(lon, lat)
     minX = Math.min(minX, mx)
     maxX = Math.max(maxX, mx)
@@ -763,7 +772,8 @@ export function createHybridMesh(
   const anchor = deriveLocalMercAnchor(
     splitResult.positions,
     minLon,
-    crossesAntimeridian
+    crossesAntimeridian,
+    allowUnwrappedLongitudes
   )
 
   const positions = encodeMercDelta(

--- a/src/renderable-region.ts
+++ b/src/renderable-region.ts
@@ -80,9 +80,9 @@ export function renderRegion(
   // Flat projection matrix for the eye-coords path (source-projected 'wgs84'
   // shader only), at the renderer's native precision (NOT pre-cast to Float32 —
   // see the anchor_clip computation below). When provided, anchor_clip is
-  // computed PER REGION from this region's shift, so the eye origin sits near
-  // the on-screen region (not the off-screen layer center): small clip
-  // magnitudes, no pan/zoom jitter.
+  // computed PER WORLD OFFSET as (shiftX + worldOffset, shiftY), so the eye
+  // origin sits near the on-screen region — and near-camera for wrapped copies,
+  // not the off-screen layer center: small clip magnitudes, no pan/zoom jitter.
   eyeMatrix?: number[] | Float32Array | Float64Array | null
 ): boolean {
   // Resolve position space and sample mode from explicit fields or defaults
@@ -116,16 +116,11 @@ export function renderRegion(
   gl.uniform1f(shaderProgram.shiftXLoc, shiftX)
   gl.uniform1f(shaderProgram.shiftYLoc, shiftY)
 
-  // Eye-coords path (MapLibre flat source-projected shader). Upload u_eye_matrix
-  // once here; u_anchor_clip is computed PER WORLD OFFSET in the draw loop below,
-  // so a wrapped copy's anchor is the wrapped origin (near the camera, small,
-  // Float32-precise) rather than the unwrapped origin plus a canceling offset
-  // term. The anchor is computed from the original matrix at the renderer's
-  // native precision (today MapLibre's is Float32; if a renderer ever supplies
-  // Float64 we don't quantize its translation first). Cast to Float32 only for
-  // the GPU upload; deltaClip uses that uploaded matrix but multiplies the small
-  // region-local delta, so any F32/F64 mismatch is sub-pixel. See
-  // VERTEX_TO_WGS84_TO_MERCATOR.
+  // Eye-coords path for flat source-projected shaders (see
+  // VERTEX_TO_WGS84_TO_MERCATOR). Upload u_eye_matrix once; u_anchor_clip is
+  // computed PER WORLD OFFSET in the draw loop below, so a wrapped copy's anchor
+  // is its near-camera wrapped origin (no large-term cancellation). The anchor is
+  // computed from the original (un-cast) matrix; cast to Float32 only for upload.
   const eyeM = eyeMatrix
   const eyeActive = !!(
     eyeM &&

--- a/src/renderable-region.ts
+++ b/src/renderable-region.ts
@@ -76,7 +76,14 @@ export function renderRegion(
   shaderProgram: ShaderProgram,
   region: RenderableRegion,
   worldOffsets: number[],
-  customShaderConfig?: CustomShaderConfig
+  customShaderConfig?: CustomShaderConfig,
+  // Flat projection matrix for the eye-coords path (source-projected 'wgs84'
+  // shader only), at the renderer's native precision (NOT pre-cast to Float32 —
+  // see the anchor_clip computation below). When provided, anchor_clip is
+  // computed PER REGION from this region's shift, so the eye origin sits near
+  // the on-screen region (not the off-screen layer center): small clip
+  // magnitudes, no pan/zoom jitter.
+  eyeMatrix?: number[] | Float32Array | Float64Array | null
 ): boolean {
   // Resolve position space and sample mode from explicit fields or defaults
   const wgs84Bounds = region.wgs84Bounds ?? null
@@ -97,10 +104,10 @@ export function renderRegion(
   } else {
     // 'wgs84' and 'wgs84-ecef' both use wgs84Bounds for scale/shift
     if (!wgs84Bounds) return false
-    scaleX = (wgs84Bounds.lon1 - wgs84Bounds.lon0) / 2
-    scaleY = (wgs84Bounds.lat1 - wgs84Bounds.lat0) / 2
-    shiftX = (wgs84Bounds.lon0 + wgs84Bounds.lon1) / 2
-    shiftY = (wgs84Bounds.lat0 + wgs84Bounds.lat1) / 2
+    scaleX = (wgs84Bounds.x1 - wgs84Bounds.x0) / 2
+    scaleY = (wgs84Bounds.y1 - wgs84Bounds.y0) / 2
+    shiftX = (wgs84Bounds.x0 + wgs84Bounds.x1) / 2
+    shiftY = (wgs84Bounds.y0 + wgs84Bounds.y1) / 2
   }
 
   gl.uniform1f(shaderProgram.scaleLoc, 0)
@@ -108,6 +115,31 @@ export function renderRegion(
   gl.uniform1f(shaderProgram.scaleYLoc, scaleY)
   gl.uniform1f(shaderProgram.shiftXLoc, shiftX)
   gl.uniform1f(shaderProgram.shiftYLoc, shiftY)
+
+  // Eye-coords path (MapLibre flat source-projected shader). Upload u_eye_matrix
+  // once here; u_anchor_clip is computed PER WORLD OFFSET in the draw loop below,
+  // so a wrapped copy's anchor is the wrapped origin (near the camera, small,
+  // Float32-precise) rather than the unwrapped origin plus a canceling offset
+  // term. The anchor is computed from the original matrix at the renderer's
+  // native precision (today MapLibre's is Float32; if a renderer ever supplies
+  // Float64 we don't quantize its translation first). Cast to Float32 only for
+  // the GPU upload; deltaClip uses that uploaded matrix but multiplies the small
+  // region-local delta, so any F32/F64 mismatch is sub-pixel. See
+  // VERTEX_TO_WGS84_TO_MERCATOR.
+  const eyeM = eyeMatrix
+  const eyeActive = !!(
+    eyeM &&
+    eyeM.length >= 16 &&
+    shaderProgram.eyeMatrixLoc &&
+    shaderProgram.anchorClipLoc
+  )
+  if (eyeActive && eyeM) {
+    gl.uniformMatrix4fv(
+      shaderProgram.eyeMatrixLoc,
+      false,
+      eyeM instanceof Float32Array ? eyeM : new Float32Array(eyeM)
+    )
+  }
 
   // Set texture transform (for parent tile fallback)
   const texScale = region.texScale ?? [1, 1]
@@ -181,6 +213,20 @@ export function renderRegion(
   // Draw for each world offset (map wrapping)
   for (const worldOffset of worldOffsets) {
     gl.uniform1f(shaderProgram.worldXOffsetLoc, worldOffset)
+    if (eyeActive && eyeM) {
+      // u_anchor_clip = M * vec4(shiftX + worldOffset, shiftY, 0, 1), in Float64
+      // then cast by uniform4f. Folding the offset in here (vs. a separate shader
+      // term) keeps a wrapped copy's anchor near the camera — no large-term
+      // cancellation. Column-major: result[i] = m[i]*x + m[4+i]*y + m[12+i].
+      const ax = shiftX + worldOffset
+      gl.uniform4f(
+        shaderProgram.anchorClipLoc,
+        eyeM[0] * ax + eyeM[4] * shiftY + eyeM[12],
+        eyeM[1] * ax + eyeM[5] * shiftY + eyeM[13],
+        eyeM[2] * ax + eyeM[6] * shiftY + eyeM[14],
+        eyeM[3] * ax + eyeM[7] * shiftY + eyeM[15]
+      )
+    }
     if (region.useIndexedMesh && region.indexBuffer) {
       gl.drawElements(gl.TRIANGLES, region.vertexCount, gl.UNSIGNED_INT, 0)
     } else {

--- a/src/shader-program.ts
+++ b/src/shader-program.ts
@@ -26,6 +26,10 @@ export interface ShaderProgram {
   shiftYLoc: WebGLUniformLocation
   worldXOffsetLoc: WebGLUniformLocation
   matrixLoc: WebGLUniformLocation | null
+  // Eye-coords uniforms — only the source-projected flat (wgs84) shader uses
+  // them; other variants drop them so these resolve to null and uploads no-op.
+  eyeMatrixLoc: WebGLUniformLocation | null
+  anchorClipLoc: WebGLUniformLocation | null
   projMatrixLoc: WebGLUniformLocation | null
   fallbackMatrixLoc: WebGLUniformLocation | null
   tileMercatorCoordsLoc: WebGLUniformLocation | null
@@ -214,10 +218,16 @@ export function createShaderProgram(
     shiftXLoc: mustGetUniformLocation(gl, program, 'shift_x'),
     shiftYLoc: mustGetUniformLocation(gl, program, 'shift_y'),
     worldXOffsetLoc: mustGetUniformLocation(gl, program, 'u_worldXOffset'),
-    // MapLibre modes use projectTile instead of matrix
-    matrixLoc: needsMaplibre
-      ? null
-      : mustGetUniformLocation(gl, program, 'matrix'),
+    // MapLibre modes use projectTile instead of matrix. The Mapbox flat
+    // source-projected (wgs84) shader uses u_eye_matrix, not matrix, so the
+    // compiler drops `matrix` there too — use the non-throwing lookup. All
+    // uploads of matrixLoc are null-guarded (see setMatrix4 in
+    // applyProjectionUniforms).
+    matrixLoc: needsMaplibre ? null : gl.getUniformLocation(program, 'matrix'),
+    // Eye-coords uniforms exist only in the source-projected flat (wgs84)
+    // shader; other variants optimize them out, so use the non-throwing lookup.
+    eyeMatrixLoc: gl.getUniformLocation(program, 'u_eye_matrix'),
+    anchorClipLoc: gl.getUniformLocation(program, 'u_anchor_clip'),
     projMatrixLoc: maplibreUniform('u_projection_matrix'),
     fallbackMatrixLoc: maplibreUniform('u_projection_fallback_matrix'),
     tileMercatorCoordsLoc: maplibreUniform('u_projection_tile_mercator_coords'),

--- a/src/shaders.ts
+++ b/src/shaders.ts
@@ -37,9 +37,9 @@ uniform float shift_y;
 uniform float u_worldXOffset;
 // Eye-coords uniforms (source-projected FLAT path only). u_eye_matrix is the
 // flat projection matrix (MapLibre mainMatrix / Mapbox matrix); u_anchor_clip
-// is matrix * vec4(regionOrigin, 0, 1) for THIS region, computed per region per
-// frame in JS Float64 (regionOrigin = the region's shift_x/shift_y). A visible
-// region is near the camera, so anchor_clip is small in clip space:
+// is matrix * vec4(regionOrigin + worldXOffset, 0, 1), computed in JS Float64
+// per region per world offset (regionOrigin = the region's shift_x/shift_y).
+// A visible region is near the camera, so anchor_clip is small in clip space:
 // Float32-exact and jitter-free. Unused by other variants (location null).
 uniform mat4 u_eye_matrix;
 uniform vec4 u_anchor_clip;`
@@ -71,24 +71,22 @@ const VERTEX_TO_MERCATOR = `
 
 /**
  * Source-projected FLAT path, eye-coords (render-relative-to-eye) decomposition.
+ * Canonical explanation — other eye-coords sites reference this block.
  *
- * vertex.xy are region-local MERCATOR deltas (pre-projected in JS Float64, see
- * encodeMercDelta); scale/shift would restore the region-anchored
- * mercator value. Instead of forming an absolute world coord in Float32 and
- * multiplying by the high-zoom matrix (which quantizes to ~4 px of jitter at
- * z≈19), decompose, anchored at this region's near-camera origin:
- *
- *   matrix·vec4(anchor + delta, 0, 1)
- *     ≡ matrix·vec4(anchor, 0, 1)  +  matrix·vec4(delta, 0, 0)
- *     ≡ u_anchor_clip (JS Float64, near origin)  +  deltaClip (small)
- *
- * Both terms are small in clip space, so their Float32 sum keeps sub-pixel
- * precision. The world-wrap offset (+/-1 for wrapped copies near the
- * antimeridian) is folded into u_anchor_clip on the CPU (per world offset, in
- * Float64) rather than added here as a separate matrix term — otherwise the
- * anchor and the offset would be two ~one-world clip values that cancel in
- * Float32 for the wrapped copy. `merc` is reconstructed at low precision ONLY
- * for the fragment varyings.
+ * vertex.xy are region-local MERCATOR deltas (Float64-projected on the CPU, see
+ * encodeMercDelta). Forming an absolute world coord in Float32 and multiplying by
+ * the high-zoom matrix quantizes to ~4 px of jitter at z~19, so instead:
+ *   matrix·(anchor + delta)  ==  u_anchor_clip  +  matrix·(delta, 0, 0)
+ * Both terms are small in clip space, so their Float32 sum stays sub-pixel.
+ * u_anchor_clip = matrix·(regionOrigin + worldXOffset), computed per region per
+ * world offset on the CPU from the matrix at its NATIVE precision (passed
+ * uncast). When the renderer's flat matrix is Float64 (as the MapLibre/Mapbox
+ * flat view-proj matrices are in practice) the anchor is full-precision — which
+ * is what keeps high zoom jitter-free; pre-casting the matrix to Float32 before
+ * this multiply would re-quantize the translation and bring the pan/zoom jitter
+ * back. The wrap offset folds in here so a wrapped antimeridian copy doesn't
+ * cancel two ~one-world clip values. `merc` is reconstructed at low precision
+ * ONLY for the fragment varyings.
  */
 const VERTEX_TO_WGS84_TO_MERCATOR = `
   vec2 mercDelta = vec2(vertex.x * sx, vertex.y * sy);
@@ -302,7 +300,7 @@ export function createVertexShader(options: VertexShaderOptions): string {
 
   // Build helper functions
   // FUNC_MERCATOR_Y_TO_LAT (inverts Mercator Y → latitude) is needed by:
-  //  - regular Mapbox globe (PROJECT_MAPBOX_GLOBE), and
+  //  - regular Mapbox globe (projectMapboxGlobe), and
   //  - both ECEF paths, which now reconstruct latitude from mercator-encoded
   //    vertices to preserve polar coverage.
   let helpers = ''
@@ -329,15 +327,11 @@ export function createVertexShader(options: VertexShaderOptions): string {
   } else if (isDirectEcef) {
     projectionOutput = PROJECT_MAPLIBRE_ECEF
   } else if (inputSpace === 'wgs84' && projection === 'maplibre') {
-    // Eye-coords FLAT path. VERTEX_TO_WGS84_TO_MERCATOR produced
-    // deltaClip (matrix * vec4(mercDelta, 0, 0)); u_anchor_clip is the
-    // JS-precomputed matrix * vec4(regionOrigin + worldOffset, 0, 1). Their
-    // Float32 sum is sub-pixel precise. Skip projectTile so we never form an
-    // absolute world coord in Float32.
-    //
-    // Scoped to MapLibre because MapLibre routes ALL globe transition to the
-    // ECEF path above (this branch is only reached when the map is truly flat,
-    // where mainMatrix is a linear world->clip map and the decomposition holds).
+    // Eye-coords flat output (see VERTEX_TO_WGS84_TO_MERCATOR). Emitted directly
+    // here only for MapLibre: it routes ALL globe transition to the ECEF path
+    // above, so this is reached only when the map is truly flat (a linear
+    // world->clip map). Mapbox can't use the bare output — its non-ECEF program
+    // serves the flat<->globe morph (projectMapboxGlobe).
     projectionOutput = `  gl_Position = u_anchor_clip + deltaClip;`
   } else if (projection === 'maplibre') {
     projectionOutput = PROJECT_MAPLIBRE_GLOBE

--- a/src/shaders.ts
+++ b/src/shaders.ts
@@ -34,7 +34,15 @@ uniform float scale_x;
 uniform float scale_y;
 uniform float shift_x;
 uniform float shift_y;
-uniform float u_worldXOffset;`
+uniform float u_worldXOffset;
+// Eye-coords uniforms (source-projected FLAT path only). u_eye_matrix is the
+// flat projection matrix (MapLibre mainMatrix / Mapbox matrix); u_anchor_clip
+// is matrix * vec4(regionOrigin, 0, 1) for THIS region, computed per region per
+// frame in JS Float64 (regionOrigin = the region's shift_x/shift_y). A visible
+// region is near the camera, so anchor_clip is small in clip space:
+// Float32-exact and jitter-free. Unused by other variants (location null).
+uniform mat4 u_eye_matrix;
+uniform vec4 u_anchor_clip;`
 
 /** Additional uniforms for Mapbox globe projection */
 const UNIFORMS_MAPBOX_GLOBE = `
@@ -61,29 +69,34 @@ const SCALE_HANDLING = `
 const VERTEX_TO_MERCATOR = `
   vec2 merc = vec2(vertex.x * sx + shift_x + u_worldXOffset, -vertex.y * sy + shift_y);`
 
-/** Transform vertex from local space to normalized WGS84, then to Mercator */
+/**
+ * Source-projected FLAT path, eye-coords (render-relative-to-eye) decomposition.
+ *
+ * vertex.xy are region-local MERCATOR deltas (pre-projected in JS Float64, see
+ * encodeMercDelta); scale/shift would restore the region-anchored
+ * mercator value. Instead of forming an absolute world coord in Float32 and
+ * multiplying by the high-zoom matrix (which quantizes to ~4 px of jitter at
+ * z≈19), decompose, anchored at this region's near-camera origin:
+ *
+ *   matrix·vec4(anchor + delta, 0, 1)
+ *     ≡ matrix·vec4(anchor, 0, 1)  +  matrix·vec4(delta, 0, 0)
+ *     ≡ u_anchor_clip (JS Float64, near origin)  +  deltaClip (small)
+ *
+ * Both terms are small in clip space, so their Float32 sum keeps sub-pixel
+ * precision. The world-wrap offset (+/-1 for wrapped copies near the
+ * antimeridian) is folded into u_anchor_clip on the CPU (per world offset, in
+ * Float64) rather than added here as a separate matrix term — otherwise the
+ * anchor and the offset would be two ~one-world clip values that cancel in
+ * Float32 for the wrapped copy. `merc` is reconstructed at low precision ONLY
+ * for the fragment varyings.
+ */
 const VERTEX_TO_WGS84_TO_MERCATOR = `
-  // vertex.xy are in local [-1, 1] space for this region
-  // scale/shift transform to absolute normalized 4326 [0,1] on world
-  float normLon = vertex.x * sx + shift_x + u_worldXOffset;
-  float normLat = vertex.y * sy + shift_y;
-
-  // Convert normalized [0,1] to degrees
-  float lon = normLon * 360.0 - 180.0;
-  float lat = normLat * 180.0 - 90.0;
-
-  // Clamp latitude to Mercator limits to avoid infinity at poles
-  lat = clamp(lat, -MERCATOR_LAT_LIMIT, MERCATOR_LAT_LIMIT);
-
-  // Mercator projection
-  float lambda = radians(lon);
-  float phi = radians(lat);
-  float mercY_raw = log(tan((PI / 2.0 + phi) / 2.0));
-
-  // Normalize mercator output to [0,1]
-  float mercX = (lambda / PI + 1.0) / 2.0;
-  float mercY = (1.0 - mercY_raw / PI) / 2.0;
-  vec2 merc = vec2(mercX, mercY);`
+  vec2 mercDelta = vec2(vertex.x * sx, vertex.y * sy);
+  vec4 deltaClip = u_eye_matrix * vec4(mercDelta, 0.0, 0.0);
+  vec2 merc = vec2(
+    shift_x + mercDelta.x + u_worldXOffset,
+    shift_y + mercDelta.y
+  );`
 
 /** Individual shader constants (composed as needed) */
 const CONST_PI = `const float PI = 3.14159265358979323846;`
@@ -101,12 +114,32 @@ float mercatorYToLatRad(float y) {
 const PROJECT_MAPLIBRE_GLOBE = `
   gl_Position = projectTile(merc);`
 
-/** Mapbox globe projection output (handles tile render vs globe render) */
-const PROJECT_MAPBOX_GLOBE = `
+/**
+ * Mapbox globe projection output (handles tile render vs globe render).
+ *
+ * For source-projected `wgs84` input, the linear flat/tile endpoint uses the
+ * eye-coords sum (u_anchor_clip + deltaClip), which is sub-pixel precise at
+ * high zoom. During the globe morph, keep Mapbox's existing absolute Mercator
+ * path because the ECEF blend is nonlinear and only active at low/mid zoom.
+ */
+const projectMapboxGlobe = (eyeCoords: boolean): string => {
+  const flatClip = eyeCoords
+    ? 'u_anchor_clip + deltaClip'
+    : 'matrix * vec4(merc, 0.0, 1.0)'
+  const mercClip = eyeCoords ? 'matrix * vec4(merc, 0.0, 1.0)' : flatClip
+  const flatEndpoint = eyeCoords
+    ? `
+  } else if (u_globe_transition >= 0.999999) {
+    vec4 flatClip = ${flatClip};
+    flatClip /= flatClip.w;
+    gl_Position = flatClip;`
+    : ''
+  return `
   if (u_tile_render == 1) {
-    gl_Position = matrix * vec4(merc, 0.0, 1.0);
+    gl_Position = ${flatClip};
+${flatEndpoint}
   } else {
-    vec4 mercClip = matrix * vec4(merc, 0.0, 1.0);
+    vec4 mercClip = ${mercClip};
     mercClip /= mercClip.w;
 
     float lonRad = (merc.x - 0.5) * 2.0 * PI;
@@ -123,36 +156,43 @@ const PROJECT_MAPBOX_GLOBE = `
 
     gl_Position = mix(globeClip, mercClip, clamp(u_globe_transition, 0.0, 1.0));
   }`
+}
 
-/** Transform vertex from local space to WGS84 normalized coords, then compute ECEF + Mercator fallback */
+/**
+ * ECEF globe path (MapLibre Y-UP). vertex.xy are layer-anchored MERCATOR deltas;
+ * restore absolute mercator (the globe is only active at low/mid zoom, where
+ * Float32 absolute coords are ample) and invert mercator-Y → latitude. The
+ * inverse gudermannian is defined for all finite mercY, so polar vertices
+ * (mercY outside [0,1]) reconstruct their true latitude → poles preserved.
+ */
 const VERTEX_WGS84_TO_ECEF = `
-  float normLon = vertex.x * sx + shift_x + u_worldXOffset;
-  float normLat = vertex.y * sy + shift_y;
+  float mercX = vertex.x * sx + shift_x + u_worldXOffset;
+  float mercY = vertex.y * sy + shift_y;
 
-  // WGS84 normalized [0,1] to radians
-  float lonRad = (normLon - 0.5) * 2.0 * PI;
-  float latDeg = normLat * 180.0 - 90.0;
-  float latRad = latDeg * PI / 180.0;
+  float lonRad = (mercX - 0.5) * 2.0 * PI;
+  float latRad = mercatorYToLatRad(mercY);
 
   // ECEF unit sphere (MapLibre Y-UP convention)
   float cosLat = cos(latRad);
   vec3 ecef = vec3(sin(lonRad) * cosLat, sin(latRad), cos(lonRad) * cosLat);
 
-  // Clamped Mercator fallback for flat-map transition
-  float clampedLatDeg = clamp(latDeg, -MERCATOR_LAT_LIMIT, MERCATOR_LAT_LIMIT);
-  float clampedLatRad = clampedLatDeg * PI / 180.0;
-  float mercY_raw = log(tan((PI / 2.0 + clampedLatRad) / 2.0));
-  vec2 merc = vec2(normLon, (1.0 - mercY_raw / PI) / 2.0);`
+  // Flat-map fallback for the globe->mercator transition: mercator coords direct.
+  vec2 merc = vec2(mercX, mercY);
 
-/** Transform vertex from local space to WGS84 normalized coords, then compute ECEF (Mapbox Y-DOWN + radius) */
+  // Geographic normalized coords for the wgs84-lookup fragment path.
+  float normLon = mercX;
+  float normLat = latRad / PI + 0.5;`
+
+/**
+ * ECEF globe path (Mapbox Y-DOWN + radius). Same mercator-delta input and
+ * merc→lat inversion as VERTEX_WGS84_TO_ECEF (see there).
+ */
 const VERTEX_WGS84_TO_ECEF_MAPBOX = `
-  float normLon = vertex.x * sx + shift_x + u_worldXOffset;
-  float normLat = vertex.y * sy + shift_y;
+  float mercX = vertex.x * sx + shift_x + u_worldXOffset;
+  float mercY = vertex.y * sy + shift_y;
 
-  // WGS84 normalized [0,1] to radians
-  float lonRad = (normLon - 0.5) * 2.0 * PI;
-  float latDeg = normLat * 180.0 - 90.0;
-  float latRad = latDeg * PI / 180.0;
+  float lonRad = (mercX - 0.5) * 2.0 * PI;
+  float latRad = mercatorYToLatRad(mercY);
 
   // Mapbox ECEF: Y-DOWN with explicit radius
   float cosLat = cos(latRad);
@@ -160,7 +200,11 @@ const VERTEX_WGS84_TO_ECEF_MAPBOX = `
     GLOBE_RADIUS * cosLat * sin(lonRad),
     -GLOBE_RADIUS * sin(latRad),
     GLOBE_RADIUS * cosLat * cos(lonRad)
-  );`
+  );
+
+  // Geographic normalized coords for the wgs84-lookup fragment path.
+  float normLon = mercX;
+  float normLat = latRad / PI + 0.5;`
 
 /** Mapbox ECEF projection output for the direct untiled globe path. */
 const PROJECT_MAPBOX_ECEF = `
@@ -257,10 +301,12 @@ export function createVertexShader(options: VertexShaderOptions): string {
     .join('\n')
 
   // Build helper functions
-  // FUNC_MERCATOR_Y_TO_LAT only needed for regular Mapbox globe (inverts Mercator Y to lat).
-  // Mapbox ECEF gets latitude directly from WGS84 input, so it doesn't need this helper.
+  // FUNC_MERCATOR_Y_TO_LAT (inverts Mercator Y → latitude) is needed by:
+  //  - regular Mapbox globe (PROJECT_MAPBOX_GLOBE), and
+  //  - both ECEF paths, which now reconstruct latitude from mercator-encoded
+  //    vertices to preserve polar coverage.
   let helpers = ''
-  if (projection === 'mapbox' && !isDirectEcef) {
+  if (isDirectEcef || projection === 'mapbox') {
     helpers = FUNC_MERCATOR_Y_TO_LAT
   }
 
@@ -282,10 +328,23 @@ export function createVertexShader(options: VertexShaderOptions): string {
     projectionOutput = PROJECT_MAPBOX_ECEF
   } else if (isDirectEcef) {
     projectionOutput = PROJECT_MAPLIBRE_ECEF
+  } else if (inputSpace === 'wgs84' && projection === 'maplibre') {
+    // Eye-coords FLAT path. VERTEX_TO_WGS84_TO_MERCATOR produced
+    // deltaClip (matrix * vec4(mercDelta, 0, 0)); u_anchor_clip is the
+    // JS-precomputed matrix * vec4(regionOrigin + worldOffset, 0, 1). Their
+    // Float32 sum is sub-pixel precise. Skip projectTile so we never form an
+    // absolute world coord in Float32.
+    //
+    // Scoped to MapLibre because MapLibre routes ALL globe transition to the
+    // ECEF path above (this branch is only reached when the map is truly flat,
+    // where mainMatrix is a linear world->clip map and the decomposition holds).
+    projectionOutput = `  gl_Position = u_anchor_clip + deltaClip;`
   } else if (projection === 'maplibre') {
     projectionOutput = PROJECT_MAPLIBRE_GLOBE
   } else {
-    projectionOutput = PROJECT_MAPBOX_GLOBE
+    // Mapbox flat + globe morph. For the source-projected path, the flat/tile
+    // endpoint uses eye-coords; the globe morph keeps absolute mercator.
+    projectionOutput = projectMapboxGlobe(inputSpace === 'wgs84')
   }
 
   // Set v_wgs84Pos: meaningful for direct ECEF, zero for other paths

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -2035,11 +2035,16 @@ export class UntiledMode implements ZarrMode {
     // Rendering at shifted world offsets on the globe produces duplicate renders.
     const worldOffsets = useDirectEcef ? [0] : context.worldOffsets
 
-    // Resolve the flat projection matrix for the eye-coords path (only the flat
-    // MapLibre wgs84 shader consumes it; the ECEF globe and Mapbox paths ignore
-    // it). MapLibre's flat map is mainMatrix; Mapbox passes its matrix directly.
-    // Pass it through at native precision — renderRegion casts to Float32 for the
-    // GPU upload but keeps full precision for the per-region anchor_clip.
+    // Resolve the flat projection matrix for the source-projected eye-coords
+    // path. MapLibre flat uses mainMatrix; Mapbox flat passes its matrix
+    // directly. ECEF/globe paths ignore these uniforms.
+    // Pass it through UN-CAST (number[] | Float32Array | Float64Array) so
+    // renderRegion computes anchor_clip from the highest-precision matrix
+    // representation available. When the flat matrix is Float64 (as it is in
+    // practice) that full-precision anchor is what keeps high-zoom pan/zoom
+    // jitter-free; do NOT pre-cast to Float32 here (it re-quantizes the
+    // translation and the jitter returns). renderRegion casts to Float32 only
+    // for the GPU upload (which drives the small deltaClip).
     let eyeMatrix: number[] | Float32Array | Float64Array | null = null
     if (useWgs84 && !useDirectEcef) {
       const raw = useMapbox

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -1112,6 +1112,11 @@ export class UntiledMode implements ZarrMode {
       transformer: this.cached4326Transformer,
       latIsAscending: this.latIsAscending,
       allowUnwrappedLongitudes: this.projectionKind === 'epsg4326',
+      // The mesh encodes vertices as deltas from a per-region mercator origin
+      // (deriveLocalMercAnchor); renderRegion uploads a matching per-region
+      // anchor_clip, keeping the eye origin near the on-screen region for
+      // high-zoom precision (no pan/zoom jitter, no seams). See
+      // VERTEX_TO_WGS84_TO_MERCATOR.
     })
     region.vertexArr = meshResult.positions
     region.pixCoordArr = meshResult.texCoords
@@ -2030,12 +2035,28 @@ export class UntiledMode implements ZarrMode {
     // Rendering at shifted world offsets on the globe produces duplicate renders.
     const worldOffsets = useDirectEcef ? [0] : context.worldOffsets
 
+    // Resolve the flat projection matrix for the eye-coords path (only the flat
+    // MapLibre wgs84 shader consumes it; the ECEF globe and Mapbox paths ignore
+    // it). MapLibre's flat map is mainMatrix; Mapbox passes its matrix directly.
+    // Pass it through at native precision — renderRegion casts to Float32 for the
+    // GPU upload but keeps full precision for the per-region anchor_clip.
+    let eyeMatrix: number[] | Float32Array | Float64Array | null = null
+    if (useWgs84 && !useDirectEcef) {
+      const raw = useMapbox
+        ? context.matrix
+        : context.projectionData?.mainMatrix
+      if (raw && raw.length >= 16) {
+        eyeMatrix = raw
+      }
+    }
+
     this.renderRegions(
       renderer,
       shaderProgram,
       worldOffsets,
       context.customShaderConfig,
-      useDirectEcef
+      useDirectEcef,
+      eyeMatrix
     )
   }
 
@@ -2088,7 +2109,8 @@ export class UntiledMode implements ZarrMode {
     shaderProgram: ShaderProgram,
     worldOffsets: number[],
     customShaderConfig?: CustomShaderConfig,
-    useDirectEcef: boolean = false
+    useDirectEcef: boolean = false,
+    eyeMatrix: number[] | Float32Array | Float64Array | null = null
   ): void {
     const gl = renderer.gl
 
@@ -2102,7 +2124,8 @@ export class UntiledMode implements ZarrMode {
         shaderProgram,
         this.regionToRenderable(region, useDirectEcef),
         worldOffsets,
-        customShaderConfig
+        customShaderConfig,
+        eyeMatrix
       )
     }
   }

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -235,7 +235,7 @@ export class UntiledMode implements ZarrMode {
   private cachedWGS84Transformer: ReturnType<
     typeof createWGS84ToSourceTransformer
   > | null = null
-  // Transformer: source CRS → EPSG:4326 (for WGS84 vertex positions and ECEF projection)
+  // Transformer: source CRS → EPSG:4326 (input to source-projected mesh generation)
   private cached4326Transformer: ReturnType<
     typeof createTransformerTo4326
   > | null = null
@@ -1053,9 +1053,8 @@ export class UntiledMode implements ZarrMode {
       region.mercatorBounds = this.computeRegionMercatorBounds(geoBounds)
     }
 
-    // Compute WGS84 vertex positions via proj4.
-    // CPU: transform vertices from source CRS to WGS84.
-    // GPU: transform WGS84 → Mercator (flat) or WGS84 → ECEF (globe).
+    // Generate a source-projected mesh via proj4. CPU transforms source CRS to
+    // WGS84, then encodes region-local Mercator deltas for the shader.
     const centerX = (geoBounds.xMin + geoBounds.xMax) / 2
     const centerY = (geoBounds.yMin + geoBounds.yMax) / 2
     const samplePoints = [
@@ -1984,7 +1983,7 @@ export class UntiledMode implements ZarrMode {
 
   render(renderer: ZarrRenderer, context: RenderContext): void {
     const useMapbox = !!context.mapbox
-    // Use the WGS84 vertex path when the source projection is resolved via proj4.
+    // Use the source-projected mesh path when the CRS is resolved via proj4.
     const useWgs84 = !!this.proj4def && !!this.cached4326Transformer
 
     // MapLibre globe exposes a projectionTransition value in the shader prelude.

--- a/src/zarr-renderer.ts
+++ b/src/zarr-renderer.ts
@@ -164,6 +164,10 @@ export class ZarrRenderer {
         isGlobeTileRender
       )
     }
+    // NOTE: the eye-coords uniforms (u_eye_matrix, u_anchor_clip) for the
+    // source-projected flat path are uploaded PER REGION in renderRegion, where
+    // the per-region mercator origin (shift_x, shift_y) is known. See
+    // VERTEX_TO_WGS84_TO_MERCATOR.
   }
 
   renderTiles(


### PR DESCRIPTION
Follow up that supersedes #63. This one preserves pole rendering (and is compatible with latest main). 

@james-willis this seems to fix the distortions and jittering from what I can see using your example data from #62. Thanks for tracking this down and providing the test data!

All untiled CRSes now encode vertices as normalized-Mercator deltas, and the flat path projects them with a render-relative-to-eye decomposition: `gl_Position = u_anchor_clip + matrix * delta`  instead of forming an absolute world coordinate in Float32 (the source of the jitter). The per-region `anchor_clip` is computed from the renderer's native-precision (Float64) flat matrix and only the small delta goes through the Float32 GPU matrix, so high-zoom rendering stays stable under pan/zoom. The ECEF globe shaders invert mercator to lat (with a near-pole clamp), so polar datasets keep full coverage on the globe.

closes #62 