### PR TITLE
Fix data dropping across the antimeridian

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,10 +9,15 @@ export const DEFAULT_MESH_MAX_ERROR = 0.125
 /** Default maximum error for query polygon edge densification (in pixels) */
 export const DEFAULT_QUERY_DENSIFY_MAX_ERROR = DEFAULT_MESH_MAX_ERROR
 
-/** Minimum subdivisions for region geometry tessellation (globe projection) */
-export const MIN_SUBDIVISIONS = 2
+/**
+ * Minimum subdivisions per axis for region geometry tessellation (globe
+ * projection). 8 (not 2) so a thin strip chunk — e.g. a single data row
+ * spanning many degrees — still gets enough vertices across its short axis to
+ * keep hard data/nodata edges from smearing on the globe.
+ */
+export const MIN_SUBDIVISIONS = 8
 
-/** Maximum subdivisions for region geometry tessellation (globe projection) */
+/** Maximum subdivisions per axis for region geometry tessellation (globe projection) */
 export const MAX_SUBDIVISIONS = 128
 
 /** Web Mercator world extent in meters (half of full world width) */

--- a/src/map-utils.ts
+++ b/src/map-utils.ts
@@ -75,9 +75,48 @@ export interface Wgs84Bounds {
 
 /**
  * Converts longitude to tile X coordinate at a given zoom level.
+ *
+ * Intentionally does NOT clamp longitude to [-180, 180]. When the viewport
+ * straddles the antimeridian, `map.getBounds()` can report unwrapped longitudes
+ * (e.g. west=175, east=195) or wrapped ones (west > east). Clamping would
+ * collapse everything past ±180 onto the edge tile and drop the tiles on the
+ * far side of the antimeridian (issue #53). Callers fold the resulting index
+ * back into [0, 2^zoom) with the standard wrap.
  */
 function lonToTile(lon: number, zoom: number): number {
-  return Math.floor(lonToMercatorNorm(lon) * Math.pow(2, zoom))
+  return Math.floor(((lon + 180) / 360) * Math.pow(2, zoom))
+}
+
+/**
+ * Longitude-interval overlap test that is aware of antimeridian wrapping.
+ *
+ * The viewport range [viewWest, viewEast] reported by `map.getBounds()` may be
+ * wrapped (viewWest > viewEast) or unwrapped with values well outside
+ * [-180, 180]: it straddles ±180 (e.g. 175→195), and with renderWorldCopies the
+ * user can pan into a neighbouring world copy, so the whole range can be offset
+ * by any multiple of 360 (e.g. 535→555). The region range [regWest, regEast] is
+ * expressed in the data's own longitude domain (typically [-180, 180] or
+ * [0, 360]).
+ *
+ * A region overlaps the viewport when some world copy of it — shifted by k·360
+ * for integer k — lands inside the viewport:
+ *   regEast + k·360 >= viewWest   AND   regWest + k·360 <= viewEast
+ * Solving each inequality for k yields a closed interval [kMin, kMax]; an
+ * overlapping copy exists iff that interval contains an integer. Testing the
+ * whole interval (rather than a fixed ±360) covers arbitrarily distant world
+ * copies and viewports wider than 360° (issues #53/#64).
+ */
+export function lonRangeOverlaps(
+  viewWest: number,
+  viewEast: number,
+  regWest: number,
+  regEast: number
+): boolean {
+  let east = viewEast
+  if (east < viewWest) east += 360
+  const kMin = Math.ceil((viewWest - regEast) / 360)
+  const kMax = Math.floor((east - regWest) / 360)
+  return kMax >= kMin
 }
 
 /**
@@ -104,7 +143,8 @@ function latToTileMercator(lat: number, zoom: number): number {
 /**
  * Gets all tiles visible at a given zoom level within geographic bounds.
  * Handles world wrap-around by normalizing tile indices to valid range.
- * Handles antimeridian crossing when west > east.
+ * Handles antimeridian crossing whether `map.getBounds()` reports it wrapped
+ * (west > east) or unwrapped (east > 180 / west < -180).
  * @param zoom - Zoom level.
  * @param bounds - Geographic bounds [[west, south], [east, north]].
  * @returns Array of tile tuples [zoom, x, y].

--- a/src/mesh-reprojector.ts
+++ b/src/mesh-reprojector.ts
@@ -14,7 +14,7 @@ import {
   sourceCRSToPixel,
   type ProjectionTransformer,
 } from './projection-utils'
-import { DEFAULT_MESH_MAX_ERROR, MAX_SUBDIVISIONS } from './constants'
+import { DEFAULT_MESH_MAX_ERROR } from './constants'
 
 // ============================================================================
 // Module constants
@@ -44,13 +44,6 @@ const WGS84_BOUNDS_EPSILON = 1e-4
  */
 const MAX_GLOBE_TRIANGLE_EDGE_DEGREES = 120
 
-/**
- * Longitude step target for EPSG:4326 meshes. This is below the long-edge cull
- * threshold so valid wide-but-shallow WGS84 strips are refined before the guard
- * runs, instead of being dropped after triangulation.
- */
-const MAX_WGS84_MESH_LONGITUDE_STEP_DEGREES = 100
-
 // ============================================================================
 // Interfaces
 // ============================================================================
@@ -74,7 +67,14 @@ interface HybridMeshOptions {
   geoBounds: { xMin: number; xMax: number; yMin: number; yMax: number }
   width: number
   height: number
-  subdivisions: number
+  /**
+   * Uniform-grid vertex counts per axis (cells = subdivisions). Separate axes
+   * let a region that is wide in one dimension and shallow in the other (e.g. a
+   * full-width latitudinal strip chunk) be densely subdivided along its long
+   * axis without wasting vertices on its short axis.
+   */
+  lonSubdivisions: number
+  latSubdivisions: number
   transformer: ProjectionTransformer
   latIsAscending: boolean
   allowUnwrappedLongitudes?: boolean
@@ -114,19 +114,6 @@ function isRenderableWgs84Position(
     lon <= maxLon + WGS84_BOUNDS_EPSILON &&
     lat >= -90 - WGS84_BOUNDS_EPSILON &&
     lat <= 90 + WGS84_BOUNDS_EPSILON
-  )
-}
-
-function getWgs84LongitudeSubdivisions(
-  xMin: number,
-  xMax: number,
-  allowUnwrappedLongitudes: boolean
-): number {
-  if (!allowUnwrappedLongitudes) return 0
-  const lonSpan = Math.min(360, Math.abs(xMax - xMin))
-  return Math.min(
-    MAX_SUBDIVISIONS,
-    Math.ceil(lonSpan / MAX_WGS84_MESH_LONGITUDE_STEP_DEGREES)
   )
 }
 
@@ -525,7 +512,8 @@ export function createHybridMesh(
     geoBounds,
     width,
     height,
-    subdivisions,
+    lonSubdivisions,
+    latSubdivisions,
     transformer,
     latIsAscending,
     allowUnwrappedLongitudes = false,
@@ -564,21 +552,20 @@ export function createHybridMesh(
   const adaptiveUVs = reprojector.uvs // [u0, v0, u1, v1, ...]
 
   // Merge adaptive + uniform grid UVs directly into pre-sized array
-  // (duplicates are harmless for Delaunator)
-  const effectiveSubdivisions = Math.max(
-    1,
-    Math.ceil(subdivisions),
-    getWgs84LongitudeSubdivisions(xMin, xMax, allowUnwrappedLongitudes)
-  )
-  const uniformVertices = (effectiveSubdivisions + 1) ** 2
+  // (duplicates are harmless for Delaunator). The grid is non-square: columns
+  // follow longitude density, rows follow latitude, so a wide-shallow strip
+  // gets many longitudinal cells without a matching blow-up in latitude.
+  const lonCells = Math.max(1, Math.ceil(lonSubdivisions))
+  const latCells = Math.max(1, Math.ceil(latSubdivisions))
+  const uniformVertices = (lonCells + 1) * (latCells + 1)
   const mergedUVs = new Float64Array(adaptiveUVs.length + uniformVertices * 2)
   mergedUVs.set(adaptiveUVs)
 
   let offset = adaptiveUVs.length
-  for (let row = 0; row <= effectiveSubdivisions; row++) {
-    for (let col = 0; col <= effectiveSubdivisions; col++) {
-      mergedUVs[offset++] = col / effectiveSubdivisions
-      mergedUVs[offset++] = row / effectiveSubdivisions
+  for (let row = 0; row <= latCells; row++) {
+    for (let col = 0; col <= lonCells; col++) {
+      mergedUVs[offset++] = col / lonCells
+      mergedUVs[offset++] = row / latCells
     }
   }
 

--- a/src/mesh-reprojector.ts
+++ b/src/mesh-reprojector.ts
@@ -488,10 +488,11 @@ function splitAntimeridianTriangles(
       newIndices.push(intOther1, other1, other2)
       newIndices.push(intOther1, other2, intOther2)
     } else {
-      // One-crossing triangles are ambiguous after source-space Delaunay
-      // triangulation: preserving them creates globe-spanning seam chords.
-      // Dropping them is conservative and avoids drawing false topology.
-      continue
+      // crossCount 1 (or 3): the triangle encloses a pole (its boundary winds
+      // around it, crossing the antimeridian an odd number of times). Keep it —
+      // the long-edge cull above already dropped the globe-spanning chords, so
+      // these are valid polar-cap triangles and dropping them holes the pole.
+      newIndices.push(i0, i1, i2)
     }
   }
 

--- a/src/mesh-reprojector.ts
+++ b/src/mesh-reprojector.ts
@@ -97,21 +97,32 @@ function normalizeLon180(lon: number): number {
 
 /**
  * Check whether a source→WGS84 reprojection produced a coordinate that can be
- * rendered on one globe. Some projections return finite but nonsensical
- * longitudes near singularities (for example sinusoidal rectangle corners near
- * the poles), and normalizing those would create false seam triangles.
+ * rendered on one globe.
+ *
+ * The longitude bound only guards proj4 reprojection: projections with
+ * singularities (e.g. sinusoidal rectangle corners near the poles) return
+ * finite-but-nonsensical longitudes that, left in, poison the mesh's
+ * antimeridian-crossing detection (see the `lons` collection in
+ * `createHybridMesh`) and draw seams across the globe. Valid proj4 output never
+ * exceeds [-180, 180], so that bound cleanly separates garbage.
+ *
+ * EPSG:4326 (allowUnwrappedLongitudes) has no such singularity — `forward` is
+ * ~identity — so any finite longitude is legitimate. Bounding it there only
+ * drops valid data whose domain sits in another world copy ([-360, 0], a
+ * half-cell past 360, etc.), so we skip the longitude bound on that path.
  */
 function isRenderableWgs84Position(
   lon: number,
   lat: number,
   allowUnwrappedLongitudes: boolean = false
 ): boolean {
-  const maxLon = allowUnwrappedLongitudes ? 360 : 180
+  const lonInRange =
+    allowUnwrappedLongitudes ||
+    (lon >= -180 - WGS84_BOUNDS_EPSILON && lon <= 180 + WGS84_BOUNDS_EPSILON)
   return (
     isFinite(lon) &&
     isFinite(lat) &&
-    lon >= -180 - WGS84_BOUNDS_EPSILON &&
-    lon <= maxLon + WGS84_BOUNDS_EPSILON &&
+    lonInRange &&
     lat >= -90 - WGS84_BOUNDS_EPSILON &&
     lat <= 90 + WGS84_BOUNDS_EPSILON
   )

--- a/src/mesh-reprojector.ts
+++ b/src/mesh-reprojector.ts
@@ -14,7 +14,7 @@ import {
   sourceCRSToPixel,
   type ProjectionTransformer,
 } from './projection-utils'
-import { DEFAULT_MESH_MAX_ERROR } from './constants'
+import { DEFAULT_MESH_MAX_ERROR, MAX_SUBDIVISIONS } from './constants'
 
 // ============================================================================
 // Module constants
@@ -44,6 +44,13 @@ const WGS84_BOUNDS_EPSILON = 1e-4
  */
 const MAX_GLOBE_TRIANGLE_EDGE_DEGREES = 120
 
+/**
+ * Longitude step target for EPSG:4326 meshes. This is below the long-edge cull
+ * threshold so valid wide-but-shallow WGS84 strips are refined before the guard
+ * runs, instead of being dropped after triangulation.
+ */
+const MAX_WGS84_MESH_LONGITUDE_STEP_DEGREES = 100
+
 // ============================================================================
 // Interfaces
 // ============================================================================
@@ -70,6 +77,7 @@ interface HybridMeshOptions {
   subdivisions: number
   transformer: ProjectionTransformer
   latIsAscending: boolean
+  allowUnwrappedLongitudes?: boolean
   maxError?: number
 }
 
@@ -93,14 +101,32 @@ function normalizeLon180(lon: number): number {
  * longitudes near singularities (for example sinusoidal rectangle corners near
  * the poles), and normalizing those would create false seam triangles.
  */
-function isRenderableWgs84Position(lon: number, lat: number): boolean {
+function isRenderableWgs84Position(
+  lon: number,
+  lat: number,
+  allowUnwrappedLongitudes: boolean = false
+): boolean {
+  const maxLon = allowUnwrappedLongitudes ? 360 : 180
   return (
     isFinite(lon) &&
     isFinite(lat) &&
     lon >= -180 - WGS84_BOUNDS_EPSILON &&
-    lon <= 180 + WGS84_BOUNDS_EPSILON &&
+    lon <= maxLon + WGS84_BOUNDS_EPSILON &&
     lat >= -90 - WGS84_BOUNDS_EPSILON &&
     lat <= 90 + WGS84_BOUNDS_EPSILON
+  )
+}
+
+function getWgs84LongitudeSubdivisions(
+  xMin: number,
+  xMax: number,
+  allowUnwrappedLongitudes: boolean
+): number {
+  if (!allowUnwrappedLongitudes) return 0
+  const lonSpan = Math.min(360, Math.abs(xMax - xMin))
+  return Math.min(
+    MAX_SUBDIVISIONS,
+    Math.ceil(lonSpan / MAX_WGS84_MESH_LONGITUDE_STEP_DEGREES)
   )
 }
 
@@ -293,7 +319,8 @@ function splitAntimeridianTriangles(
   wgs84Positions: Float64Array,
   texCoords: Float64Array,
   triangles: ArrayLike<number>,
-  canCrossAntimeridian: boolean
+  canCrossAntimeridian: boolean,
+  allowUnwrappedLongitudes: boolean
 ): SplitResult {
   const numVerts = wgs84Positions.length / 2
 
@@ -302,7 +329,13 @@ function splitAntimeridianTriangles(
   for (let i = 0; i < numVerts; i++) {
     const lon = wgs84Positions[i * 2]
     const lat = wgs84Positions[i * 2 + 1]
-    validVertex[i] = isRenderableWgs84Position(lon, lat) ? 1 : 0
+    validVertex[i] = isRenderableWgs84Position(
+      lon,
+      lat,
+      allowUnwrappedLongitudes
+    )
+      ? 1
+      : 0
   }
 
   // Fast path: no crossing possible, just filter invalid triangles
@@ -495,6 +528,7 @@ export function createHybridMesh(
     subdivisions,
     transformer,
     latIsAscending,
+    allowUnwrappedLongitudes = false,
     maxError = DEFAULT_MESH_MAX_ERROR,
   } = options
   const { xMin, xMax, yMin, yMax } = geoBounds
@@ -531,15 +565,20 @@ export function createHybridMesh(
 
   // Merge adaptive + uniform grid UVs directly into pre-sized array
   // (duplicates are harmless for Delaunator)
-  const uniformVertices = (subdivisions + 1) ** 2
+  const effectiveSubdivisions = Math.max(
+    1,
+    Math.ceil(subdivisions),
+    getWgs84LongitudeSubdivisions(xMin, xMax, allowUnwrappedLongitudes)
+  )
+  const uniformVertices = (effectiveSubdivisions + 1) ** 2
   const mergedUVs = new Float64Array(adaptiveUVs.length + uniformVertices * 2)
   mergedUVs.set(adaptiveUVs)
 
   let offset = adaptiveUVs.length
-  for (let row = 0; row <= subdivisions; row++) {
-    for (let col = 0; col <= subdivisions; col++) {
-      mergedUVs[offset++] = col / subdivisions
-      mergedUVs[offset++] = row / subdivisions
+  for (let row = 0; row <= effectiveSubdivisions; row++) {
+    for (let col = 0; col <= effectiveSubdivisions; col++) {
+      mergedUVs[offset++] = col / effectiveSubdivisions
+      mergedUVs[offset++] = row / effectiveSubdivisions
     }
   }
 
@@ -570,7 +609,7 @@ export function createHybridMesh(
     wgs84Positions[i * 2] = lon
     wgs84Positions[i * 2 + 1] = lat
 
-    if (isRenderableWgs84Position(lon, lat)) {
+    if (isRenderableWgs84Position(lon, lat, allowUnwrappedLongitudes)) {
       lons.push(normalizeLon180(lon))
       minLat = Math.min(minLat, lat)
       maxLat = Math.max(maxLat, lat)
@@ -634,7 +673,8 @@ export function createHybridMesh(
     wgs84Positions,
     texCoords,
     triangles,
-    canCrossAntimeridian
+    canCrossAntimeridian,
+    allowUnwrappedLongitudes
   )
 
   // Encode as absolute WGS84 coordinates so that shared-edge vertices between

--- a/src/mesh-reprojector.ts
+++ b/src/mesh-reprojector.ts
@@ -34,6 +34,16 @@ const MAX_ITERATIONS = 1000
  */
 const POLAR_LON_COVERAGE_THRESHOLD = 270
 
+/** Tolerance for coordinates returned just outside WGS84's valid degree range. */
+const WGS84_BOUNDS_EPSILON = 1e-4
+
+/**
+ * Maximum allowed great-circle edge for one mesh triangle. Edges larger than
+ * this are almost always topology left behind after invalid projection-domain
+ * vertices were culled, and draw as ECEF chords through the globe.
+ */
+const MAX_GLOBE_TRIANGLE_EDGE_DEGREES = 120
+
 // ============================================================================
 // Interfaces
 // ============================================================================
@@ -75,6 +85,62 @@ function normalizeLon180(lon: number): number {
   if (!isFinite(lon)) return lon
   // Shift to [0, 360) then back to [-180, 180)
   return ((((lon + 180) % 360) + 360) % 360) - 180
+}
+
+/**
+ * Check whether a source→WGS84 reprojection produced a coordinate that can be
+ * rendered on one globe. Some projections return finite but nonsensical
+ * longitudes near singularities (for example sinusoidal rectangle corners near
+ * the poles), and normalizing those would create false seam triangles.
+ */
+function isRenderableWgs84Position(lon: number, lat: number): boolean {
+  return (
+    isFinite(lon) &&
+    isFinite(lat) &&
+    lon >= -180 - WGS84_BOUNDS_EPSILON &&
+    lon <= 180 + WGS84_BOUNDS_EPSILON &&
+    lat >= -90 - WGS84_BOUNDS_EPSILON &&
+    lat <= 90 + WGS84_BOUNDS_EPSILON
+  )
+}
+
+function angularDistanceDegrees(
+  lon1: number,
+  lat1: number,
+  lon2: number,
+  lat2: number
+): number {
+  const lambda1 = (normalizeLon180(lon1) * Math.PI) / 180
+  const lambda2 = (normalizeLon180(lon2) * Math.PI) / 180
+  const phi1 = (lat1 * Math.PI) / 180
+  const phi2 = (lat2 * Math.PI) / 180
+  const dLambda = lambda2 - lambda1
+  const dPhi = phi2 - phi1
+  const hav =
+    Math.sin(dPhi / 2) ** 2 +
+    Math.cos(phi1) * Math.cos(phi2) * Math.sin(dLambda / 2) ** 2
+  return (
+    (2 * Math.atan2(Math.sqrt(hav), Math.sqrt(Math.max(0, 1 - hav))) * 180) /
+    Math.PI
+  )
+}
+
+function triangleHasLongGlobeEdge(
+  lon0: number,
+  lat0: number,
+  lon1: number,
+  lat1: number,
+  lon2: number,
+  lat2: number
+): boolean {
+  return (
+    angularDistanceDegrees(lon0, lat0, lon1, lat1) >
+      MAX_GLOBE_TRIANGLE_EDGE_DEGREES ||
+    angularDistanceDegrees(lon1, lat1, lon2, lat2) >
+      MAX_GLOBE_TRIANGLE_EDGE_DEGREES ||
+    angularDistanceDegrees(lon2, lat2, lon0, lat0) >
+      MAX_GLOBE_TRIANGLE_EDGE_DEGREES
+  )
 }
 
 /**
@@ -220,7 +286,7 @@ interface SplitResult {
 
 /**
  * Process triangles that span the antimeridian by splitting them.
- * Filters out triangles with non-finite coordinates.
+ * Filters out triangles with non-renderable WGS84 coordinates.
  * When canCrossAntimeridian is false, skips crossing checks for better performance.
  */
 function splitAntimeridianTriangles(
@@ -231,12 +297,12 @@ function splitAntimeridianTriangles(
 ): SplitResult {
   const numVerts = wgs84Positions.length / 2
 
-  // Pre-compute which vertices are valid (have finite coords)
+  // Pre-compute which vertices are valid renderable WGS84 positions.
   const validVertex = new Uint8Array(numVerts)
   for (let i = 0; i < numVerts; i++) {
     const lon = wgs84Positions[i * 2]
     const lat = wgs84Positions[i * 2 + 1]
-    validVertex[i] = isFinite(lon) && isFinite(lat) ? 1 : 0
+    validVertex[i] = isRenderableWgs84Position(lon, lat) ? 1 : 0
   }
 
   // Fast path: no crossing possible, just filter invalid triangles
@@ -246,9 +312,19 @@ function splitAntimeridianTriangles(
       const i0 = triangles[i]
       const i1 = triangles[i + 1]
       const i2 = triangles[i + 2]
-      if (validVertex[i0] && validVertex[i1] && validVertex[i2]) {
-        newIndices.push(i0, i1, i2)
+      if (!validVertex[i0] || !validVertex[i1] || !validVertex[i2]) {
+        continue
       }
+      const lon0 = wgs84Positions[i0 * 2]
+      const lat0 = wgs84Positions[i0 * 2 + 1]
+      const lon1 = wgs84Positions[i1 * 2]
+      const lat1 = wgs84Positions[i1 * 2 + 1]
+      const lon2 = wgs84Positions[i2 * 2]
+      const lat2 = wgs84Positions[i2 * 2 + 1]
+      if (triangleHasLongGlobeEdge(lon0, lat0, lon1, lat1, lon2, lat2)) {
+        continue
+      }
+      newIndices.push(i0, i1, i2)
     }
     return {
       positions: wgs84Positions,
@@ -295,6 +371,10 @@ function splitAntimeridianTriangles(
     const lon0 = normalizeLon180(lon0raw)
     const lon1 = normalizeLon180(lon1raw)
     const lon2 = normalizeLon180(lon2raw)
+
+    if (triangleHasLongGlobeEdge(lon0, lat0, lon1, lat1, lon2, lat2)) {
+      continue
+    }
 
     // Check which edges cross the antimeridian
     const cross01 = edgeCrossesAntimeridian(lon0, lon1)
@@ -377,8 +457,10 @@ function splitAntimeridianTriangles(
       newIndices.push(intOther1, other1, other2)
       newIndices.push(intOther1, other2, intOther2)
     } else {
-      // crossCount === 1 or 3: preserve triangle to avoid holes
-      newIndices.push(i0, i1, i2)
+      // One-crossing triangles are ambiguous after source-space Delaunay
+      // triangulation: preserving them creates globe-spanning seam chords.
+      // Dropping them is conservative and avoids drawing false topology.
+      continue
     }
   }
 
@@ -488,7 +570,7 @@ export function createHybridMesh(
     wgs84Positions[i * 2] = lon
     wgs84Positions[i * 2 + 1] = lat
 
-    if (isFinite(lon) && isFinite(lat)) {
+    if (isRenderableWgs84Position(lon, lat)) {
       lons.push(normalizeLon180(lon))
       minLat = Math.min(minLat, lat)
       maxLat = Math.max(maxLat, lat)

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -1082,6 +1082,7 @@ export class UntiledMode implements ZarrMode {
       subdivisions: meshSubdivisions,
       transformer: this.cached4326Transformer,
       latIsAscending: this.latIsAscending,
+      allowUnwrappedLongitudes: this.projectionKind === 'epsg4326',
     })
     region.vertexArr = meshResult.positions
     region.pixCoordArr = meshResult.texCoords

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -41,6 +41,7 @@ import type {
 import { ZarrStore } from './zarr-store'
 import {
   boundsToMercatorNorm,
+  lonRangeOverlaps,
   type MercatorBounds,
   type XYLimits,
   type Wgs84Bounds,
@@ -635,8 +636,7 @@ export class UntiledMode implements ZarrMode {
       if (!hasValid) continue
 
       if (
-        regEast >= west &&
-        regWest <= east &&
+        lonRangeOverlaps(west, east, regWest, regEast) &&
         regNorth >= south &&
         regSouth <= north
       ) {
@@ -949,6 +949,18 @@ export class UntiledMode implements ZarrMode {
     rXMax = Math.min(numRegionsX - 1, rXMax)
     rYMin = Math.max(0, rYMin)
     rYMax = Math.min(numRegionsY - 1, rYMax)
+
+    // When the viewport straddles the antimeridian, forward-projecting the
+    // sampled longitudes folds source X back on itself (e.g. proj4 adjust_lon),
+    // so the srcX min/max span no longer bounds the visible columns. Treat
+    // every X region as a candidate; the antimeridian-aware overlap check in
+    // getVisibleRegions then keeps only the columns that are actually visible,
+    // so this widens the search without over-fetching the result (issue #64).
+    const crossesAntimeridian = east < west || east > 180 || west < -180
+    if (crossesAntimeridian) {
+      rXMin = 0
+      rXMax = numRegionsX - 1
+    }
 
     const candidates: Array<{ regionX: number; regionY: number }> = []
     for (let ry = rYMin; ry <= rYMax; ry++) {

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -1893,9 +1893,26 @@ export class UntiledMode implements ZarrMode {
         this.xyLimits.xMax,
         this.xyLimits.yMax
       )
-      const dataWidthMeters = Math.abs(maxMercX - minMercX)
+      let dataWidthMeters = Math.abs(maxMercX - minMercX)
       const fullWorldMeters = 2 * WEB_MERCATOR_EXTENT
-      worldFraction = dataWidthMeters / fullWorldMeters
+      // worldFraction > 1 means the corner projection failed: for projections
+      // like MODIS sinusoidal the rectangular bbox corners fall outside the
+      // valid CRS domain (near-polar latitudes give out-of-domain longitudes),
+      // yielding a garbage or non-finite width. Fall back to the equatorial
+      // strip (y=0), which stays in-domain for any cylindrical-like projection
+      // and gives the correct horizontal extent.
+      if (!isFinite(dataWidthMeters) || dataWidthMeters > fullWorldMeters) {
+        const [eqMinX] = this.cachedMercatorTransformer.forward(
+          this.xyLimits.xMin,
+          0
+        )
+        const [eqMaxX] = this.cachedMercatorTransformer.forward(
+          this.xyLimits.xMax,
+          0
+        )
+        dataWidthMeters = Math.abs(eqMaxX - eqMinX)
+      }
+      worldFraction = Math.min(1, dataWidthMeters / fullWorldMeters)
     } else {
       const dataWidth = this.xyLimits.xMax - this.xyLimits.xMin
       worldFraction = dataWidth / 360

--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -1070,16 +1070,45 @@ export class UntiledMode implements ZarrMode {
       .filter((lat) => isFinite(lat))
     const latSpan =
       validLats.length > 0 ? Math.max(...validLats) - Math.min(...validLats) : 0
-    const meshSubdivisions = Math.max(
-      MIN_SUBDIVISIONS,
-      Math.min(MAX_SUBDIVISIONS, Math.ceil(latSpan))
-    )
+
+    // WGS84 longitude span of this chunk, paired with latSpan to size the mesh
+    // below. EPSG:4326's source X is longitude in degrees and a 0-360 store
+    // keeps its unwrapped span there, so use the source span; forward-projecting
+    // would fold it via adjust_lon and understate it. Other projections have no
+    // such direct measure, so use the sampled WGS84 longitudes.
+    let lonSpan: number
+    if (this.projectionKind === 'epsg4326') {
+      lonSpan = Math.min(360, Math.abs(geoBounds.xMax - geoBounds.xMin))
+    } else {
+      const validLons = samplePoints
+        .map((p) => p[0])
+        .filter((lon) => isFinite(lon))
+      lonSpan =
+        validLons.length > 0
+          ? Math.min(360, Math.max(...validLons) - Math.min(...validLons))
+          : 0
+    }
+
+    // Tessellate each axis from its span, addressing two distinct concerns:
+    //  - Wide axis: ceil(span) gives ~1 vertex/degree so the mesh bends around
+    //    the globe. Too-wide cells can't follow the curve and can exceed the
+    //    mesh long-edge cull, dropping triangles entirely (issue #58).
+    //  - Thin axis: the MIN_SUBDIVISIONS floor. A chunk that is a single data
+    //    row spanning tens of degrees has a near-zero short span; without the
+    //    floor, too few vertices there let hard data/nodata edges smear across
+    //    globe-projected triangles.
+    // Handles row and column strip chunks alike (whichever axis is thin).
+    const subdivisionsForSpan = (span: number) =>
+      Math.max(MIN_SUBDIVISIONS, Math.min(MAX_SUBDIVISIONS, Math.ceil(span)))
+    const lonSubdivisions = subdivisionsForSpan(lonSpan)
+    const latSubdivisions = subdivisionsForSpan(latSpan)
 
     const meshResult = createHybridMesh({
       geoBounds,
       width: region.width,
       height: region.height,
-      subdivisions: meshSubdivisions,
+      lonSubdivisions,
+      latSubdivisions,
       transformer: this.cached4326Transformer,
       latIsAscending: this.latIsAscending,
       allowUnwrappedLongitudes: this.projectionKind === 'epsg4326',

--- a/src/zarr-layer.ts
+++ b/src/zarr-layer.ts
@@ -102,6 +102,7 @@ function mapboxGlobeToMercatorTransition(zoom: number): number {
 export class ZarrLayer {
   readonly type: 'custom' = 'custom'
   readonly renderingMode: '2d' | '3d'
+  readonly wrapTileId = true
 
   id: string
   private url: string


### PR DESCRIPTION
Closes #53. Closes #64. Closes #58. This supersedes #65 to point to latest main (sorry for letting that get stale @egagli, I added you as co-author to these commits).

When a viewport straddles 180, MapLibre's `getBounds()` reports unwrapped longitudes (e.g. west=104, east=255 at center 180), and two selection paths dropped data on one side until the user panned across:

- **Tiled (#53):** `getTilesAtZoom` clamped lon to [-180, 180] when computing tile-X, so tiles past the dateline were never requested. (EPSG:4326's path never clamped: why `tasmax` worked but the EPSG:3857 pyramids didn't.)
- **Untiled (#64):** `getVisibleRegions`' overlap test wasn't antimeridian-aware, so far-side regions failed the comparison.

`map-utils.ts`: `getTilesAtZoom` no longer clamps lon (existing `wrappedX` fold handles both wrapped and unwrapped bounds; normal views unchanged). New `lonRangeOverlaps` does an antimeridian-aware overlap that solves for every world-copy offset k·360 (not just ±360), so it's correct for distant `renderWorldCopies` pans and 0–360 stores.

`untiled-mode.ts`: `getVisibleRegions` uses `lonRangeOverlaps`; `getCandidateRegions` widens to all X columns when crossing (the overlap check trims it back, so no over-fetch).

Also ports #65's separate `worldFraction` fix (co-authored @egagli): proj4 bbox corners can project out-of-domain (e.g. MODIS sinusoidal) -> NaN worldFraction -> broken level selection; falls back to the equatorial strip and clamps to <= 1.

This also covers two more antimeridian rendering paths that the selection fix alone didn't:

`zarr-layer.ts`: sets `wrapTileId = true` so Mapbox renders draped tiles into wrapped world copies. Under terrain the draped `renderToTile` path only drew the canonical world, so one side of the dateline stayed blank even with data loaded (depends on the selection fix above to have data on both sides).

`mesh-reprojector.ts`: culls out-of-domain reprojected vertices and triangles with globe-spanning edges, so source-projected meshes that wrap past 180 (e.g. sinusoidal) no longer draw a flat sheet through the center of the globe on MapLibre / smear across the whole globe on Mapbox.

### Strip-chunked stores on the globe (#58)

Some virtual stores chunk the data into thin strips: a single row of latitude (or column of longitude) spanning the whole extent. A region maps to one chunk, so these became full-width, near-flat strips that didn't reproject correctly on the globe (mercator was fine): they smeared north on the globe.

`mesh-reprojector.ts` / `untiled-mode.ts`: the reprojected mesh now tessellates each axis **independently** (a non-square uniform grid via separate `lonSubdivisions`/`latSubdivisions`) instead of a single square subdivision count. Each axis gets `ceil(span)` (~1 vertex/degree), clamped to `[MIN_SUBDIVISIONS, MAX_SUBDIVISIONS]`. Two concerns:

- **Wide axis** — enough vertices to bend around the globe and stay under the long-edge cull. A coarse wide strip would otherwise chord through the globe or get culled entirely.
- **Thin axis** — `MIN_SUBDIVISIONS` raised 2 → 8 (`constants.ts`). A single-row strip has a near-zero short span; with only 2 cross-vertices, hard data/nodata edges smeared on the globe (worst on MapLibre globe). The floor guarantees enough cross-vertices regardless of span. Works for row and column chunks alike — whichever axis is thin hits the floor.

This replaces an earlier longitude-only heuristic; the per-axis `ceil(span)` + floor subsumes it and also removed the dense-subdivision sliver triangles that flickered when overzoomed.