### PR TITLE
Dedupe band names that sanitize to the same GLSL identifier

### DIFF
--- a/src/zarr-utils.ts
+++ b/src/zarr-utils.ts
@@ -193,7 +193,15 @@ function getBandInformation(
         // Sanitize band names to be valid GLSL identifiers
         const rawName =
           typeof bandValue === 'string' ? bandValue : `${key}_${bandValue}`
-        const bandName = sanitizeGlslName(rawName)
+        let bandName = sanitizeGlslName(rawName)
+        // Distinct band values can sanitize to the same GLSL identifier
+        // (e.g. 'band-1' and 'band.1' both become 'band_1'). Without this
+        // guard the later entry silently overwrites the earlier one in
+        // `result`, dropping a band from the render. Suffix collisions with
+        // the index to keep every band addressable.
+        if (result[bandName]) {
+          bandName = `${bandName}_${idx}`
+        }
         result[bandName] = { band: bandValue, index: idx }
       })
     }


### PR DESCRIPTION
## Problem

`getBandInformation` keys its `result` map by `sanitizeGlslName(rawName)`. Two distinct band values can sanitize to the **same** GLSL identifier (e.g. `band-1` and `band.1` both become `band_1`). When that happens the later entry silently overwrites the earlier one in `result`, so one band is dropped — the render is missing a band / maps the wrong data.

## Fix

If a sanitized name already exists in `result`, suffix it with the band index (`${bandName}_${idx}`) so every band stays addressable.

```ts
let bandName = sanitizeGlslName(rawName)
if (result[bandName]) {
  bandName = `${bandName}_${idx}`
}
result[bandName] = { band: bandValue, index: idx }
```

Single, isolated change in `src/zarr-utils.ts`. We've carried this as a downstream patch in wherobots-gl; upstreaming it here so we can drop the patch.

Root `npm run typecheck` passes. (Pre-commit hook also runs the demo app's typecheck, which fails on pre-existing implicit-any in `demo/pages/index.tsx` unrelated to this change.)