### PR TITLE
Bump proj4js dep - CRS bug on rotated pole grids

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@developmentseed/raster-reproject": "^0.1.0",
     "delaunator": "^5.0.1",
-    "proj4": "^2.20.2",
+    "proj4": "^2.20.9",
     "zarrita": "^0.7.1"
   },
   "lint-staged": {


### PR DESCRIPTION
See https://github.com/proj4js/proj4js/pull/573, merged in [v.2.20.9 of proj4js](https://github.com/proj4js/proj4js/releases/tag/v2.20.9).

I ran into this as an issue when working on https://charles-turner-1.github.io/dwer-csi-streamer/view-data - viewport intersections were failing at higher zooms. Eventually figured out it was due to some mod(360) logic failures in that library.

This might not be a super common issue - I don't know how common rotated pole grids are - so if the pin makes life difficult for other reasons there might be a better way to deal with it? 

Love the project BTW! Thanks for all the great work!