### PR TITLE
feat: add onAuthError option for credential-expiry detection

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,22 @@ export type TransformRequest = (
   options?: TransformRequestOptions
 ) => RequestParameters | Promise<RequestParameters>
 
+/**
+ * Callback invoked when a request made through `transformRequest` fails with a
+ * credential-shaped HTTP status (400 or 401).
+ *
+ * `transformRequest` is typically used for signed/authenticated requests (e.g.
+ * presigned S3 URLs). When the credentials behind it expire mid-session, the
+ * service rejects subsequent requests — expired temporary AWS credentials
+ * return 400 (ExpiredToken/InvalidToken), not just 401 — frequently with no
+ * readable body (HEAD probes or CORS-gated error responses). Those failures are
+ * otherwise opaque to the consumer because the store turns them into missing
+ * chunks. This hook surfaces the status so the consumer can refresh credentials.
+ *
+ * @param status - HTTP status of the failed response (400 or 401)
+ */
+export type OnAuthError = (status: number) => void
+
 export type ColormapArray = number[][] | string[]
 
 export type SelectorValue = number | number[] | string | string[]
@@ -129,6 +145,13 @@ export interface ZarrLayerOptions {
    * When provided, the store cache is bypassed to prevent credential sharing between layers.
    */
   transformRequest?: TransformRequest
+  /**
+   * Called when a `transformRequest`-signed request fails with a
+   * credential-shaped status (400/401), e.g. expired presigned-URL credentials.
+   * Lets the consumer refresh credentials and re-add the layer. See
+   * {@link OnAuthError}.
+   */
+  onAuthError?: OnAuthError
   /**
    * Enable full polar coverage in Mapbox globe view for untiled EPSG:4326 or
    * proj4 datasets. Has no effect on tiled or EPSG:3857 data.

--- a/src/zarr-layer.ts
+++ b/src/zarr-layer.ts
@@ -29,6 +29,7 @@ import type {
   NormalizedSelector,
   ZarrLayerOptions,
   TransformRequest,
+  OnAuthError,
 } from './types'
 import type { ZarrMode, RenderContext } from './zarr-mode'
 import { TiledMode } from './tiled-mode'
@@ -182,6 +183,7 @@ export class ZarrLayer {
   private initError: Error | null = null
   private proj4: string | undefined
   private transformRequest: TransformRequest | undefined
+  private onAuthError: OnAuthError | undefined
   private customStore: Readable | undefined
   private renderPoles: boolean
   private lastIsGlobe: boolean | null = null
@@ -299,6 +301,7 @@ export class ZarrLayer {
     onLoadingStateChange,
     proj4,
     transformRequest,
+    onAuthError,
     store,
     renderPoles = false,
   }: ZarrLayerOptions) {
@@ -365,6 +368,7 @@ export class ZarrLayer {
     this.onLoadingStateChange = onLoadingStateChange
     this.proj4 = proj4
     this.transformRequest = transformRequest
+    this.onAuthError = onAuthError
     this.customStore = store
     this.renderPoles = renderPoles
   }
@@ -631,6 +635,7 @@ export class ZarrLayer {
         coordinateKeys: Object.keys(this.selector),
         proj4: this.proj4,
         transformRequest: this.transformRequest,
+        onAuthError: this.onAuthError,
         customStore: this.customStore,
       })
 

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -8,6 +8,7 @@ import type {
   CRS,
   UntiledLevel,
   TransformRequest,
+  OnAuthError,
 } from './types'
 import type { XYLimits } from './map-utils'
 import { DEFAULT_TILE_SIZE } from './constants'
@@ -64,6 +65,8 @@ interface ZarrStoreOptions {
   latIsAscending?: boolean | null
   proj4?: string
   transformRequest?: TransformRequest
+  /** Called when a signed request fails with a credential-shaped status (400/401). */
+  onAuthError?: OnAuthError
   /** Custom store to use instead of FetchStore. When provided, source becomes optional. */
   customStore?: Readable | AsyncReadable
 }
@@ -97,7 +100,8 @@ interface StoreDescription {
  */
 const createFetchStore = (
   url: string,
-  transformRequest?: TransformRequest
+  transformRequest?: TransformRequest,
+  onAuthError?: OnAuthError
 ): zarr.FetchStore => {
   if (!transformRequest) {
     return new zarr.FetchStore(url)
@@ -125,8 +129,23 @@ const createFetchStore = (
           headers: mergedHeaders,
         })
       )
+      // Credential-expiry detection. transformRequest is only set for signed
+      // (authenticated) requests, so a 400/401 here has no benign meaning — a
+      // missing object is 404 and a denied one is 403. Expired temporary
+      // credentials in particular return 400 (ExpiredToken/InvalidToken/
+      // malformed presign), frequently with no readable body (HEAD probes or
+      // CORS-gated error responses), so we key off the status rather than the
+      // body. Notify the consumer via onAuthError so it can refresh credentials,
+      // and remap to 404 so the store treats it as a missing chunk instead of
+      // throwing.
+      if (response.status === 400 || response.status === 401) {
+        onAuthError?.(response.status)
+        return new Response(null, { status: 404 })
+      }
       // Remap 403 to 404 for S3/CloudFront compatibility: these services
-      // return 403 (not 404) for missing or inaccessible paths.
+      // return 403 (not 404) for missing or inaccessible paths. Left as a plain
+      // missing-chunk remap (no onAuthError) so sparse pyramids that legitimately
+      // 403 absent chunks don't trigger spurious credential refreshes.
       if (response.status === 403) {
         return new Response(null, { status: 404 })
       }
@@ -143,6 +162,7 @@ export class ZarrStore {
   private explicitBounds: Bounds | null
   coordinateKeys: string[]
   private transformRequest?: TransformRequest
+  private onAuthError?: OnAuthError
   private customStore?: Readable | AsyncReadable
 
   dimensions: string[] = []
@@ -199,6 +219,7 @@ export class ZarrStore {
     latIsAscending = null,
     proj4,
     transformRequest,
+    onAuthError,
     customStore,
   }: ZarrStoreOptions) {
     if (!source && !customStore) {
@@ -231,6 +252,7 @@ export class ZarrStore {
       }
     }
     this.transformRequest = transformRequest
+    this.onAuthError = onAuthError
     this.customStore = customStore
 
     this.initialized = this._initialize()
@@ -277,7 +299,7 @@ export class ZarrStore {
           ? { format: 'v3' }
           : undefined
       this.store = (await zarr.extendStore(
-        createFetchStore(this.source, this.transformRequest),
+        createFetchStore(this.source, this.transformRequest, this.onAuthError),
         (store) =>
           zarr
             .withMaybeConsolidatedMetadata(store, consolidatedOpts)


### PR DESCRIPTION
Surface signed-request failures (HTTP 400/401) through a new optional onAuthError(status) layer option so consumers can detect expired credentials and refresh them.

transformRequest is only used for signed/authenticated requests, so a 400 is due to expired credentials(not authorized -> 401, missing -> 404, denied -> 403). Because temporary credentials in particular return 400 (ExpiredToken/ InvalidToken), often with no readable body (HEAD probes / CORS-gated errors), we have to rely on the status code itself. On 400/401 the fetch store calls onAuthError(status) and remaps to 404 so the read is treated as a missing chunk instead of throwing. The existing 403->404 remap is left untouched (no onAuthError) so sparse pyramids that 403 absent chunks don't trigger spurious refreshes.