### PR TITLE
Resolve coordinate arrays at the active level for multiscale pyramids

### DIFF
--- a/src/untiled-mode.ts
+++ b/src/untiled-mode.ts
@@ -2363,10 +2363,35 @@ export class UntiledMode implements ZarrMode {
       return typeof value === 'number' ? value : 0
     }
 
+    // Multiscale pyramids keep per-dimension coordinate arrays under per-level
+    // paths (e.g. `0/band/c/0`), not at the root. Passing `null` here resolves
+    // the coordinate array from the root, which 404s for those datasets; the
+    // catch below then falls back to index 0 for every selector value. An RGB
+    // selection (red/green/blue by name) therefore collapses all three channels
+    // to band 0 and renders greyscale. Resolve the in-flight level's path
+    // instead, gated on `isMultiscale` so single-level datasets (coordinates at
+    // root) are unaffected. `loadLevel` calls `buildSliceArgsForSelector`
+    // (and so this) before committing `activeLevel`, so fall through
+    // activeLevel.index -> loadingLevelIndex -> desiredLevelIndex -> 0 to use
+    // the level the in-flight load is actually targeting.
+    let levelInfo: string | null = null
+    if (this.isMultiscale && this.levels.length > 0) {
+      const rawLevelIndex =
+        this.activeLevel?.index ??
+        this.loadingLevelIndex ??
+        this.desiredLevelIndex ??
+        0
+      const safeIdx = Math.max(
+        0,
+        Math.min(rawLevelIndex, this.levels.length - 1)
+      )
+      levelInfo = this.levels[safeIdx]?.asset ?? null
+    }
+
     try {
       const coords = await loadDimensionValues(
         this.dimensionValues,
-        null,
+        levelInfo,
         dimInfo,
         this.zarrStore.root,
         this.zarrStore.version


### PR DESCRIPTION
## Problem

`UntiledMode.resolveSelectionIndex` passes `null` as the level path to `loadDimensionValues`, so coordinate arrays are always resolved from the **root**. Multiscale pyramids keep per-dimension coordinate arrays under per-level paths (e.g. `0/band/c/0`), not at the root — so the root lookup 404s. The `catch` then falls back to index `0` for every selector value.

For an RGB selection (band names `red`/`green`/`blue` resolved by name), all three channels collapse to band index 0 → R==G==B → the layer renders **greyscale**. The same fallback also silently picks the wrong band/time when selecting any non-spatial dimension by value on a multiscale dataset.

`loadInitialDimensionValues` already passes `levelInfos[0]`, but `loadLevel → buildSliceArgsForSelector → resolveSelectionIndex` runs before that populates the coord cache, so the `null` path still executes.

## Fix

Resolve the in-flight level's `asset` path instead of `null`, gated on `isMultiscale` so single-level datasets (coordinates at root) are unaffected. Since `loadLevel` runs this before committing `activeLevel`, fall through `activeLevel.index → loadingLevelIndex → desiredLevelIndex → 0` to use the level the in-flight load is targeting.

## Verification

Against an RGB multiscale dataset (`marion_county_optimized.zarr`):
- before: `0/band/c/0` → 404, `Could not resolve coordinate for 'band'`, greyscale render
- after: `0/band/c/0` → 200, clean console, full true-color render

`npm run typecheck` passes. We've carried this as a downstream patch in wherobots-gl; upstreaming so we can drop it. Isolated to `src/untiled-mode.ts`. (Pre-commit hook also runs the demo app typecheck, which fails on pre-existing implicit-any in `demo/pages/index.tsx` unrelated to this change.)