### PR TITLE
docs: premultiply alpha in customFrag examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ Custom fragment shaders let you do math on your data to change how it's displaye
 
 Band names are automatically sanitized to valid GLSL identifiers: any characters that aren't letters, digits, or underscores are replaced with underscores, and names starting with a digit are prefixed with an underscore. For example, `s2med_harvest:B02` becomes `s2med_harvest_B02` and `123band` becomes `_123band`.
 
+The layer blends with a premultiplied alpha blend function, so your `customFrag` must output premultiplied color. Multiply RGB by your final alpha (e.g. `fragColor = vec4(c.rgb * opacity, opacity)`). Emitting straight `vec4(c.rgb, opacity)` renders correctly only at full opacity.
+
 When a `customFrag` is supplied, **it owns discarding**. Missing/fill pixels are surfaced as `NaN` instead of being dropped automatically, so you can aggregate over partial coverage (e.g. a mean over bands with differing coverage) rather than just their intersection. Note that `NaN` propagates through arithmetic (even `NaN * 0.0` is `NaN`), so guard values before multiplying or accumulating, e.g. `isnan(x) ? 0.0 : x`. Add your own `discard` for pixels you want to drop:
 
 ```ts
@@ -201,7 +203,7 @@ new ZarrLayer({
     float val = band_a * u_weight;
     float norm = (val - clim.x) / (clim.y - clim.x);
     vec4 c = texture(colormap, vec2(clamp(norm, 0.0, 1.0), 0.5));
-    fragColor = vec4(c.rgb, opacity);
+    fragColor = vec4(c.rgb * opacity, opacity);
   `,
   uniforms: { u_weight: 1.0 },
 })
@@ -227,7 +229,7 @@ new ZarrLayer({
     float ndvi = (B08 - B04) / (B08 + B04);
     float norm = (ndvi - clim.x) / (clim.y - clim.x);
     vec4 c = texture(colormap, vec2(clamp(norm, 0.0, 1.0), 0.5));
-    fragColor = vec4(c.rgb, opacity);
+    fragColor = vec4(c.rgb * opacity, opacity);
   `,
 })
 ```

--- a/demo/datasets/carbonplan-4d.tsx
+++ b/demo/datasets/carbonplan-4d.tsx
@@ -18,7 +18,7 @@ const combinedBandsCustomFrag = `
   float norm = (combined - clim.x) / (clim.y - clim.x);
   float cla = clamp(norm, 0.0, 1.0);
   vec4 c = texture(colormap, vec2(cla, 0.5));
-  fragColor = vec4(c.r, c.g, c.b, opacity);
+  fragColor = vec4(c.rgb * opacity, opacity);
 `
 
 const monthRangeAverageFrag = `
@@ -39,7 +39,7 @@ const monthRangeAverageFrag = `
   float average = sum / count;
   float rescaled = (average - clim.x) / (clim.y - clim.x);
   vec4 c = texture(colormap, vec2(clamp(rescaled, 0.0, 1.0), 0.5));
-  fragColor = vec4(c.r, c.g, c.b, opacity);
+  fragColor = vec4(c.rgb * opacity, opacity);
 `
 
 const BANDS = ['prec', 'tavg', 'tavg_range', 'prec_range', 'weighted'] as const


### PR DESCRIPTION
The blend func has been premultiplied alpha (`gl.ONE, gl.ONE_MINUS_SRC_ALPHA`) since 0.4.3, but the `customFrag` examples still emit straight `vec4(c.rgb, opacity)`, so they render too bright at `opacity < 1` (correct at full opacity, which is why it went unnoticed).

Fixes both README examples and the demo to premultiply (`vec4(c.rgb * opacity, opacity)`), and adds a short note that `customFrag` owns its output and must premultiply.