### PR TITLE
feat!: let customFrag own NaN discard decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Custom fragment shaders let you do math on your data to change how it's displaye
 
 Band names are automatically sanitized to valid GLSL identifiers: any characters that aren't letters, digits, or underscores are replaced with underscores, and names starting with a digit are prefixed with an underscore. For example, `s2med_harvest:B02` becomes `s2med_harvest_B02` and `123band` becomes `_123band`.
 
-When a `customFrag` is supplied, **it owns discarding**. Missing/fill pixels are surfaced as `NaN` instead of being dropped automatically, so you can aggregate over partial coverage (e.g. a mean over bands with differing coverage) rather than just their intersection. Add your own `discard` for pixels you want to drop:
+When a `customFrag` is supplied, **it owns discarding**. Missing/fill pixels are surfaced as `NaN` instead of being dropped automatically, so you can aggregate over partial coverage (e.g. a mean over bands with differing coverage) rather than just their intersection. Note that `NaN` propagates through arithmetic (even `NaN * 0.0` is `NaN`), so guard values before multiplying or accumulating, e.g. `isnan(x) ? 0.0 : x`. Add your own `discard` for pixels you want to drop:
 
 ```ts
 new ZarrLayer({

--- a/README.md
+++ b/README.md
@@ -188,11 +188,16 @@ Custom fragment shaders let you do math on your data to change how it's displaye
 
 Band names are automatically sanitized to valid GLSL identifiers: any characters that aren't letters, digits, or underscores are replaced with underscores, and names starting with a digit are prefixed with an underscore. For example, `s2med_harvest:B02` becomes `s2med_harvest_B02` and `123band` becomes `_123band`.
 
+When a `customFrag` is supplied, **it owns discarding**. Missing/fill pixels are surfaced as `NaN` instead of being dropped automatically, so you can aggregate over partial coverage (e.g. a mean over bands with differing coverage) rather than just their intersection. Add your own `discard` for pixels you want to drop:
+
 ```ts
 new ZarrLayer({
   // ...
   customFrag: `
     uniform float u_weight;
+    if (isnan(band_a)) {
+      discard;
+    }
     float val = band_a * u_weight;
     float norm = (val - clim.x) / (clim.y - clim.x);
     vec4 c = texture(colormap, vec2(clamp(norm, 0.0, 1.0), 0.5));
@@ -216,6 +221,9 @@ new ZarrLayer({
   selector: { band: ['B08', 'B04'], time: 0 },
   clim: [-1, 1],
   customFrag: `
+    if (isnan(B08) || isnan(B04)) {
+      discard;
+    }
     float ndvi = (B08 - B04) / (B08 + B04);
     float norm = (ndvi - clim.x) / (clim.y - clim.x);
     vec4 c = texture(colormap, vec2(clamp(norm, 0.0, 1.0), 0.5));

--- a/demo/datasets/carbonplan-4d.tsx
+++ b/demo/datasets/carbonplan-4d.tsx
@@ -13,6 +13,7 @@ const ALL_MONTHS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 const combinedBandsCustomFrag = `
   // custom fragment shader w/ uniform example
   uniform float u_precipWeight;
+  if (isnan(prec)) { discard; }
   float combined = prec * u_precipWeight;
   float norm = (combined - clim.x) / (clim.y - clim.x);
   float cla = clamp(norm, 0.0, 1.0);
@@ -27,13 +28,15 @@ const monthRangeAverageFrag = `
   float count = 0.0;
   ${ALL_MONTHS.map(
     (month) => `
+  float valid_${month} = isnan(month_${month}) ? 0.0 : 1.0;
   float inRange_${month} = step(u_monthStart, ${month.toFixed(
       1
-    )}) * step(${month.toFixed(1)}, u_monthEnd);
-  sum += month_${month} * inRange_${month};
+    )}) * step(${month.toFixed(1)}, u_monthEnd) * valid_${month};
+  sum += (isnan(month_${month}) ? 0.0 : month_${month}) * inRange_${month};
   count += inRange_${month};`
   ).join('')}
-  float average = sum / max(count, 1.0);
+  if (count < 0.5) { discard; }
+  float average = sum / count;
   float rescaled = (average - clim.x) / (clim.y - clim.x);
   vec4 c = texture(colormap, vec2(clamp(rescaled, 0.0, 1.0), 0.5));
   fragColor = vec4(c.r, c.g, c.b, opacity);

--- a/src/shaders.ts
+++ b/src/shaders.ts
@@ -495,7 +495,6 @@ export function createFragmentShaderSource(
   options: FragmentShaderOptions
 ): string {
   const { bands, customUniforms = [], customFrag } = options
-  const hasBands = bands.length > 0
 
   const bandSamplers = bands
     .map((name) => `uniform sampler2D ${name};`)
@@ -536,14 +535,6 @@ export function createFragmentShaderSource(
     .map((name) => `(isnan(${name}_tex) || isnan(${name}_val))`)
     .join(' || ')
 
-  const commonDiscardChecks = hasBands
-    ? `
-  if (${fillValueChecks}) {
-    discard;
-  }
-`
-    : ''
-
   return `#version 300 es
 precision highp float;
 
@@ -581,8 +572,8 @@ ${bandReads}
 ${bandAliases}
 ${
   processedFragBody
-    ? `
-${commonDiscardChecks}
+    ? // No pre-discard: customFrag owns discarding (band values incl. NaN are in scope). See #71.
+      `
 ${processedFragBody.replace(/gl_FragColor/g, 'fragColor')}`
     : bands.length === 1
     ? `


### PR DESCRIPTION
Closes #71.

In multi-band mode the generated fragment shader injected an any-band-NaN `discard` before `customFrag` ran, so aggregations over partial coverage (e.g. multi-model median/mean with gaps) could only render the intersection of all bands, never the union.

Now when a `customFrag` is supplied it owns the discard decision — every band value is already in scope (NaN included for missing/fill pixels), so the shader chooses how to handle missing bands. Default (no-customFrag) single- and multi-band paths keep their existing discards.

**Breaking:** existing `customFrag` shaders that relied on the implicit NaN discard must now add their own `discard`. README examples updated to show the pattern.