### PR TITLE
break up region renderer into testable bits and add tests

### DIFF
--- a/.github/scripts/test-summary.mjs
+++ b/.github/scripts/test-summary.mjs
@@ -1,0 +1,97 @@
+/**
+ * Render vitest's JSON report as markdown for the Actions run summary.
+ *
+ * Usage: node .github/scripts/test-summary.mjs <report.json>
+ *
+ * Always exits 0 — the vitest step is what fails the job.
+ */
+
+import { readFileSync } from 'node:fs'
+
+const reportPath = process.argv[2]
+
+let report
+try {
+  report = JSON.parse(readFileSync(reportPath, 'utf8'))
+} catch (err) {
+  // Vitest died before writing a report (crash, OOM, bad config). Saying so
+  // beats reporting zero tests, which reads like a clean run.
+  process.stdout.write(
+    `### Tests\n\nNo test report was produced — vitest exited before writing \`${reportPath}\`.\n\n> ${err.message}\n`
+  )
+  process.exit(0)
+}
+
+const {
+  numTotalTests = 0,
+  numPassedTests = 0,
+  numFailedTests = 0,
+  numPendingTests = 0,
+  numTodoTests = 0,
+  testResults = [],
+  success,
+} = report
+
+const elapsed = (file) =>
+  Math.max(0, (file.endTime ?? 0) - (file.startTime ?? 0))
+const seconds = (ms) => `${(ms / 1000).toFixed(1)}s`
+const relative = (name) => name.replace(`${process.cwd()}/`, '')
+
+const skipped = numPendingTests + numTodoTests
+const duration = testResults.reduce((total, file) => total + elapsed(file), 0)
+
+const lines = [
+  `### ${success ? '✅' : '❌'} Tests`,
+  '',
+  `**${numPassedTests}/${numTotalTests} passed**` +
+    (numFailedTests ? ` · ${numFailedTests} failed` : '') +
+    (skipped ? ` · ${skipped} skipped` : '') +
+    ` · ${seconds(duration)} · ${testResults.length} files`,
+  '',
+]
+
+const failedFiles = testResults.filter((file) => file.status === 'failed')
+
+if (failedFiles.length) {
+  lines.push('| Test | File |', '| --- | --- |')
+  for (const file of failedFiles) {
+    const failures = (file.assertionResults ?? []).filter(
+      (assertion) => assertion.status === 'failed'
+    )
+    // An import-time throw fails the file without failing any single test.
+    if (!failures.length) {
+      lines.push(`| _suite failed to run_ | \`${relative(file.name)}\` |`)
+      continue
+    }
+    for (const failure of failures) {
+      const title = [...(failure.ancestorTitles ?? []), failure.title]
+        .filter(Boolean)
+        .join(' › ')
+      lines.push(
+        `| ${title.replace(/\|/g, '\\|')} | \`${relative(file.name)}\` |`
+      )
+    }
+  }
+  lines.push(
+    '',
+    'Failure output is annotated inline on the diff and printed in full in the job log.'
+  )
+} else {
+  const slowest = [...testResults]
+    .sort((a, b) => elapsed(b) - elapsed(a))
+    .slice(0, 5)
+  lines.push(
+    '<details><summary>Slowest files</summary>',
+    '',
+    '| File | Duration |',
+    '| --- | --- |',
+    ...slowest.map(
+      (file) => `| \`${relative(file.name)}\` | ${seconds(elapsed(file))} |`
+    ),
+    '',
+    '</details>'
+  )
+}
+
+lines.push('')
+process.stdout.write(lines.join('\n'))

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,26 +10,58 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  typecheck:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22.x
           cache: npm
       - run: npm ci
       - run: npm run typecheck
+
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+      - run: npm ci
       - run: npm run format:check
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+      - run: npm ci
       - name: Run tests
         run: npm run test:ci
       - name: Test summary
-        if: always() && matrix.node-version == '22.x'
+        if: always()
         run: node .github/scripts/test-summary.mjs test-results.json >> "$GITHUB_STEP_SUMMARY"
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+      - run: npm ci
+      - run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on: [push, pull_request]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run format:check
+      - name: Run tests
+        run: npm run test:ci
+      - name: Test summary
+        if: always() && matrix.node-version == '22.x'
+        run: node .github/scripts/test-summary.mjs test-results.json >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ demo/node_modules/
 demo/.next/
 demo/.env.local
 dist/
+test-results.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "maplibre-gl": "^5.15.0",
         "prettier": "^2.2.1",
         "tsup": "^8.5.0",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "vitest": "^3.2.4"
       },
       "peerDependencies": {
         "mapbox-gl": "*",
@@ -961,6 +962,24 @@
         "win32"
       ]
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/delaunator": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/delaunator/-/delaunator-5.0.3.tgz",
@@ -1021,6 +1040,121 @@
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@zarrita/storage": {
@@ -1095,6 +1229,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -1134,12 +1278,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cheap-ruler": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-4.0.0.tgz",
       "integrity": "sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -1249,6 +1420,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/delaunator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
@@ -1290,6 +1471,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.0",
@@ -1333,12 +1521,32 @@
         "@esbuild/win32-x64": "0.27.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1503,6 +1711,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-stringify-pretty-compact": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
@@ -1619,6 +1834,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1837,6 +2059,25 @@
         "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/numcodecs": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.2.tgz",
@@ -1878,6 +2119,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pbf": {
       "version": "4.0.1",
@@ -1945,6 +2196,35 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postcss-load-config": {
@@ -2160,6 +2440,13 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -2200,10 +2487,34 @@
         "node": ">= 12"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/splaytree": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
       "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2248,6 +2559,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/sucrase": {
@@ -2306,6 +2630,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -2330,12 +2661,42 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyqueue": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -2448,6 +2809,194 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wkt-parser": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "dev": "tsup --watch",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run typecheck && npm run build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky"
@@ -71,6 +73,7 @@
     "maplibre-gl": "^5.15.0",
     "prettier": "^2.2.1",
     "tsup": "^8.5.0",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:ci": "vitest run --reporter=default --reporter=github-actions --reporter=json --outputFile=test-results.json",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/src/__fixtures__/fake-gl.ts
+++ b/src/__fixtures__/fake-gl.ts
@@ -1,0 +1,231 @@
+/**
+ * @module __fixtures__/fake-gl
+ *
+ * A recording stand-in for WebGL2RenderingContext. Programs "compile" and
+ * "link" unconditionally; what the stub actually models is the one GL behavior
+ * the renderer's control flow depends on: which uniforms resolve to a location.
+ *
+ * A real driver reports a uniform as active only when it is declared AND
+ * reachable from main(), and the renderer leans on that — `matrixLoc`,
+ * `eyeMatrixLoc`, and `anchorClipLoc` are expected to come back null on the
+ * variants that don't use them, which is what makes their uploads no-op. The
+ * stub approximates the rule by looking for a declaration plus a reference
+ * outside it. It does not dead-code-eliminate, so a uniform referenced only
+ * from an uncalled function still resolves here (real GL may drop it); nothing
+ * in the renderer distinguishes the two cases, since every such upload is
+ * null-guarded.
+ */
+
+import { vi } from 'vitest'
+
+export interface UniformLocationStub {
+  name: string
+}
+
+/** Comments are not code: the uniform blocks document each other by name, and
+ *  a mention there must not read as a reference. */
+const stripComments = (source: string) =>
+  source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
+
+const isActiveUniform = (source: string, name: string): boolean => {
+  const code = stripComments(source)
+  const declaration = new RegExp(`uniform\\s+\\w+\\s+${name}\\s*;`)
+  if (!declaration.test(code)) return false
+  return new RegExp(`\\b${name}\\b`).test(code.replace(declaration, ''))
+}
+
+/** A MapLibre-shaped vertex prelude: declares the projection uniforms the
+ *  maplibre variants read and references them from projectTile(). */
+export const FAKE_MAPLIBRE_PRELUDE = `
+const float PI = 3.14159265358979323846;
+uniform mat4 u_projection_matrix;
+uniform mat4 u_projection_fallback_matrix;
+uniform vec4 u_projection_tile_mercator_coords;
+uniform vec4 u_projection_clipping_plane;
+uniform float u_projection_transition;
+vec4 projectTile(vec2 p) {
+  vec4 flat_pos = u_projection_fallback_matrix * vec4(p, 0.0, 1.0);
+  vec4 globe_pos = u_projection_matrix * vec4(p, 0.0, 1.0);
+  globe_pos.z += dot(u_projection_clipping_plane, u_projection_tile_mercator_coords);
+  return mix(flat_pos, globe_pos, u_projection_transition);
+}`
+
+export const FAKE_SHADER_DATA = {
+  vertexShaderPrelude: FAKE_MAPLIBRE_PRELUDE,
+  define: '#define ZARR_FAKE 1',
+  variantName: 'fake-variant',
+}
+
+export interface RecordedCall {
+  name: string
+  args: unknown[]
+}
+
+export interface RecordingGl extends WebGL2RenderingContext {
+  /** Every uniform/draw call in order, for assertions on what was uploaded. */
+  calls: RecordedCall[]
+  /** Vertex + fragment sources handed to each linked program. */
+  sourcesFor(program: WebGLProgram): { vertex: string; fragment: string }
+  /** Uniform names uploaded via any uniform*/
+  uploadedUniforms(): string[]
+  callsTo(name: string): RecordedCall[]
+}
+
+/**
+ * @param failTextures - make createTexture return null, to drive the
+ *   "region cannot be uploaded" branches.
+ */
+export function createRecordingGl({
+  failTextures = false,
+}: { failTextures?: boolean } = {}): RecordingGl {
+  const calls: RecordedCall[] = []
+  const record = (name: string, ...args: unknown[]) => {
+    calls.push({ name, args })
+  }
+
+  type ShaderStub = { type: number; source: string }
+  type ProgramStub = { shaders: ShaderStub[] }
+
+  const programSources = new Map<
+    ProgramStub,
+    { vertex: string; fragment: string }
+  >()
+  let textures = 0
+  let buffers = 0
+
+  const VERTEX_SHADER = 0x8b31
+  const FRAGMENT_SHADER = 0x8b30
+
+  const sourcesOf = (program: ProgramStub) => {
+    const cached = programSources.get(program)
+    if (cached) return cached
+    const resolved = {
+      vertex:
+        program.shaders.find((s) => s.type === VERTEX_SHADER)?.source ?? '',
+      fragment:
+        program.shaders.find((s) => s.type === FRAGMENT_SHADER)?.source ?? '',
+    }
+    programSources.set(program, resolved)
+    return resolved
+  }
+
+  const gl = {
+    // Constants the renderer reads off the context.
+    VERTEX_SHADER,
+    FRAGMENT_SHADER,
+    COMPILE_STATUS: 0x8b81,
+    LINK_STATUS: 0x8b82,
+    TEXTURE0: 0x84c0,
+    TEXTURE1: 0x84c1,
+    TEXTURE_2D: 0x0de1,
+    TEXTURE_MIN_FILTER: 0x2801,
+    TEXTURE_MAG_FILTER: 0x2800,
+    TEXTURE_WRAP_S: 0x2802,
+    TEXTURE_WRAP_T: 0x2803,
+    NEAREST: 0x2600,
+    LINEAR: 0x2601,
+    CLAMP_TO_EDGE: 0x812f,
+    ARRAY_BUFFER: 0x8892,
+    ELEMENT_ARRAY_BUFFER: 0x8893,
+    STATIC_DRAW: 0x88e4,
+    TRIANGLES: 0x0004,
+    TRIANGLE_STRIP: 0x0005,
+    UNSIGNED_INT: 0x1405,
+    FLOAT: 0x1406,
+    BLEND: 0x0be2,
+    ONE: 1,
+    ONE_MINUS_SRC_ALPHA: 0x0303,
+    RED: 0x1903,
+    RG: 0x8227,
+    RGB: 0x1907,
+    RGBA: 0x1908,
+    R32F: 0x822e,
+    RG32F: 0x8230,
+    RGB32F: 0x8815,
+    RGBA32F: 0x8814,
+    RGB16F: 0x881b,
+
+    getExtension: vi.fn(() => null),
+    drawBuffers: vi.fn(),
+
+    createShader: vi.fn((type: number) => ({ type, source: '' })),
+    shaderSource: vi.fn((shader: ShaderStub, source: string) => {
+      shader.source = source
+    }),
+    compileShader: vi.fn(),
+    getShaderParameter: vi.fn(() => true),
+    getShaderInfoLog: vi.fn(() => ''),
+    deleteShader: vi.fn(),
+
+    createProgram: vi.fn((): ProgramStub => ({ shaders: [] })),
+    attachShader: vi.fn((program: ProgramStub, shader: ShaderStub) => {
+      program.shaders.push(shader)
+    }),
+    linkProgram: vi.fn(),
+    getProgramParameter: vi.fn(() => true),
+    getProgramInfoLog: vi.fn(() => ''),
+    deleteProgram: vi.fn(),
+    useProgram: vi.fn(),
+
+    getUniformLocation: vi.fn(
+      (program: ProgramStub, name: string): UniformLocationStub | null => {
+        const { vertex, fragment } = sourcesOf(program)
+        return isActiveUniform(vertex, name) || isActiveUniform(fragment, name)
+          ? { name }
+          : null
+      }
+    ),
+    getAttribLocation: vi.fn((_program: ProgramStub, name: string) =>
+      name === 'vertex' ? 0 : 1
+    ),
+
+    uniform1i: vi.fn((loc: UniformLocationStub, v: number) =>
+      record('uniform1i', loc?.name, v)
+    ),
+    uniform1f: vi.fn((loc: UniformLocationStub, v: number) =>
+      record('uniform1f', loc?.name, v)
+    ),
+    uniform2f: vi.fn((loc: UniformLocationStub, a: number, b: number) =>
+      record('uniform2f', loc?.name, a, b)
+    ),
+    uniform4f: vi.fn((loc: UniformLocationStub, ...v: number[]) =>
+      record('uniform4f', loc?.name, ...v)
+    ),
+    uniformMatrix4fv: vi.fn(
+      (loc: UniformLocationStub, _transpose: boolean, value: Float32Array) =>
+        record('uniformMatrix4fv', loc?.name, value)
+    ),
+
+    createTexture: vi.fn(() => (failTextures ? null : { tex: ++textures })),
+    deleteTexture: vi.fn(),
+    bindTexture: vi.fn(),
+    activeTexture: vi.fn(),
+    texParameteri: vi.fn(),
+    texImage2D: vi.fn(),
+
+    createBuffer: vi.fn(() => ({ buf: ++buffers })),
+    deleteBuffer: vi.fn(),
+    bindBuffer: vi.fn(),
+    bufferData: vi.fn(),
+    enableVertexAttribArray: vi.fn(),
+    vertexAttribPointer: vi.fn(),
+
+    drawArrays: vi.fn((...args: unknown[]) => record('drawArrays', ...args)),
+    drawElements: vi.fn((...args: unknown[]) =>
+      record('drawElements', ...args)
+    ),
+
+    enable: vi.fn(),
+    blendFunc: vi.fn(),
+
+    calls,
+    callsTo: (name: string) => calls.filter((c) => c.name === name),
+    uploadedUniforms: () =>
+      calls
+        .filter((c) => c.name.startsWith('uniform'))
+        .map((c) => c.args[0] as string),
+    sourcesFor: (program: unknown) => sourcesOf(program as ProgramStub),
+  }
+
+  return gl as unknown as RecordingGl
+}

--- a/src/__fixtures__/geometry.ts
+++ b/src/__fixtures__/geometry.ts
@@ -1,0 +1,77 @@
+/**
+ * @module __fixtures__/geometry
+ *
+ * Reusable GeoJSON query-geometry fixtures. Coordinates are WGS84 lon/lat,
+ * matching the public query API.
+ */
+
+import type { GeoJSONPolygon, GeoJSONMultiPolygon } from '../query/types'
+
+/** Axis-aligned rectangle as a closed polygon ring (CCW). */
+export function rect(
+  west: number,
+  south: number,
+  east: number,
+  north: number
+): GeoJSONPolygon {
+  return {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [west, south],
+        [east, south],
+        [east, north],
+        [west, north],
+        [west, south],
+      ],
+    ],
+  }
+}
+
+/** A 0..20 square with a centered 5..15 square hole. */
+export const squareWithHole: GeoJSONPolygon = {
+  type: 'Polygon',
+  coordinates: [
+    [
+      [0, 0],
+      [20, 0],
+      [20, 20],
+      [0, 20],
+      [0, 0],
+    ],
+    [
+      [5, 5],
+      [15, 5],
+      [15, 15],
+      [5, 15],
+      [5, 5],
+    ],
+  ],
+}
+
+/** Two disjoint rectangles. */
+export const twoBoxes: GeoJSONMultiPolygon = {
+  type: 'MultiPolygon',
+  coordinates: [
+    rect(-150, -10, -140, 10).coordinates,
+    rect(140, -10, 150, 10).coordinates,
+  ],
+}
+
+/**
+ * Polygon that crosses the antimeridian, expressed with explicit out-of-range
+ * longitudes (170 → 190). After preprocessing this should be detected as
+ * crossing and clipped into a west strip (170..180) and east strip (-180..-170).
+ */
+export const antimeridianPolygon: GeoJSONPolygon = {
+  type: 'Polygon',
+  coordinates: [
+    [
+      [170, -10],
+      [190, -10],
+      [190, 10],
+      [170, 10],
+      [170, -10],
+    ],
+  ],
+}

--- a/src/__fixtures__/grids.ts
+++ b/src/__fixtures__/grids.ts
@@ -1,0 +1,34 @@
+/**
+ * @module __fixtures__/grids
+ *
+ * Synthetic raster fixtures for query/projection tests.
+ *
+ * `indexRamp` fills each pixel with its own row-major flat index, so a test
+ * can map a returned value back to the (x, y) pixel that produced it — the
+ * cleanest way to assert *which* pixels a query selected, independent of any
+ * coordinate transform.
+ */
+
+export interface Grid {
+  width: number
+  height: number
+  data: Float32Array
+}
+
+/** Row-major grid where `data[y * width + x] === y * width + x`. */
+export function indexRamp(width: number, height: number): Grid {
+  const data = new Float32Array(width * height)
+  for (let i = 0; i < data.length; i++) data[i] = i
+  return { width, height, data }
+}
+
+/** Grid filled with a single constant value. */
+export function constant(width: number, height: number, value: number): Grid {
+  const data = new Float32Array(width * height).fill(value)
+  return { width, height, data }
+}
+
+/** Convert a flat index (as produced by `indexRamp`) back to `[x, y]`. */
+export function indexToXY(index: number, width: number): [number, number] {
+  return [index % width, Math.floor(index / width)]
+}

--- a/src/__fixtures__/memory-zarr.ts
+++ b/src/__fixtures__/memory-zarr.ts
@@ -1,0 +1,97 @@
+/**
+ * @module __fixtures__/memory-zarr
+ *
+ * Builds an in-memory, zarrita-compatible Zarr v3 store from a declarative
+ * spec — no network, filesystem, or GL. The returned object implements the
+ * zarrita `Readable` interface (`get(key)`), so it can be passed to
+ * `new ZarrStore({ customStore })` to exercise the real metadata → description
+ * pipeline against frozen fixture bytes.
+ *
+ * Store keys use zarrita's leading-slash convention (`/zarr.json`,
+ * `/lat/zarr.json`, `/lat/c/0`). Arrays are written uncompressed with the v3
+ * `bytes` codec, so chunk bytes are just the raw little-endian typed-array
+ * buffer.
+ */
+
+export interface ArraySpec {
+  /** Array name / path segment (e.g. 'temperature', 'lat'). */
+  name: string
+  shape: number[]
+  chunkShape: number[]
+  /** Defaults to 'float32'. */
+  dtype?: 'float32' | 'float64'
+  fillValue?: number | null
+  dimensionNames?: string[]
+  /** Array-level attributes (e.g. scale_factor, add_offset). */
+  attributes?: Record<string, unknown>
+  /**
+   * Chunk data keyed by chunk index joined with '/' (matching the v3 default
+   * chunk-key encoding). A 1D array's only chunk is `'0'`; a 3D array's is
+   * `'0/0/0'`.
+   */
+  chunks?: Record<string, ArrayLike<number>>
+}
+
+export interface ZarrSpec {
+  /** Root group attributes (e.g. `multiscales`). */
+  attributes?: Record<string, unknown>
+  arrays: ArraySpec[]
+}
+
+const CHUNK_ENCODERS: Record<string, (data: ArrayLike<number>) => Uint8Array> =
+  {
+    float32: (data) => new Uint8Array(Float32Array.from(data).buffer),
+    float64: (data) => new Uint8Array(Float64Array.from(data).buffer),
+  }
+
+/** Minimal Readable shape; matches zarrita's `Readable` structurally. */
+export interface MemoryStore {
+  get(key: string): Promise<Uint8Array | undefined>
+}
+
+export function buildMemoryZarrStore(spec: ZarrSpec): MemoryStore {
+  const map = new Map<string, Uint8Array>()
+  const enc = new TextEncoder()
+  const writeJson = (key: string, value: unknown) =>
+    map.set(key, enc.encode(JSON.stringify(value)))
+
+  writeJson('/zarr.json', {
+    zarr_format: 3,
+    node_type: 'group',
+    attributes: spec.attributes ?? {},
+  })
+
+  for (const a of spec.arrays) {
+    const dtype = a.dtype ?? 'float32'
+    writeJson(`/${a.name}/zarr.json`, {
+      zarr_format: 3,
+      node_type: 'array',
+      shape: a.shape,
+      data_type: dtype,
+      chunk_grid: {
+        name: 'regular',
+        configuration: { chunk_shape: a.chunkShape },
+      },
+      chunk_key_encoding: {
+        name: 'default',
+        configuration: { separator: '/' },
+      },
+      codecs: [{ name: 'bytes', configuration: { endian: 'little' } }],
+      fill_value: a.fillValue ?? null,
+      dimension_names: a.dimensionNames,
+      attributes: a.attributes ?? {},
+    })
+
+    const encode = CHUNK_ENCODERS[dtype]
+    for (const [idx, data] of Object.entries(a.chunks ?? {})) {
+      map.set(`/${a.name}/c/${idx}`, encode(data))
+    }
+  }
+
+  return { get: async (key: string) => map.get(key) }
+}
+
+/** Build a row-major ramp [0, 1, ..., n-1] of the given length. */
+export function ramp(length: number): number[] {
+  return Array.from({ length }, (_, i) => i)
+}

--- a/src/colormap.test.ts
+++ b/src/colormap.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { ColormapState } from './colormap'
+
+// ColormapState.build() runs in the constructor and produces the CPU-side
+// representation (colors + Float32 texture data). GL upload is not exercised
+// here — it needs a WebGL context — but the data layout that the shader
+// samples is fully testable.
+
+describe('ColormapState build', () => {
+  it('parses hex colors and normalizes to [0, 1] float data', () => {
+    const cm = new ColormapState(['#ff0000', '#00ff00'])
+    expect(cm.length).toBe(2)
+    expect(cm.colors).toEqual([
+      [255, 0, 0],
+      [0, 255, 0],
+    ])
+    expect(Array.from(cm.floatData)).toEqual([1, 0, 0, 0, 1, 0])
+  })
+
+  it('scales 0-255 RGB triples down to [0, 1]', () => {
+    const cm = new ColormapState([
+      [255, 0, 0],
+      [0, 0, 0],
+    ])
+    expect(Array.from(cm.floatData)).toEqual([1, 0, 0, 0, 0, 0])
+  })
+
+  it('leaves already-normalized [0, 1] data unscaled', () => {
+    const cm = new ColormapState([
+      [1, 0, 0],
+      [0, 0, 1],
+    ])
+    expect(Array.from(cm.floatData)).toEqual([1, 0, 0, 0, 0, 1])
+  })
+
+  it('replaces the ramp via apply()', () => {
+    const cm = new ColormapState(['#ffffff'])
+    cm.apply(['#000000', '#ffffff'])
+    expect(cm.length).toBe(2)
+    expect(Array.from(cm.floatData)).toEqual([0, 0, 0, 1, 1, 1])
+  })
+
+  it('rejects invalid input', () => {
+    expect(() => new ColormapState([])).toThrow(/non-empty/)
+    expect(() => new ColormapState(['#ff' as string])).toThrow(
+      /Invalid hex color/
+    )
+    expect(() => new ColormapState([[1, 2] as unknown as number[]])).toThrow(
+      /\[r, g, b\]/
+    )
+  })
+})

--- a/src/decoded-chunk-cache.test.ts
+++ b/src/decoded-chunk-cache.test.ts
@@ -11,7 +11,11 @@ import { buildMemoryZarrStore, ramp } from './__fixtures__/memory-zarr'
 
 const CHUNK_BYTES = 4 * 4 * 4
 
-async function makeArray(opts: { maxEntries?: number; maxBytes?: number }) {
+async function makeArray(opts: {
+  maxEntries?: number
+  maxBytes?: number
+  minEntries?: number
+}) {
   const memory = buildMemoryZarrStore({
     arrays: [
       {
@@ -66,6 +70,7 @@ describe('withDecodedChunkCaching', () => {
     const { array, reads } = await makeArray({
       maxEntries: 512,
       maxBytes: CHUNK_BYTES * 2,
+      minEntries: 1,
     })
     await array.getChunk([0, 0])
     await array.getChunk([0, 1])
@@ -82,10 +87,34 @@ describe('withDecodedChunkCaching', () => {
   })
 
   it('keeps a chunk larger than the whole budget rather than caching nothing', async () => {
-    const { array, reads } = await makeArray({ maxBytes: 1 })
+    const { array, reads } = await makeArray({ maxBytes: 1, minEntries: 1 })
     await array.getChunk([0, 0])
     await array.getChunk([0, 0])
     expect(reads).toHaveLength(1)
+  })
+
+  it('holds the working set even when it exceeds the byte budget', async () => {
+    // Budget for one chunk, but four are in play. A cache smaller than the
+    // working set evicts chunks that are still being read, so the floor wins
+    // and every one of them stays resident.
+    const { array, reads } = await makeArray({
+      maxBytes: CHUNK_BYTES,
+      minEntries: 4,
+    })
+    for (const x of [0, 1, 2, 3]) await array.getChunk([0, x])
+    expect(reads).toHaveLength(4)
+
+    for (const x of [0, 1, 2, 3]) await array.getChunk([0, x])
+    expect(reads).toHaveLength(4)
+  })
+
+  it('defaults the floor to the region cache capacity', async () => {
+    // Four large chunks against a one-byte budget: the default floor is well
+    // above four, so nothing is evicted.
+    const { array, reads } = await makeArray({ maxBytes: 1 })
+    for (const x of [0, 1, 2, 3]) await array.getChunk([0, x])
+    for (const x of [0, 1, 2, 3]) await array.getChunk([0, x])
+    expect(reads).toHaveLength(4)
   })
 
   it('still honors the entry cap when chunks are small', async () => {
@@ -101,7 +130,10 @@ describe('withDecodedChunkCaching', () => {
   })
 
   it('refreshes recency on a cache hit', async () => {
-    const { array, reads } = await makeArray({ maxBytes: CHUNK_BYTES * 2 })
+    const { array, reads } = await makeArray({
+      maxBytes: CHUNK_BYTES * 2,
+      minEntries: 1,
+    })
     await array.getChunk([0, 0])
     await array.getChunk([0, 1])
     // Touch the oldest so the next insert evicts [0, 1] instead.

--- a/src/decoded-chunk-cache.test.ts
+++ b/src/decoded-chunk-cache.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import * as zarr from 'zarrita'
+import { withDecodedChunkCaching } from './decoded-chunk-cache'
+import { buildMemoryZarrStore, ramp } from './__fixtures__/memory-zarr'
+
+/**
+ * The cache is exercised through real zarrita reads against the in-memory
+ * fixture, counting store reads: a chunk served from cache issues no read, an
+ * evicted one issues another. Chunks here are 4x4 float32, so 64 bytes each.
+ */
+
+const CHUNK_BYTES = 4 * 4 * 4
+
+async function makeArray(opts: { maxEntries?: number; maxBytes?: number }) {
+  const memory = buildMemoryZarrStore({
+    arrays: [
+      {
+        name: 'temperature',
+        shape: [4, 16],
+        chunkShape: [4, 4],
+        dimensionNames: ['lat', 'lon'],
+        chunks: {
+          '0/0': ramp(16),
+          '0/1': ramp(16),
+          '0/2': ramp(16),
+          '0/3': ramp(16),
+        },
+      },
+    ],
+  })
+
+  const reads: string[] = []
+  const counting = {
+    get: async (key: string) => {
+      if (key.includes('/c/')) reads.push(key)
+      return memory.get(key)
+    },
+  }
+
+  const store = await zarr.extendStore(counting, (inner) =>
+    withDecodedChunkCaching(inner, opts)
+  )
+  const array = await zarr.open.v3(zarr.root(store).resolve('temperature'), {
+    kind: 'array',
+  })
+  return { array, reads }
+}
+
+describe('withDecodedChunkCaching', () => {
+  it('serves a repeated chunk read from cache', async () => {
+    const { array, reads } = await makeArray({})
+    await array.getChunk([0, 0])
+    await array.getChunk([0, 0])
+    expect(reads).toHaveLength(1)
+  })
+
+  it('shares one read between concurrent callers', async () => {
+    const { array, reads } = await makeArray({})
+    await Promise.all([array.getChunk([0, 0]), array.getChunk([0, 0])])
+    expect(reads).toHaveLength(1)
+  })
+
+  it('evicts by total bytes, not just entry count', async () => {
+    // Room for two chunks. The entry cap is far higher, so only the byte
+    // budget can force the eviction below.
+    const { array, reads } = await makeArray({
+      maxEntries: 512,
+      maxBytes: CHUNK_BYTES * 2,
+    })
+    await array.getChunk([0, 0])
+    await array.getChunk([0, 1])
+    await array.getChunk([0, 2])
+    expect(reads).toHaveLength(3)
+
+    // The oldest is gone, the two newest are still resident.
+    await array.getChunk([0, 1])
+    await array.getChunk([0, 2])
+    expect(reads).toHaveLength(3)
+
+    await array.getChunk([0, 0])
+    expect(reads).toHaveLength(4)
+  })
+
+  it('keeps a chunk larger than the whole budget rather than caching nothing', async () => {
+    const { array, reads } = await makeArray({ maxBytes: 1 })
+    await array.getChunk([0, 0])
+    await array.getChunk([0, 0])
+    expect(reads).toHaveLength(1)
+  })
+
+  it('still honors the entry cap when chunks are small', async () => {
+    const { array, reads } = await makeArray({
+      maxEntries: 2,
+      maxBytes: 1024 * 1024,
+    })
+    await array.getChunk([0, 0])
+    await array.getChunk([0, 1])
+    await array.getChunk([0, 2])
+    await array.getChunk([0, 0])
+    expect(reads).toHaveLength(4)
+  })
+
+  it('refreshes recency on a cache hit', async () => {
+    const { array, reads } = await makeArray({ maxBytes: CHUNK_BYTES * 2 })
+    await array.getChunk([0, 0])
+    await array.getChunk([0, 1])
+    // Touch the oldest so the next insert evicts [0, 1] instead.
+    await array.getChunk([0, 0])
+    await array.getChunk([0, 2])
+    expect(reads).toHaveLength(3)
+
+    await array.getChunk([0, 0])
+    expect(reads).toHaveLength(3)
+    await array.getChunk([0, 1])
+    expect(reads).toHaveLength(4)
+  })
+})

--- a/src/decoded-chunk-cache.test.ts
+++ b/src/decoded-chunk-cache.test.ts
@@ -11,11 +11,7 @@ import { buildMemoryZarrStore, ramp } from './__fixtures__/memory-zarr'
 
 const CHUNK_BYTES = 4 * 4 * 4
 
-async function makeArray(opts: {
-  maxEntries?: number
-  maxBytes?: number
-  minEntries?: number
-}) {
+async function makeArray(opts: { maxEntries?: number; maxBytes?: number }) {
   const memory = buildMemoryZarrStore({
     arrays: [
       {
@@ -58,6 +54,18 @@ describe('withDecodedChunkCaching', () => {
     expect(reads).toHaveLength(1)
   })
 
+  it('holds a viewport worth of ordinary chunks by default', async () => {
+    // The default budget has to clear the working set: one rendered region
+    // reads one chunk, so a cache below that turns panning and every selector
+    // change back into network reads.
+    const { array, reads } = await makeArray({})
+    for (const x of [0, 1, 2, 3]) await array.getChunk([0, x])
+    expect(reads).toHaveLength(4)
+
+    for (const x of [0, 1, 2, 3]) await array.getChunk([0, x])
+    expect(reads).toHaveLength(4)
+  })
+
   it('shares one read between concurrent callers', async () => {
     const { array, reads } = await makeArray({})
     await Promise.all([array.getChunk([0, 0]), array.getChunk([0, 0])])
@@ -70,7 +78,6 @@ describe('withDecodedChunkCaching', () => {
     const { array, reads } = await makeArray({
       maxEntries: 512,
       maxBytes: CHUNK_BYTES * 2,
-      minEntries: 1,
     })
     await array.getChunk([0, 0])
     await array.getChunk([0, 1])
@@ -87,34 +94,36 @@ describe('withDecodedChunkCaching', () => {
   })
 
   it('keeps a chunk larger than the whole budget rather than caching nothing', async () => {
-    const { array, reads } = await makeArray({ maxBytes: 1, minEntries: 1 })
+    const { array, reads } = await makeArray({ maxBytes: 1 })
     await array.getChunk([0, 0])
     await array.getChunk([0, 0])
     expect(reads).toHaveLength(1)
   })
 
-  it('holds the working set even when it exceeds the byte budget', async () => {
-    // Budget for one chunk, but four are in play. A cache smaller than the
-    // working set evicts chunks that are still being read, so the floor wins
-    // and every one of them stays resident.
-    const { array, reads } = await makeArray({
-      maxBytes: CHUNK_BYTES,
-      minEntries: 4,
-    })
+  it('never retains more than the byte budget', async () => {
+    // The budget is the hard bound: no entry floor keeps chunks resident past
+    // it, which is what would let a large chunk size retain gigabytes.
+    const { array, reads } = await makeArray({ maxBytes: CHUNK_BYTES })
     for (const x of [0, 1, 2, 3]) await array.getChunk([0, x])
     expect(reads).toHaveLength(4)
 
-    for (const x of [0, 1, 2, 3]) await array.getChunk([0, x])
-    expect(reads).toHaveLength(4)
+    // Only the newest survived, so every earlier chunk reads again.
+    for (const x of [0, 1, 2]) await array.getChunk([0, x])
+    expect(reads).toHaveLength(7)
   })
 
-  it('defaults the floor to the region cache capacity', async () => {
-    // Four large chunks against a one-byte budget: the default floor is well
-    // above four, so nothing is evicted.
+  it('serves in-flight readers from the shared fetch, not the cache', async () => {
+    // Awaiters resolve from the pending promise, so eviction between the
+    // fetch starting and finishing cannot break them. Worth pinning: it is
+    // the reason the byte bound needs no carve-out for active chunks.
     const { array, reads } = await makeArray({ maxBytes: 1 })
-    for (const x of [0, 1, 2, 3]) await array.getChunk([0, x])
-    for (const x of [0, 1, 2, 3]) await array.getChunk([0, x])
-    expect(reads).toHaveLength(4)
+    const [a, b] = await Promise.all([
+      array.getChunk([0, 0]),
+      array.getChunk([0, 0]),
+    ])
+    expect(reads).toHaveLength(1)
+    expect(a).toBe(b)
+    expect(Array.from(a.data as Float32Array)).toEqual(ramp(16))
   })
 
   it('still honors the entry cap when chunks are small', async () => {
@@ -130,10 +139,7 @@ describe('withDecodedChunkCaching', () => {
   })
 
   it('refreshes recency on a cache hit', async () => {
-    const { array, reads } = await makeArray({
-      maxBytes: CHUNK_BYTES * 2,
-      minEntries: 1,
-    })
+    const { array, reads } = await makeArray({ maxBytes: CHUNK_BYTES * 2 })
     await array.getChunk([0, 0])
     await array.getChunk([0, 1])
     // Touch the oldest so the next insert evicts [0, 1] instead.

--- a/src/decoded-chunk-cache.ts
+++ b/src/decoded-chunk-cache.ts
@@ -1,23 +1,48 @@
 import * as zarr from 'zarrita'
 
-/** Insertion-order LRU bounded by entry count. */
-const createLRU = <V>(maxEntries: number) => {
-  const store = new Map<string, V>()
+/**
+ * Insertion-order LRU bounded by entry count and by total bytes, whichever
+ * binds first. Chunk sizes vary by orders of magnitude between datasets (a 2D
+ * 128x128 float32 chunk is 65 KB; a 4D [2, 12, 128, 128] chunk is 1.5 MB), so
+ * a count-only bound would hold a quarter-gigabyte of the latter.
+ */
+const createLRU = <V>(
+  maxEntries: number,
+  maxBytes: number,
+  sizeOf: (value: V) => number
+) => {
+  const store = new Map<string, { value: V; bytes: number }>()
+  let totalBytes = 0
+
+  const drop = (key: string): void => {
+    const entry = store.get(key)
+    if (!entry) return
+    totalBytes -= entry.bytes
+    store.delete(key)
+  }
+
   return {
     get(key: string): V | undefined {
-      if (!store.has(key)) return undefined
-      const hit = store.get(key) as V
+      const entry = store.get(key)
+      if (!entry) return undefined
       store.delete(key)
-      store.set(key, hit)
-      return hit
+      store.set(key, entry)
+      return entry.value
     },
     set(key: string, value: V): void {
-      if (store.has(key)) store.delete(key)
-      store.set(key, value)
-      while (store.size > maxEntries) {
+      drop(key)
+      const bytes = sizeOf(value)
+      store.set(key, { value, bytes })
+      totalBytes += bytes
+      // Keep the most recent entry even when it alone exceeds the budget,
+      // so a dataset with very large chunks caches one instead of none.
+      while (
+        store.size > maxEntries ||
+        (totalBytes > maxBytes && store.size > 1)
+      ) {
         const oldest = store.keys().next().value
         if (oldest === undefined) break
-        store.delete(oldest)
+        drop(oldest)
       }
     },
   }
@@ -35,10 +60,18 @@ const createLRU = <V>(maxEntries: number) => {
  * extract into fresh arrays), which keeps the cache safe. Mutating a
  * cached chunk will corrupt every future read that hits the same key.
  *
- * Keyed on `(array.path, chunkCoords)`, per-store, count-bounded LRU.
+ * Keyed on `(array.path, chunkCoords)`, per-store, count- and byte-bounded LRU.
  */
 
 type AnyChunk = zarr.Chunk<zarr.DataType>
+
+/** Cap on decoded bytes held per store. */
+const DEFAULT_MAX_BYTES = 128 * 1024 * 1024
+
+const chunkBytes = (chunk: AnyChunk): number => {
+  const data = chunk.data as { byteLength?: number; length?: number }
+  return data?.byteLength ?? data?.length ?? 0
+}
 
 const chunkCacheKey = (path: string, coords: number[]): string =>
   `${path}\0${coords.join(',')}`
@@ -161,8 +194,12 @@ const decodedChunkExtension = zarr.defineArrayExtension(
  * field so `zarr.open` auto-applies it to every array.
  */
 export const withDecodedChunkCaching = zarr.defineStoreExtension(
-  (_inner, opts: { maxEntries?: number } = {}) => {
-    const cache = createLRU<AnyChunk>(opts.maxEntries ?? 512)
+  (_inner, opts: { maxEntries?: number; maxBytes?: number } = {}) => {
+    const cache = createLRU<AnyChunk>(
+      opts.maxEntries ?? 512,
+      opts.maxBytes ?? DEFAULT_MAX_BYTES,
+      chunkBytes
+    )
     const pending = new Map<string, PendingEntry>()
     return {
       arrayExtensions: [

--- a/src/decoded-chunk-cache.ts
+++ b/src/decoded-chunk-cache.ts
@@ -10,7 +10,6 @@ import { MAX_CACHED_REGIONS } from './region-cache'
 const createLRU = <V>(
   maxEntries: number,
   maxBytes: number,
-  minEntries: number,
   sizeOf: (value: V) => number
 ) => {
   const store = new Map<string, { value: V; bytes: number }>()
@@ -36,14 +35,11 @@ const createLRU = <V>(
       const bytes = sizeOf(value)
       store.set(key, { value, bytes })
       totalBytes += bytes
-      // The byte budget never shrinks the cache below the working set: a
-      // cache smaller than one viewport evicts chunks that are still being
-      // sliced, turning every selector change into a refetch storm. Holding
-      // the working set costs more memory than the budget asks for and is
-      // still bounded; thrashing it is not.
+      // Keep the most recent entry even when it alone exceeds the budget, so
+      // a dataset with very large chunks caches one instead of none.
       while (
         store.size > maxEntries ||
-        (totalBytes > maxBytes && store.size > minEntries)
+        (totalBytes > maxBytes && store.size > 1)
       ) {
         const oldest = store.keys().next().value
         if (oldest === undefined) break
@@ -70,15 +66,17 @@ const createLRU = <V>(
 
 type AnyChunk = zarr.Chunk<zarr.DataType>
 
-/** Soft cap on decoded bytes held per store, applied above the working set. */
-const DEFAULT_MAX_BYTES = 128 * 1024 * 1024
-
 /**
- * Chunks the byte budget will never evict. One rendered region reads one
- * chunk, so this mirrors the region cache's own cap: a smaller chunk cache
- * would evict chunks that regions still in flight are slicing.
+ * Hard cap on decoded bytes held per store.
+ *
+ * Sized so a full viewport still fits for ordinary chunk sizes: one rendered
+ * region reads one chunk, so the working set is up to `MAX_CACHED_REGIONS`
+ * chunks, and a cache below that turns every selector change back into
+ * network reads. Above ~2 MB per chunk the byte cap wins and re-reads start
+ * missing, which is the right trade: the alternative is an entry floor that
+ * would let a 50 MB chunk size retain gigabytes.
  */
-const DEFAULT_MIN_ENTRIES = MAX_CACHED_REGIONS
+const DEFAULT_MAX_BYTES = 2 * 1024 * 1024 * MAX_CACHED_REGIONS
 
 const chunkBytes = (chunk: AnyChunk): number => {
   const data = chunk.data as { byteLength?: number; length?: number }
@@ -211,13 +209,11 @@ export const withDecodedChunkCaching = zarr.defineStoreExtension(
     opts: {
       maxEntries?: number
       maxBytes?: number
-      minEntries?: number
     } = {}
   ) => {
     const cache = createLRU<AnyChunk>(
       opts.maxEntries ?? 512,
       opts.maxBytes ?? DEFAULT_MAX_BYTES,
-      opts.minEntries ?? DEFAULT_MIN_ENTRIES,
       chunkBytes
     )
     const pending = new Map<string, PendingEntry>()

--- a/src/decoded-chunk-cache.ts
+++ b/src/decoded-chunk-cache.ts
@@ -1,4 +1,5 @@
 import * as zarr from 'zarrita'
+import { MAX_CACHED_REGIONS } from './region-cache'
 
 /**
  * Insertion-order LRU bounded by entry count and by total bytes, whichever
@@ -9,6 +10,7 @@ import * as zarr from 'zarrita'
 const createLRU = <V>(
   maxEntries: number,
   maxBytes: number,
+  minEntries: number,
   sizeOf: (value: V) => number
 ) => {
   const store = new Map<string, { value: V; bytes: number }>()
@@ -34,11 +36,14 @@ const createLRU = <V>(
       const bytes = sizeOf(value)
       store.set(key, { value, bytes })
       totalBytes += bytes
-      // Keep the most recent entry even when it alone exceeds the budget,
-      // so a dataset with very large chunks caches one instead of none.
+      // The byte budget never shrinks the cache below the working set: a
+      // cache smaller than one viewport evicts chunks that are still being
+      // sliced, turning every selector change into a refetch storm. Holding
+      // the working set costs more memory than the budget asks for and is
+      // still bounded; thrashing it is not.
       while (
         store.size > maxEntries ||
-        (totalBytes > maxBytes && store.size > 1)
+        (totalBytes > maxBytes && store.size > minEntries)
       ) {
         const oldest = store.keys().next().value
         if (oldest === undefined) break
@@ -65,8 +70,15 @@ const createLRU = <V>(
 
 type AnyChunk = zarr.Chunk<zarr.DataType>
 
-/** Cap on decoded bytes held per store. */
+/** Soft cap on decoded bytes held per store, applied above the working set. */
 const DEFAULT_MAX_BYTES = 128 * 1024 * 1024
+
+/**
+ * Chunks the byte budget will never evict. One rendered region reads one
+ * chunk, so this mirrors the region cache's own cap: a smaller chunk cache
+ * would evict chunks that regions still in flight are slicing.
+ */
+const DEFAULT_MIN_ENTRIES = MAX_CACHED_REGIONS
 
 const chunkBytes = (chunk: AnyChunk): number => {
   const data = chunk.data as { byteLength?: number; length?: number }
@@ -194,10 +206,18 @@ const decodedChunkExtension = zarr.defineArrayExtension(
  * field so `zarr.open` auto-applies it to every array.
  */
 export const withDecodedChunkCaching = zarr.defineStoreExtension(
-  (_inner, opts: { maxEntries?: number; maxBytes?: number } = {}) => {
+  (
+    _inner,
+    opts: {
+      maxEntries?: number
+      maxBytes?: number
+      minEntries?: number
+    } = {}
+  ) => {
     const cache = createLRU<AnyChunk>(
       opts.maxEntries ?? 512,
       opts.maxBytes ?? DEFAULT_MAX_BYTES,
+      opts.minEntries ?? DEFAULT_MIN_ENTRIES,
       chunkBytes
     )
     const pending = new Map<string, PendingEntry>()

--- a/src/decoded-chunk-cache.ts
+++ b/src/decoded-chunk-cache.ts
@@ -5,7 +5,7 @@ import { MAX_CACHED_REGIONS } from './region-cache'
  * Insertion-order LRU bounded by entry count and by total bytes, whichever
  * binds first. Chunk sizes vary by orders of magnitude between datasets (a 2D
  * 128x128 float32 chunk is 65 KB; a 4D [2, 12, 128, 128] chunk is 1.5 MB), so
- * a count-only bound would hold a quarter-gigabyte of the latter.
+ * a count-only bound would hold 768 MB of the latter at the 512-entry default.
  */
 const createLRU = <V>(
   maxEntries: number,

--- a/src/level-loader.test.ts
+++ b/src/level-loader.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi } from 'vitest'
+import { LevelLoader, type LevelLoaderContext } from './level-loader'
+import type { NormalizedSelector } from './types'
+import type * as zarr from 'zarrita'
+
+/**
+ * Race tests for the level-load state machine: dedupe, token-based
+ * supersession, selector atomicity, and dispose. The context's `resolveArray`
+ * is gated on per-call deferreds so each test controls exactly when a load's
+ * async work completes relative to competing calls.
+ */
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (err: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+type Resolved = {
+  zarrArray: zarr.Array<zarr.DataType>
+  width: number
+  height: number
+  regionSize: [number, number]
+  reusedArray: boolean
+}
+
+function makeHarness(
+  opts: { isMultiscale?: boolean; levelCount?: number } = {}
+) {
+  const { isMultiscale = true, levelCount = 3 } = opts
+  const gates: Array<ReturnType<typeof deferred<void>>> = []
+  let selector: NormalizedSelector = {}
+  const calls = {
+    resolveArray: [] as Array<{ levelIndex: number; reuse: boolean }>,
+    cancels: 0,
+    commits: 0,
+    invalidates: 0,
+  }
+
+  const context: LevelLoaderContext = {
+    isMultiscale: () => isMultiscale,
+    getLevelCount: () => (isMultiscale ? levelCount : 0),
+    resolveArray: async (levelIndex, reuse) => {
+      calls.resolveArray.push({ levelIndex, reuse })
+      const gate = deferred<void>()
+      gates.push(gate)
+      await gate.promise
+      return {
+        zarrArray: { shape: [10, 20] } as unknown as zarr.Array<zarr.DataType>,
+        width: 20,
+        height: 10,
+        regionSize: [5, 5],
+        reusedArray: reuse,
+      } satisfies Resolved
+    },
+    buildSliceArgs: async () => ({
+      baseSliceArgs: [0, 0],
+      baseMultiValueDims: [],
+    }),
+    getSelector: () => selector,
+    isRemoved: () => false,
+    onCancelInflight: () => {
+      calls.cancels++
+    },
+    onNewArrayCommitted: () => {
+      calls.commits++
+    },
+    invalidate: () => {
+      calls.invalidates++
+    },
+    getAssetLabel: (levelIndex) => String(levelIndex),
+  }
+
+  const loader = new LevelLoader(context)
+  return {
+    loader,
+    calls,
+    gates,
+    setSelector: (next: NormalizedSelector) => {
+      selector = next
+    },
+  }
+}
+
+describe('LevelLoader.loadLevel', () => {
+  it('commits an atomic level runtime', async () => {
+    const { loader, gates } = makeHarness()
+    loader.desiredIndex = 1
+    const load = loader.loadLevel(1)
+    expect(loader.active).toBeNull()
+    expect(loader.loadingIndex).toBe(1)
+    gates[0].resolve()
+    await load
+
+    expect(loader.active).toMatchObject({
+      index: 1,
+      width: 20,
+      height: 10,
+      regionSize: [5, 5],
+    })
+    expect(loader.loadingIndex).toBeNull()
+  })
+
+  it('dedupes loads for the target already in flight', async () => {
+    const { loader, calls, gates } = makeHarness()
+    loader.desiredIndex = 1
+    const first = loader.loadLevel(1)
+    // Per-frame update() calls must not restart the in-flight load.
+    const second = loader.loadLevel(1)
+    const third = loader.loadLevel(1)
+    gates[0].resolve()
+    await Promise.all([first, second, third])
+
+    expect(calls.resolveArray).toHaveLength(1)
+    expect(loader.active?.index).toBe(1)
+  })
+
+  it('rejects out-of-range targets without touching state', async () => {
+    const { loader, calls } = makeHarness({ levelCount: 3 })
+    await loader.loadLevel(5)
+    await loader.loadLevel(-1)
+    expect(calls.resolveArray).toHaveLength(0)
+    expect(loader.loadingIndex).toBeNull()
+  })
+
+  it('only loads level 0 for single-level datasets', async () => {
+    const { loader, calls, gates } = makeHarness({ isMultiscale: false })
+    await loader.loadLevel(2)
+    expect(calls.resolveArray).toHaveLength(0)
+    const load = loader.loadLevel(0)
+    gates[0].resolve()
+    await load
+    expect(loader.active?.index).toBe(0)
+  })
+
+  it('drops a superseded load at the commit guard (token bump)', async () => {
+    const { loader, gates } = makeHarness()
+    loader.desiredIndex = 1
+    const first = loader.loadLevel(1)
+    // A selector rebuild for the same level supersedes via reuseArray.
+    const second = loader.loadLevel(1, { reuseArray: true })
+    // Resolve the FIRST load; its token is stale so the commit must drop.
+    gates[0].resolve()
+    await first
+    expect(loader.active).toBeNull()
+
+    gates[1].resolve()
+    await second
+    expect(loader.active?.index).toBe(1)
+  })
+
+  it('drops the commit when the selector changed mid-load', async () => {
+    const { loader, gates, setSelector } = makeHarness()
+    loader.desiredIndex = 1
+    const load = loader.loadLevel(1)
+    setSelector({ month: { selected: 6, type: 'value' } })
+    gates[0].resolve()
+    await load
+    expect(loader.active).toBeNull()
+  })
+
+  it('drops the commit when the zoom target moved on', async () => {
+    const { loader, gates } = makeHarness()
+    loader.desiredIndex = 1
+    const load = loader.loadLevel(1)
+    loader.desiredIndex = 2
+    gates[0].resolve()
+    await load
+    expect(loader.active).toBeNull()
+  })
+
+  it('reuseArray commits even when the desired index moved (selector rebuild)', async () => {
+    const { loader, gates } = makeHarness()
+    loader.desiredIndex = 1
+    const first = loader.loadLevel(1)
+    gates[0].resolve()
+    await first
+
+    loader.desiredIndex = 2
+    const rebuild = loader.loadLevel(1, { reuseArray: true })
+    gates[1].resolve()
+    await rebuild
+    expect(loader.active?.index).toBe(1)
+  })
+
+  it('signals cache reset only when a new array was fetched', async () => {
+    const { loader, calls, gates } = makeHarness()
+    loader.desiredIndex = 1
+    const first = loader.loadLevel(1)
+    gates[0].resolve()
+    await first
+    expect(calls.commits).toBe(1)
+
+    const rebuild = loader.loadLevel(1, { reuseArray: true })
+    gates[1].resolve()
+    await rebuild
+    // resolveArray reported reusedArray: true -> no cache reset.
+    expect(calls.commits).toBe(1)
+    expect(calls.resolveArray[1]).toEqual({ levelIndex: 1, reuse: true })
+  })
+
+  it('cancels in-flight region fetches at the start of every load', async () => {
+    const { loader, calls, gates } = makeHarness()
+    loader.desiredIndex = 1
+    const load = loader.loadLevel(1)
+    gates[0].resolve()
+    await load
+    expect(calls.cancels).toBe(1)
+  })
+
+  it('dispose during a load drops the commit and clears state', async () => {
+    const { loader, gates } = makeHarness()
+    loader.desiredIndex = 1
+    const load = loader.loadLevel(1)
+    loader.dispose()
+    gates[0].resolve()
+    await load
+    expect(loader.active).toBeNull()
+    expect(loader.loadingIndex).toBeNull()
+  })
+
+  it('a stale load does not clobber the newer load state', async () => {
+    const { loader, gates } = makeHarness()
+    loader.desiredIndex = 1
+    const first = loader.loadLevel(1)
+    loader.desiredIndex = 2
+    const second = loader.loadLevel(2)
+    expect(loader.loadingIndex).toBe(2)
+
+    // The stale first load finishing must not null the newer loadingIndex.
+    gates[0].resolve()
+    await first
+    expect(loader.loadingIndex).toBe(2)
+
+    gates[1].resolve()
+    await second
+    expect(loader.active?.index).toBe(2)
+    expect(loader.loadingIndex).toBeNull()
+  })
+
+  it('logs errors only for the load that still owns the token', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const { loader, gates } = makeHarness()
+      loader.desiredIndex = 1
+      const first = loader.loadLevel(1)
+      const second = loader.loadLevel(1, { reuseArray: true })
+
+      // Stale load fails: silent.
+      gates[0].reject(new Error('network down'))
+      await first
+      expect(errorSpy).not.toHaveBeenCalled()
+
+      // Current load fails: logged.
+      gates[1].reject(new Error('network down'))
+      await second
+      expect(errorSpy).toHaveBeenCalledTimes(1)
+      expect(loader.loadingIndex).toBeNull()
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+})

--- a/src/level-loader.ts
+++ b/src/level-loader.ts
@@ -1,0 +1,150 @@
+import type * as zarr from 'zarrita'
+import type { LevelRuntime } from './region-state'
+import type { NormalizedSelector } from './types'
+
+type ResolvedLevel = Pick<
+  LevelRuntime,
+  'zarrArray' | 'width' | 'height' | 'regionSize'
+> & { reusedArray: boolean }
+
+export type LevelLoaderContext = {
+  isMultiscale: () => boolean
+  getLevelCount: () => number
+  resolveArray: (levelIndex: number, reuse: boolean) => Promise<ResolvedLevel>
+  buildSliceArgs: (
+    selector: NormalizedSelector,
+    array: zarr.Array<zarr.DataType>,
+    coordLevelIndex: number
+  ) => Promise<Pick<LevelRuntime, 'baseSliceArgs' | 'baseMultiValueDims'>>
+  getSelector: () => NormalizedSelector
+  isRemoved: () => boolean
+  onCancelInflight: () => void
+  onNewArrayCommitted: () => void
+  invalidate: () => void
+  getAssetLabel: (levelIndex: number) => string
+}
+
+export class LevelLoader {
+  private loadToken = 0
+  private desiredLevelIndex = 0
+  private loadingLevelIndex: number | null = null
+  private activeLevel: LevelRuntime | null = null
+
+  constructor(private context: LevelLoaderContext) {}
+
+  get active(): LevelRuntime | null {
+    return this.activeLevel
+  }
+  get desiredIndex(): number {
+    return this.desiredLevelIndex
+  }
+  set desiredIndex(levelIndex: number) {
+    this.desiredLevelIndex = levelIndex
+  }
+  get loadingIndex(): number | null {
+    return this.loadingLevelIndex
+  }
+
+  /**
+   * Unified level load: handles initial load, zoom-driven switch, and
+   * selector-driven slice-args rebuild. Builds a `LevelRuntime` off to
+   * the side and swaps it into `activeLevel` atomically, so readers
+   * never see a half-committed level.
+   *
+   * `reuseArray` reuses the current committed array/dims — used by
+   * `setSelector` to rebuild slice args without refetching. `loadToken`
+   * acts as a cancellation token: any load whose token is stale at
+   * commit time drops its result.
+   */
+  async loadLevel(
+    levelIndex: number,
+    { reuseArray = false }: { reuseArray?: boolean } = {}
+  ): Promise<void> {
+    if (this.context.isMultiscale() && this.context.getLevelCount() > 0) {
+      if (levelIndex < 0 || levelIndex >= this.context.getLevelCount()) return
+    } else if (levelIndex !== 0) {
+      return
+    }
+
+    // Dedupe: an in-flight load for the same target is already on it.
+    // A selector rebuild (`reuseArray`) intentionally supersedes.
+    if (this.loadingLevelIndex === levelIndex && !reuseArray) return
+
+    const token = ++this.loadToken
+    // Snapshot the selector so we can detect a concurrent `setSelector`
+    // that arrived after `buildSliceArgsForSelector` resolved; committing
+    // old slice args with a new selector would leak stale data.
+    const selectorSnapshot = this.context.getSelector()
+    this.loadingLevelIndex = levelIndex
+
+    // Cancel any in-flight region fetches — they were tied to the old
+    // level's array/dims (or old selector) and can't be reused.
+    this.context.onCancelInflight()
+
+    try {
+      const resolved = await this.context.resolveArray(levelIndex, reuseArray)
+      const coordLevelIndex =
+        this.activeLevel?.index ??
+        this.loadingLevelIndex ??
+        this.desiredLevelIndex ??
+        0
+      const { baseSliceArgs, baseMultiValueDims } =
+        await this.context.buildSliceArgs(
+          selectorSnapshot,
+          resolved.zarrArray,
+          coordLevelIndex
+        )
+      const targetStillDesired =
+        reuseArray ||
+        !this.context.isMultiscale() ||
+        levelIndex === this.desiredLevelIndex
+
+      // Drop on the floor if anything raced past us: a newer load (or
+      // dispose) bumped the token, the zoom target moved on, or
+      // `setSelector` replaced the selector we built slice args against.
+      if (
+        token !== this.loadToken ||
+        this.context.isRemoved() ||
+        this.context.getSelector() !== selectorSnapshot ||
+        !targetStillDesired
+      ) {
+        this.context.invalidate()
+        return
+      }
+
+      // Atomic commit — one reference swap replaces all per-level state.
+      this.activeLevel = {
+        index: levelIndex,
+        zarrArray: resolved.zarrArray,
+        width: resolved.width,
+        height: resolved.height,
+        regionSize: resolved.regionSize,
+        baseSliceArgs,
+        baseMultiValueDims,
+      }
+
+      // Don't clear the region cache on level changes — older-level
+      // regions serve as fallback rendering while the new level's
+      // regions load, and the LRU disposes them properly once they're no
+      // longer protected. Bare `.clear()` here would leak WebGL resources.
+      if (!resolved.reusedArray) this.context.onNewArrayCommitted()
+      this.context.invalidate()
+    } catch (err) {
+      if (token === this.loadToken) {
+        console.error(
+          `Failed to load level ${this.context.getAssetLabel(levelIndex)}:`,
+          err
+        )
+      }
+    } finally {
+      if (token === this.loadToken) this.loadingLevelIndex = null
+    }
+  }
+
+  dispose(): void {
+    // Bump so any pending `loadLevel` drops its result on commit.
+    this.loadToken++
+    this.loadingLevelIndex = null
+    this.activeLevel = null
+  }
+}

--- a/src/map-utils.projection.test.ts
+++ b/src/map-utils.projection.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeWorldOffsets,
+  isGlobeProjection,
+  resolveProjectionParams,
+} from './map-utils'
+import { MAPBOX_IDENTITY_MATRIX } from './mapbox-utils'
+import type { MapLike } from './types'
+
+/**
+ * `resolveProjectionParams` is the single funnel that turns a render callback's
+ * arguments into the renderer's projection state, and the two map libraries
+ * call it with completely different shapes:
+ *
+ *   MapLibre  render(gl, args)          — args.shaderData + args.defaultProjectionData
+ *   Mapbox    render(gl, matrix)        — mercator: a bare 16-float matrix
+ *   Mapbox    render(gl, matrix, projection, toMercMatrix, transition) — globe
+ *
+ * Whether the result carries a `mapbox` block is what decides the whole shader
+ * family downstream (see resolveProjectionMode), so provider detection failing
+ * silently would put a MapLibre map on Mapbox shaders and render nothing.
+ */
+
+const MATRIX = Array.from({ length: 16 }, (_, i) => i)
+
+const maplibreParams = (projectionTransition: number) => ({
+  shaderData: {
+    vertexShaderPrelude: '// prelude',
+    define: '#define X 1',
+    variantName: 'globe',
+  },
+  defaultProjectionData: {
+    mainMatrix: MATRIX,
+    fallbackMatrix: MATRIX,
+    tileMercatorCoords: [0, 0, 1, 1],
+    clippingPlane: [0, 0, 1, 0],
+    projectionTransition,
+  },
+})
+
+describe('isGlobeProjection', () => {
+  it('reads the globe flag off either library’s projection object', () => {
+    // Mapbox reports `name`, MapLibre reports `type`.
+    expect(isGlobeProjection({ name: 'globe' })).toBe(true)
+    expect(isGlobeProjection({ type: 'globe' })).toBe(true)
+    expect(isGlobeProjection({ name: 'mercator' })).toBe(false)
+    expect(isGlobeProjection({ type: 'mercator' })).toBe(false)
+  })
+
+  it('treats a missing projection as not-globe', () => {
+    expect(isGlobeProjection(null)).toBe(false)
+    expect(isGlobeProjection(undefined)).toBe(false)
+    expect(isGlobeProjection({})).toBe(false)
+  })
+})
+
+describe('resolveProjectionParams — MapLibre', () => {
+  it('takes the matrix and projection data from the params object', () => {
+    const resolved = resolveProjectionParams(maplibreParams(0))
+
+    expect(resolved.matrix).toBe(MATRIX)
+    expect(resolved.shaderData?.variantName).toBe('globe')
+    expect(resolved.projectionData?.projectionTransition).toBe(0)
+  })
+
+  it('never produces a mapbox block, in mercator or globe', () => {
+    // The mapbox block is the provider discriminator downstream; a MapLibre
+    // frame acquiring one would select the Mapbox shader family.
+    expect(resolveProjectionParams(maplibreParams(0)).mapbox).toBeUndefined()
+    expect(resolveProjectionParams(maplibreParams(1)).mapbox).toBeUndefined()
+  })
+
+  it('carries the globe transition through, which is what activates ECEF', () => {
+    expect(
+      resolveProjectionParams(maplibreParams(0.42)).projectionData
+        ?.projectionTransition
+    ).toBe(0.42)
+  })
+
+  it('drops projection data that is missing any field it needs', () => {
+    const params = maplibreParams(1) as {
+      defaultProjectionData: Record<string, unknown>
+    }
+    delete params.defaultProjectionData.clippingPlane
+
+    const resolved = resolveProjectionParams(params)
+
+    // A partially-populated block would upload garbage clipping planes, so it
+    // is refused wholesale rather than filled in.
+    expect(resolved.projectionData).toBeUndefined()
+    expect(resolved.matrix).toBeNull()
+  })
+
+  it('falls back to a legacy matrix-carrying params object', () => {
+    expect(
+      resolveProjectionParams({ modelViewProjectionMatrix: MATRIX }).matrix
+    ).toBe(MATRIX)
+    expect(resolveProjectionParams({ projectionMatrix: MATRIX }).matrix).toBe(
+      MATRIX
+    )
+  })
+
+  it('reports no matrix when params carry none, so render can bail', () => {
+    expect(resolveProjectionParams({}).matrix).toBeNull()
+    expect(resolveProjectionParams(undefined).matrix).toBeNull()
+  })
+})
+
+describe('resolveProjectionParams — Mapbox', () => {
+  it('treats a bare matrix as mapbox mercator', () => {
+    const matrix = new Float64Array(MATRIX)
+
+    const resolved = resolveProjectionParams(matrix)
+
+    expect(resolved.matrix).toBe(matrix)
+    expect(resolved.mapbox?.projection).toEqual({ name: 'mercator' })
+    // Mercator is the transition=1 endpoint of the globe shader's blend, with
+    // an identity globe->mercator matrix.
+    expect(resolved.mapbox?.transition).toBe(1)
+    expect(resolved.mapbox?.globeToMercatorMatrix).toBe(MAPBOX_IDENTITY_MATRIX)
+    expect(resolved.projectionData).toBeUndefined()
+  })
+
+  it('detects mapbox from a plain-array matrix too', () => {
+    expect(resolveProjectionParams(MATRIX).mapbox?.projection.name).toBe(
+      'mercator'
+    )
+  })
+
+  it('carries the globe morph arguments through', () => {
+    const globeToMerc = new Float32Array(MATRIX)
+
+    const resolved = resolveProjectionParams(
+      MATRIX,
+      { name: 'globe' },
+      globeToMerc,
+      0.37
+    )
+
+    expect(resolved.mapbox?.projection).toEqual({ name: 'globe' })
+    expect(resolved.mapbox?.globeToMercatorMatrix).toBe(globeToMerc)
+    expect(resolved.mapbox?.transition).toBe(0.37)
+  })
+
+  it('keeps transition 0 rather than defaulting it to mercator', () => {
+    // 0 is the fully-globe endpoint. Treating it as absent would flatten the
+    // globe to mercator for the whole low-zoom range.
+    expect(
+      resolveProjectionParams(MATRIX, { name: 'globe' }, MATRIX, 0).mapbox
+        ?.transition
+    ).toBe(0)
+  })
+
+  it('is detected from the projection argument even without a matrix', () => {
+    expect(
+      resolveProjectionParams(undefined, { name: 'globe' }).mapbox?.projection
+        .name
+    ).toBe('globe')
+  })
+})
+
+describe('computeWorldOffsets', () => {
+  const mapSpanning = (
+    west: number,
+    east: number,
+    renderWorldCopies = true
+  ): MapLike => ({
+    getBounds: () => ({
+      getWest: () => west,
+      getEast: () => east,
+      toArray: () => [
+        [west, -85],
+        [east, 85],
+      ],
+    }),
+    getRenderWorldCopies: () => renderWorldCopies,
+  })
+
+  it('draws a single copy on the globe', () => {
+    // The globe has no world copies; drawing at ±1 would stack duplicate
+    // geometry on the same sphere.
+    expect(computeWorldOffsets(mapSpanning(-180, 180), true)).toEqual([0])
+    expect(computeWorldOffsets(mapSpanning(-200, 200), true)).toEqual([0])
+  })
+
+  it('draws a single copy when the map disables world copies', () => {
+    expect(computeWorldOffsets(mapSpanning(-200, 200, false), false)).toEqual([
+      0,
+    ])
+  })
+
+  it('draws one copy for a mercator viewport inside a single world', () => {
+    expect(computeWorldOffsets(mapSpanning(-50, 50), false)).toEqual([0])
+  })
+
+  it('draws both copies when a mercator viewport crosses a world seam', () => {
+    expect(computeWorldOffsets(mapSpanning(100, 260), false)).toEqual([0, 1])
+  })
+
+  it('follows the viewport into a far world copy', () => {
+    // Panning east repeatedly keeps unwrapping the bounds; the offsets have to
+    // track it or the data stops drawing after a few wraps.
+    expect(computeWorldOffsets(mapSpanning(900, 1000), false)).toEqual([3])
+  })
+
+  it('handles bounds reported wrapped across the antimeridian', () => {
+    // getBounds() can report west > east when the viewport straddles ±180.
+    expect(computeWorldOffsets(mapSpanning(170, -170), false)).toEqual([0, 1])
+  })
+
+  it('covers a viewport wider than one world', () => {
+    expect(computeWorldOffsets(mapSpanning(-400, 400), false)).toEqual([
+      -1, 0, 1,
+    ])
+  })
+
+  it('falls back to one copy without a map or bounds', () => {
+    expect(computeWorldOffsets(null, false)).toEqual([0])
+    expect(computeWorldOffsets({ getBounds: () => null }, false)).toEqual([0])
+  })
+
+  it('assumes world copies when the map does not expose the setting', () => {
+    const { getBounds } = mapSpanning(100, 260)
+    expect(computeWorldOffsets({ getBounds }, false)).toEqual([0, 1])
+  })
+})

--- a/src/map-utils.test.ts
+++ b/src/map-utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { latToMercatorNorm, boundsToMercatorNorm } from './map-utils'
+import { MERCATOR_LAT_LIMIT } from './constants'
+
+describe('latToMercatorNorm', () => {
+  it('puts the equator at Y=0.5 with north at the top', () => {
+    expect(latToMercatorNorm(0)).toBeCloseTo(0.5, 12)
+    // The mercator latitude limit is defined as the lat where Y reaches the edge.
+    expect(latToMercatorNorm(MERCATOR_LAT_LIMIT)).toBeCloseTo(0, 6)
+    expect(latToMercatorNorm(-MERCATOR_LAT_LIMIT)).toBeCloseTo(1, 6)
+    // Northern latitudes sit above the equator (smaller Y).
+    expect(latToMercatorNorm(45)).toBeLessThan(0.5)
+  })
+
+  it('clamps latitude to the mercator limit', () => {
+    expect(latToMercatorNorm(89)).toBeCloseTo(
+      latToMercatorNorm(MERCATOR_LAT_LIMIT),
+      12
+    )
+    expect(latToMercatorNorm(-89)).toBeCloseTo(
+      latToMercatorNorm(-MERCATOR_LAT_LIMIT),
+      12
+    )
+  })
+})
+
+describe('boundsToMercatorNorm', () => {
+  it('maps full-world EPSG:3857 bounds to the unit square', () => {
+    const E = 20037508.342789244
+    expect(
+      boundsToMercatorNorm(
+        { xMin: -E, xMax: E, yMin: -E, yMax: E },
+        'EPSG:3857'
+      )
+    ).toEqual({ x0: 0, y0: 0, x1: 1, y1: 1 })
+  })
+
+  it('maps full-world EPSG:4326 bounds to the unit square', () => {
+    const b = boundsToMercatorNorm(
+      { xMin: -180, xMax: 180, yMin: -90, yMax: 90 },
+      'EPSG:4326'
+    )
+    expect(b.x0).toBe(0)
+    expect(b.x1).toBe(1)
+    expect(b.y0).toBeCloseTo(0, 6)
+    expect(b.y1).toBeCloseTo(1, 6)
+  })
+
+  it('maps a regional EPSG:4326 box', () => {
+    const b = boundsToMercatorNorm(
+      { xMin: 0, xMax: 90, yMin: 0, yMax: 45 },
+      'EPSG:4326'
+    )
+    expect(b.x0).toBeCloseTo(0.5, 12)
+    expect(b.x1).toBeCloseTo(0.75, 12)
+    expect(b.y1).toBeCloseTo(0.5, 12) // yMin=0 -> equator
+    expect(b.y0).toBeLessThan(0.5) // yMax=45 -> north of equator
+  })
+})

--- a/src/mesh-reprojector.test.ts
+++ b/src/mesh-reprojector.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest'
+import { createHybridMesh } from './mesh-reprojector'
+import { latToMercatorNorm } from './map-utils'
+import {
+  createTransformerTo4326,
+  type ProjectionTransformer,
+} from './projection-utils'
+import { WEB_MERCATOR_EXTENT } from './constants'
+import type { Bounds } from './types'
+
+/**
+ * Tests for the client-side reprojection mesh — the geometry that the GPU
+ * drapes the raster onto. createHybridMesh is pure (no GL): it builds an
+ * adaptive + uniform vertex grid, triangulates it (Delaunay), reprojects to
+ * WGS84, and splits triangles at the antimeridian.
+ *
+ * Exact vertex positions depend on adaptive refinement, so these assert
+ * invariants that pin the contract and catch the regression classes this
+ * module has historically hit: non-finite vertices at projection edges,
+ * corrupt/inconsistent triangulation, and non-determinism.
+ */
+
+/** Identity transformer: treats the source CRS as WGS84 (forward = passthrough). */
+function identityTransformer(bounds: Bounds): ProjectionTransformer {
+  return {
+    forward: (x, y) => [x, y],
+    inverse: (x, y) => [x, y],
+    bounds,
+  }
+}
+
+/** Assert a typed array contains only finite numbers. */
+function expectAllFinite(arr: ArrayLike<number>, label: string) {
+  for (let i = 0; i < arr.length; i++) {
+    if (!Number.isFinite(arr[i])) {
+      throw new Error(`${label}[${i}] is not finite: ${arr[i]}`)
+    }
+  }
+}
+
+/** Shared structural invariants every mesh must satisfy. */
+function expectValidMesh(mesh: ReturnType<typeof createHybridMesh>) {
+  const numVerts = mesh.positions.length / 2
+  expect(numVerts).toBeGreaterThan(0)
+  // positions and texCoords are paired (x,y) / (u,v) per vertex.
+  expect(mesh.texCoords.length).toBe(mesh.positions.length)
+  // Triangles: a whole number of them, all referencing valid vertices.
+  expect(mesh.indices.length % 3).toBe(0)
+  expect(mesh.indices.length).toBeGreaterThan(0)
+  for (let i = 0; i < mesh.indices.length; i++) {
+    expect(mesh.indices[i]).toBeLessThan(numVerts)
+  }
+}
+
+describe('createHybridMesh — identity (EPSG:4326 passthrough)', () => {
+  const bounds: Bounds = [-90, -45, 90, 45]
+  const mesh = createHybridMesh({
+    geoBounds: { xMin: -90, yMin: -45, xMax: 90, yMax: 45 },
+    width: 128,
+    height: 64,
+    lonSubdivisions: 8,
+    latSubdivisions: 8,
+    transformer: identityTransformer(bounds),
+    latIsAscending: false,
+  })
+
+  it('produces a structurally valid, all-finite mesh', () => {
+    expectValidMesh(mesh)
+    expectAllFinite(mesh.positions, 'positions')
+    expectAllFinite(mesh.texCoords, 'texCoords')
+  })
+
+  it('covers the region in anchor-relative space', () => {
+    // Positions are mercator deltas from the region anchor, normalized by the
+    // half-extent — so the region's own edges land exactly at ±1.
+    const xs: number[] = []
+    const ys: number[] = []
+    for (let i = 0; i < mesh.positions.length; i += 2) {
+      xs.push(mesh.positions[i])
+      ys.push(mesh.positions[i + 1])
+    }
+    expect(Math.min(...xs)).toBeCloseTo(-1, 5)
+    expect(Math.max(...xs)).toBeCloseTo(1, 5)
+    expect(Math.min(...ys)).toBeCloseTo(-1, 5)
+    expect(Math.max(...ys)).toBeCloseTo(1, 5)
+  })
+
+  it('emits texture UVs spanning the full [0, 1] range', () => {
+    let min = Infinity
+    let max = -Infinity
+    for (let i = 0; i < mesh.texCoords.length; i++) {
+      min = Math.min(min, mesh.texCoords[i])
+      max = Math.max(max, mesh.texCoords[i])
+    }
+    expect(min).toBeCloseTo(0, 5)
+    expect(max).toBeCloseTo(1, 5)
+  })
+
+  it('wgs84Bounds carries the region extent in normalized mercator', () => {
+    // lon ±90 -> mercator X 0.25..0.75; lat ±45 -> mercator Y via the
+    // gudermannian forward (smaller Y = north).
+    expect(mesh.wgs84Bounds.x0).toBeCloseTo(0.25, 9)
+    expect(mesh.wgs84Bounds.x1).toBeCloseTo(0.75, 9)
+    expect(mesh.wgs84Bounds.y0).toBeCloseTo(latToMercatorNorm(45), 9)
+    expect(mesh.wgs84Bounds.y1).toBeCloseTo(latToMercatorNorm(-45), 9)
+  })
+
+  it('is deterministic for identical input', () => {
+    const again = createHybridMesh({
+      geoBounds: { xMin: -90, yMin: -45, xMax: 90, yMax: 45 },
+      width: 128,
+      height: 64,
+      lonSubdivisions: 8,
+      latSubdivisions: 8,
+      transformer: identityTransformer(bounds),
+      latIsAscending: false,
+    })
+    expect(Array.from(again.positions)).toEqual(Array.from(mesh.positions))
+    expect(Array.from(again.indices)).toEqual(Array.from(mesh.indices))
+  })
+
+  it('adds vertices as subdivisions increase', () => {
+    const opts = (subdivisions: number) => ({
+      geoBounds: { xMin: -90, yMin: -45, xMax: 90, yMax: 45 },
+      width: 128,
+      height: 64,
+      lonSubdivisions: subdivisions,
+      latSubdivisions: subdivisions,
+      transformer: identityTransformer(bounds),
+      latIsAscending: false,
+    })
+    const coarse = createHybridMesh(opts(2))
+    const fine = createHybridMesh(opts(16))
+    expect(fine.positions.length).toBeGreaterThan(coarse.positions.length)
+  })
+})
+
+describe('createHybridMesh — real EPSG:3857 reprojection', () => {
+  it('reprojects mercator meters to a finite, valid mesh', () => {
+    const E = WEB_MERCATOR_EXTENT
+    const bounds: Bounds = [-E / 2, -E / 2, E / 2, E / 2]
+    const transformer = createTransformerTo4326('EPSG:3857', bounds)
+
+    const mesh = createHybridMesh({
+      geoBounds: { xMin: -E / 2, yMin: -E / 2, xMax: E / 2, yMax: E / 2 },
+      width: 256,
+      height: 256,
+      lonSubdivisions: 8,
+      latSubdivisions: 8,
+      transformer,
+      latIsAscending: false,
+    })
+
+    expectValidMesh(mesh)
+    // The key regression guard: no NaN vertices from the projection path.
+    expectAllFinite(mesh.positions, 'positions')
+    expectAllFinite(mesh.texCoords, 'texCoords')
+  })
+})

--- a/src/projection-utils.test.ts
+++ b/src/projection-utils.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest'
+import {
+  sourceCRSToPixel,
+  pixelToSourceCRS,
+  clampLatLonToProj4def,
+  createWGS84ToSourceTransformer,
+  createTransformer,
+  sampleEdgesToMercatorBounds,
+} from './projection-utils'
+import { MERCATOR_LAT_LIMIT, WEB_MERCATOR_EXTENT } from './constants'
+import type { Bounds } from './types'
+
+const bounds10: Bounds = [0, 0, 10, 10]
+
+describe('sourceCRSToPixel', () => {
+  it('uses an edge-to-edge model (xMin -> 0, xMax -> width)', () => {
+    expect(sourceCRSToPixel(0, 0, bounds10, 10, 10)).toEqual([0, 0])
+    expect(sourceCRSToPixel(5, 5, bounds10, 10, 10)).toEqual([5, 5])
+    expect(sourceCRSToPixel(10, 10, bounds10, 10, 10)).toEqual([10, 10])
+  })
+
+  it('flips Y when latIsAscending is false (row 0 = north)', () => {
+    // y=yMin (south) -> bottom row (pixel = height); y=yMax (north) -> row 0.
+    expect(sourceCRSToPixel(0, 0, bounds10, 10, 10, false)).toEqual([0, 10])
+    expect(sourceCRSToPixel(0, 10, bounds10, 10, 10, false)).toEqual([0, 0])
+  })
+
+  it('falls back to the grid center for degenerate bounds', () => {
+    const bad: Bounds = [0, 0, 0, 10] // xMax <= xMin
+    expect(sourceCRSToPixel(5, 5, bad, 10, 10)).toEqual([5, 5])
+  })
+})
+
+describe('pixelToSourceCRS', () => {
+  it('round-trips with sourceCRSToPixel (ascending)', () => {
+    const [px, py] = sourceCRSToPixel(3, 7, bounds10, 10, 10)
+    const [x, y] = pixelToSourceCRS(px, py, bounds10, 10, 10)
+    expect(x).toBeCloseTo(3, 12)
+    expect(y).toBeCloseTo(7, 12)
+  })
+
+  it('round-trips with sourceCRSToPixel (descending)', () => {
+    const [px, py] = sourceCRSToPixel(3, 7, bounds10, 10, 10, false)
+    const [x, y] = pixelToSourceCRS(px, py, bounds10, 10, 10, false)
+    expect(x).toBeCloseTo(3, 12)
+    expect(y).toBeCloseTo(7, 12)
+  })
+
+  it('falls back to the bounds center for degenerate bounds', () => {
+    const bad: Bounds = [0, 0, 0, 10]
+    expect(pixelToSourceCRS(5, 5, bad, 10, 10)).toEqual([0, 5])
+  })
+})
+
+describe('clampLatLonToProj4def', () => {
+  it('clamps latitude to the mercator limit for EPSG:3857', () => {
+    expect(clampLatLonToProj4def(200, 89, 'EPSG:3857')).toEqual([
+      200,
+      MERCATOR_LAT_LIMIT,
+    ])
+    expect(clampLatLonToProj4def(0, -89, 'EPSG:3857')).toEqual([
+      0,
+      -MERCATOR_LAT_LIMIT,
+    ])
+  })
+
+  it('leaves coordinates untouched for other projections', () => {
+    expect(clampLatLonToProj4def(200, 89, 'EPSG:4326')).toEqual([200, 89])
+  })
+})
+
+describe('createWGS84ToSourceTransformer (EPSG:3857)', () => {
+  const t = createWGS84ToSourceTransformer('EPSG:3857')
+
+  it('maps the origin to the mercator origin', () => {
+    const [x, y] = t.forward(0, 0)
+    expect(x).toBeCloseTo(0, 6)
+    expect(y).toBeCloseTo(0, 6)
+  })
+
+  it('maps ±180° lon to the mercator world edges', () => {
+    expect(t.forward(180, 0)[0]).toBeCloseTo(WEB_MERCATOR_EXTENT, 2)
+    expect(t.forward(-180, 0)[0]).toBeCloseTo(-WEB_MERCATOR_EXTENT, 2)
+  })
+
+  it('round-trips forward/inverse', () => {
+    const [x, y] = t.forward(-122.4, 37.8)
+    const [lon, lat] = t.inverse(x, y)
+    expect(lon).toBeCloseTo(-122.4, 9)
+    expect(lat).toBeCloseTo(37.8, 9)
+  })
+
+  it('throws a helpful error for an invalid proj4 string', () => {
+    expect(() => createWGS84ToSourceTransformer('not-a-projection')).toThrow(
+      /Invalid proj4 string/
+    )
+  })
+})
+
+describe('sampleEdgesToMercatorBounds', () => {
+  it('maps a full-mercator extent to the unit square via an identity transformer', () => {
+    const identity = {
+      forward: (x: number, y: number): [number, number] => [x, y],
+    }
+    const result = sampleEdgesToMercatorBounds(
+      {
+        xMin: -WEB_MERCATOR_EXTENT,
+        xMax: WEB_MERCATOR_EXTENT,
+        yMin: -WEB_MERCATOR_EXTENT,
+        yMax: WEB_MERCATOR_EXTENT,
+      },
+      identity,
+      4
+    )
+    expect(result).not.toBeNull()
+    expect(result!.x0).toBeCloseTo(0, 12)
+    expect(result!.y0).toBeCloseTo(0, 12)
+    expect(result!.x1).toBeCloseTo(1, 12)
+    expect(result!.y1).toBeCloseTo(1, 12)
+  })
+
+  it('returns null when no sample projects to a finite point', () => {
+    const broken = { forward: (): [number, number] => [NaN, NaN] }
+    expect(
+      sampleEdgesToMercatorBounds(
+        { xMin: 0, xMax: 1, yMin: 0, yMax: 1 },
+        broken,
+        4
+      )
+    ).toBeNull()
+  })
+})
+
+describe('createTransformer (source -> EPSG:3857)', () => {
+  it('projects EPSG:4326 source coordinates to Web Mercator meters', () => {
+    const t = createTransformer('EPSG:4326', [-180, -90, 180, 90])
+    // Origin maps to origin...
+    const [x, y] = t.forward(0, 0)
+    expect(x).toBeCloseTo(0, 6)
+    expect(y).toBeCloseTo(0, 6)
+    // ...and ±180° lon reaches the mercator world edges. An origin-only check
+    // can't tell a real projection from an identity/no-op; this pins the scale.
+    expect(t.forward(180, 0)[0]).toBeCloseTo(WEB_MERCATOR_EXTENT, 2)
+    expect(t.forward(-180, 0)[0]).toBeCloseTo(-WEB_MERCATOR_EXTENT, 2)
+    expect(t.bounds).toEqual([-180, -90, 180, 90])
+  })
+})

--- a/src/projection-utils.ts
+++ b/src/projection-utils.ts
@@ -1,7 +1,99 @@
 import proj4 from 'proj4'
-import type { MercatorBounds } from './map-utils'
+import type { MercatorBounds, XYLimits } from './map-utils'
 import { MERCATOR_LAT_LIMIT, WEB_MERCATOR_EXTENT } from './constants'
-import type { Bounds } from './types'
+import type { Bounds, CRS } from './types'
+
+export type ProjectionKind = 'epsg4326' | 'epsg3857' | 'custom-proj4'
+
+export type ProjectionContext = {
+  kind: ProjectionKind
+  def: string
+  toMercator: ProjectionTransformer | null
+  toWGS84: ReturnType<typeof createWGS84ToSourceTransformer> | null
+  to4326: ReturnType<typeof createTransformerTo4326> | null
+}
+
+export function createProjectionContext({
+  crs,
+  proj4def,
+  xyLimits,
+}: {
+  crs: CRS
+  proj4def: string | null
+  xyLimits: XYLimits | null
+}): ProjectionContext {
+  const kind = resolveProjectionKind(crs, proj4def)
+  const def = resolveProjectionDef(crs, proj4def)
+  if (!xyLimits) {
+    return { kind, def, toMercator: null, toWGS84: null, to4326: null }
+  }
+
+  const bounds: Bounds = [
+    xyLimits.xMin,
+    xyLimits.yMin,
+    xyLimits.xMax,
+    xyLimits.yMax,
+  ]
+  const rawMercatorTransformer = createTransformer(def, bounds)
+  // Wrap the source→3857 forward so lat=±90° inputs (common for global
+  // EPSG:4326 rasters) are clamped to ±MERCATOR_LAT_LIMIT before proj4
+  // sees them. Without this, `sampleEdgesToMercatorBounds` silently
+  // drops the polar edge samples and produces too-tight mercator bounds.
+  const toMercator =
+    kind === 'epsg4326'
+      ? {
+          ...rawMercatorTransformer,
+          forward: (x: number, y: number): [number, number] =>
+            rawMercatorTransformer.forward(
+              x,
+              Math.max(-MERCATOR_LAT_LIMIT, Math.min(MERCATOR_LAT_LIMIT, y))
+            ),
+        }
+      : rawMercatorTransformer
+
+  return {
+    kind,
+    def,
+    toMercator,
+    toWGS84: createWGS84ToSourceTransformer(def),
+    to4326: createTransformerTo4326(def, bounds),
+  }
+}
+
+export function normalizeBuiltinProjectionDef(
+  def: string | null | undefined
+): CRS | null {
+  if (!def) return null
+  const normalized = def.trim().toUpperCase()
+  return normalized === 'EPSG:4326' || normalized === 'EPSG:3857'
+    ? normalized
+    : null
+}
+
+export function resolveProjectionKind(
+  crs: CRS,
+  proj4def: string | null
+): ProjectionKind {
+  const builtinProj4Def = normalizeBuiltinProjectionDef(proj4def)
+  if (builtinProj4Def) {
+    return builtinProj4Def === 'EPSG:3857' ? 'epsg3857' : 'epsg4326'
+  }
+  if (proj4def?.trim()) {
+    return 'custom-proj4'
+  }
+  return crs === 'EPSG:3857' ? 'epsg3857' : 'epsg4326'
+}
+
+export function resolveProjectionDef(
+  crs: CRS,
+  proj4def: string | null
+): string {
+  const builtinProj4Def = normalizeBuiltinProjectionDef(proj4def)
+  if (builtinProj4Def) return builtinProj4Def
+  const trimmedProj4Def = proj4def?.trim()
+  if (trimmedProj4Def) return trimmedProj4Def
+  return crs
+}
 
 /**
  * Clamp WGS84 lon/lat to the source CRS's valid input range so a subsequent

--- a/src/query/data-query.test.ts
+++ b/src/query/data-query.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { mergeQueryResults, mergeNestedValues } from './data-query'
+import type { NestedValues, QueryResult } from './types'
+
+/**
+ * Merge semantics for antimeridian two-strip queries: west-strip pixels then
+ * east-strip pixels, spatial coordinate arrays concatenated, non-spatial
+ * coordinates taken from the first strip.
+ */
+
+describe('mergeQueryResults', () => {
+  it('concatenates values and spatial coordinates', () => {
+    const west: QueryResult = {
+      temp: [1, 2],
+      dimensions: ['lat', 'lon'],
+      coordinates: { lat: [10, 10], lon: [179, 179.5], month: [1] },
+    }
+    const east: QueryResult = {
+      temp: [3],
+      dimensions: ['lat', 'lon'],
+      coordinates: { lat: [10], lon: [-179.5], month: [1] },
+    }
+    const merged = mergeQueryResults(west, east, 'temp', 'lat', 'lon')
+
+    expect(merged.temp).toEqual([1, 2, 3])
+    expect(merged.coordinates.lat).toEqual([10, 10, 10])
+    expect(merged.coordinates.lon).toEqual([179, 179.5, -179.5])
+    // Non-spatial coordinates come from the first strip unchanged.
+    expect(merged.coordinates.month).toEqual([1])
+    expect(merged.dimensions).toEqual(['lat', 'lon'])
+  })
+
+  it('merges nested multi-band values recursively', () => {
+    const west: QueryResult = {
+      temp: { jan: [1] },
+      dimensions: ['lat', 'lon'],
+      coordinates: { lat: [0], lon: [179] },
+    }
+    const east: QueryResult = {
+      temp: { jan: [2], feb: [3] },
+      dimensions: ['lat', 'lon'],
+      coordinates: { lat: [0], lon: [-179] },
+    }
+    const merged = mergeQueryResults(west, east, 'temp', 'lat', 'lon')
+    expect(merged.temp).toEqual({ jan: [1, 2], feb: [3] })
+  })
+
+  it('takes the first side when value shapes disagree', () => {
+    const west: QueryResult = {
+      temp: [1],
+      dimensions: ['lat', 'lon'],
+      coordinates: { lat: [0], lon: [179] },
+    }
+    const east: QueryResult = {
+      temp: { jan: [2] },
+      dimensions: ['lat', 'lon'],
+      coordinates: { lat: [0], lon: [-179] },
+    }
+    const merged = mergeQueryResults(west, east, 'temp', 'lat', 'lon')
+    expect(merged.temp).toEqual([1])
+  })
+})
+
+describe('mergeNestedValues', () => {
+  it('concatenates leaf arrays at any depth', () => {
+    const a: NestedValues = { r: { low: [1] }, g: { low: [2] } }
+    const b: NestedValues = { r: { low: [3], high: [4] } }
+    expect(mergeNestedValues(a, b)).toEqual({
+      r: { low: [1, 3], high: [4] },
+      g: { low: [2] },
+    })
+  })
+
+  it('includes keys present only in the second object', () => {
+    expect(mergeNestedValues({ a: [1] }, { b: [2] })).toEqual({
+      a: [1],
+      b: [2],
+    })
+  })
+})

--- a/src/query/data-query.test.ts
+++ b/src/query/data-query.test.ts
@@ -184,8 +184,13 @@ describe('queryData', () => {
           ],
         ],
       }
-      await queryData(proj4Context, crossing)
-      await queryData(proj4Context, crossing)
+      const result = await queryData(proj4Context, crossing, { time: 10 })
+      // One strip clamped to the raster extent, not the two-strip merge the
+      // EPSG:4326 path produces for the same polygon ([7, 0]).
+      expect(result.temp).toEqual([7])
+      expect(result.coordinates.lon).toEqual([157.5])
+
+      await queryData(proj4Context, crossing, { time: 10 })
       expect(warnSpy).toHaveBeenCalledTimes(1)
       expect(proj4Context.antimeridianWarnings.has('proj4-crossing')).toBe(true)
     } finally {

--- a/src/query/data-query.test.ts
+++ b/src/query/data-query.test.ts
@@ -1,6 +1,211 @@
-import { describe, it, expect } from 'vitest'
-import { mergeQueryResults, mergeNestedValues } from './data-query'
-import type { NestedValues, QueryResult } from './types'
+import { describe, it, expect, vi } from 'vitest'
+import {
+  queryData,
+  mergeQueryResults,
+  mergeNestedValues,
+  type QueryContext,
+} from './data-query'
+import type { NestedValues, QueryGeometry, QueryResult } from './types'
+import { ZarrStore } from '../zarr-store'
+import { createProjectionContext } from '../projection-utils'
+import { buildMemoryZarrStore, ramp } from '../__fixtures__/memory-zarr'
+
+/**
+ * End-to-end orchestration tests against the in-memory Zarr fixture (real
+ * ZarrStore + zarrita reads): pixel selection, selector resolution,
+ * multichannel packing, the antimeridian two-strip merge, and abort
+ * propagation. Plus the pure merge helpers used by the two-strip path.
+ *
+ * Fixture: 2-time x 4-lat x 8-lon index ramp (value = t*32 + y*8 + x) on a
+ * global 45-degree grid, lat north-first. Pixel (x, y) has center
+ * lon = (x + 0.5) / 8 * 360 - 180 and lat = 90 - (y + 0.5) / 4 * 180.
+ */
+
+const WORLD = { xMin: -180, xMax: 180, yMin: -90, yMax: 90 }
+
+async function makeQueryHarness(opts: { gateReads?: boolean } = {}) {
+  const memory = buildMemoryZarrStore({
+    arrays: [
+      {
+        name: 'temp',
+        shape: [2, 4, 8],
+        chunkShape: [2, 4, 8],
+        dimensionNames: ['time', 'lat', 'lon'],
+        chunks: { '0/0/0': ramp(2 * 4 * 8) },
+      },
+      {
+        name: 'time',
+        shape: [2],
+        chunkShape: [2],
+        dimensionNames: ['time'],
+        chunks: { '0': [10, 20] },
+      },
+    ],
+  })
+
+  let releaseReads = () => {}
+  const readsReleased = new Promise<void>((res) => {
+    releaseReads = res
+  })
+  const customStore = opts.gateReads
+    ? {
+        get: async (key: string) => {
+          if (key.includes('/temp/c/')) await readsReleased
+          return memory.get(key)
+        },
+      }
+    : memory
+
+  const store = new ZarrStore({
+    customStore,
+    variable: 'temp',
+    version: 3,
+    bounds: [-180, -90, 180, 90],
+    latIsAscending: false,
+  })
+  await store.initialized
+  const zarrArray = await store.getArray()
+
+  const context: QueryContext = {
+    zarrStore: store,
+    variable: 'temp',
+    selector: {},
+    xyLimits: WORLD,
+    mercatorBounds: { x0: 0, y0: 0, x1: 1, y1: 1 },
+    latIsAscending: false,
+    levels: [],
+    level: { index: 0, zarrArray, width: 8, height: 4 },
+    projection: createProjectionContext({
+      crs: 'EPSG:4326',
+      proj4def: null,
+      xyLimits: WORLD,
+    }),
+    antimeridianWarnings: new Set(),
+    dimensionValues: {},
+    isMultiscale: false,
+    coordLevelIndex: 0,
+  }
+
+  return { context, releaseReads }
+}
+
+const point = (lon: number, lat: number): QueryGeometry => ({
+  type: 'Point',
+  coordinates: [lon, lat],
+})
+
+describe('queryData', () => {
+  it('returns an empty result without a committed level', async () => {
+    const { context } = await makeQueryHarness()
+    const result = await queryData(
+      { ...context, level: null },
+      point(-157.5, 67.5)
+    )
+    expect(result.temp).toEqual([])
+    expect(result.coordinates).toEqual({ lat: [], lon: [] })
+  })
+
+  it('resolves point queries to the correct pixel', async () => {
+    const { context } = await makeQueryHarness()
+    // Pixel (0, 0), time plane 0.
+    const northWest = await queryData(context, point(-157.5, 67.5), {
+      time: 10,
+    })
+    expect(northWest.temp).toEqual([0])
+    // Pixel (7, 3): 3*8 + 7.
+    const southEast = await queryData(context, point(157.5, -67.5), {
+      time: 10,
+    })
+    expect(southEast.temp).toEqual([31])
+  })
+
+  it('normalizes a raw selector and resolves it against coordinate arrays', async () => {
+    const { context } = await makeQueryHarness()
+    // time=20 is coordinate VALUE 20 (index 1): plane offset 32.
+    const result = await queryData(context, point(-157.5, 67.5), { time: 20 })
+    expect(result.temp).toEqual([32])
+  })
+
+  it('packs multi-value selectors into label-keyed channels', async () => {
+    const { context } = await makeQueryHarness()
+    const result = await queryData(context, point(-157.5, 67.5), {
+      time: [10, 20],
+    })
+    expect(result.temp).toEqual({ 10: [0], 20: [32] })
+  })
+
+  it('merges the two strips of an antimeridian-crossing polygon', async () => {
+    const { context } = await makeQueryHarness()
+    // Unwrapped lon 130..230 (crossing is signalled by out-of-range lons):
+    // covers exactly pixel (7, 0) west of the antimeridian and pixel (0, 0)
+    // east of it.
+    const result = await queryData(
+      context,
+      {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [130, 50],
+            [230, 50],
+            [230, 80],
+            [130, 80],
+            [130, 50],
+          ],
+        ],
+      },
+      { time: 10 }
+    )
+    expect(result.temp).toEqual([7, 0])
+    expect(result.coordinates.lon).toEqual([157.5, -157.5])
+    expect(result.coordinates.lat).toEqual([67.5, 67.5])
+  })
+
+  it('warns once and single-fetches antimeridian crossings on proj4 data', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const { context } = await makeQueryHarness()
+      const proj4Context: QueryContext = {
+        ...context,
+        projection: createProjectionContext({
+          crs: 'EPSG:4326',
+          proj4def: '+proj=longlat +datum=WGS84 +no_defs',
+          xyLimits: WORLD,
+        }),
+      }
+      const crossing: QueryGeometry = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [130, 50],
+            [230, 50],
+            [230, 80],
+            [130, 80],
+            [130, 50],
+          ],
+        ],
+      }
+      await queryData(proj4Context, crossing)
+      await queryData(proj4Context, crossing)
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(proj4Context.antimeridianWarnings.has('proj4-crossing')).toBe(true)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('propagates aborts as AbortError', async () => {
+    const { context, releaseReads } = await makeQueryHarness({
+      gateReads: true,
+    })
+    const controller = new AbortController()
+    const pending = queryData(context, point(-157.5, 67.5), undefined, {
+      signal: controller.signal,
+    })
+    controller.abort()
+    releaseReads()
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+  })
+})
 
 /**
  * Merge semantics for antimeridian two-strip queries: west-strip pixels then

--- a/src/query/data-query.ts
+++ b/src/query/data-query.ts
@@ -1,0 +1,408 @@
+import * as zarr from 'zarrita'
+import type {
+  Bounds,
+  NormalizedSelector,
+  Selector,
+  UntiledLevel,
+} from '../types'
+import type { MercatorBounds, XYLimits } from '../map-utils'
+import type { ProjectionContext } from '../projection-utils'
+import { pixelToSourceCRS } from '../projection-utils'
+import type { QueryLevelSnapshot } from '../region-state'
+import type { ZarrStore } from '../zarr-store'
+import {
+  buildChannelCombinations,
+  buildSliceArgsForSelector,
+  type DimensionValuesCache,
+} from '../selector-resolution'
+import { normalizeSelector } from '../zarr-utils'
+import { queryRegionUntiled, findSpatialDimNames } from './region-query'
+import {
+  computePixelBoundsFromGeometry,
+  preprocessQueryGeometry,
+  wrappedBboxToPixelSpans,
+  rasterExtentCrossesAntimeridian,
+  type PixelRect,
+} from './query-utils'
+import type {
+  NestedValues,
+  QueryDataValues,
+  QueryGeometry,
+  QueryOptions,
+  QueryResult,
+} from './types'
+
+export type QueryContext = {
+  zarrStore: ZarrStore
+  variable: string
+  selector: NormalizedSelector
+  xyLimits: XYLimits | null
+  mercatorBounds: MercatorBounds | null
+  latIsAscending: boolean
+  levels: UntiledLevel[]
+  level: QueryLevelSnapshot | null
+  projection: ProjectionContext
+  antimeridianWarnings: Set<string>
+  dimensionValues: DimensionValuesCache
+  isMultiscale: boolean
+  coordLevelIndex: number
+}
+
+/**
+ * Unified method to fetch query data for either point or region queries.
+ * Handles multi-value dimensions and channel combinations.
+ */
+export async function fetchQueryData(
+  context: QueryContext,
+  level: QueryLevelSnapshot,
+  selector: NormalizedSelector,
+  spatialQuery: {
+    minX: number
+    maxX: number
+    minY: number
+    maxY: number
+  },
+  signal?: AbortSignal
+): Promise<{
+  data: Float32Array
+  width: number
+  height: number
+  channels: number
+  channelLabels: (string | number)[][]
+  multiValueDimNames: string[]
+} | null> {
+  try {
+    const { sliceArgs: baseSliceArgs, multiValueDims } =
+      await buildSliceArgsForSelector(
+        {
+          zarrStore: context.zarrStore,
+          dimIndices: context.zarrStore.describe().dimIndices,
+          levels: context.levels,
+          isMultiscale: context.isMultiscale,
+          dimensionValues: context.dimensionValues,
+          coordLevelIndex: context.coordLevelIndex,
+        },
+        selector,
+        {
+          includeSpatialSlices: false,
+          trackMultiValue: true,
+          spatialBounds: spatialQuery,
+          array: level.zarrArray,
+        }
+      )
+
+    const {
+      combinations: channelCombinations,
+      labelCombinations: channelLabelCombinations,
+    } = buildChannelCombinations(multiValueDims)
+    const numChannels = channelCombinations.length || 1
+    const multiValueDimNames = multiValueDims.map((d) => d.dimName)
+    const getOpts = signal ? { signal } : undefined
+    const fetchWidth = spatialQuery.maxX - spatialQuery.minX
+    const fetchHeight = spatialQuery.maxY - spatialQuery.minY
+
+    if (numChannels === 1) {
+      const result = (await zarr.get(
+        level.zarrArray,
+        baseSliceArgs,
+        getOpts
+      )) as { data: ArrayLike<number> }
+      return {
+        data: new Float32Array(result.data),
+        width: fetchWidth,
+        height: fetchHeight,
+        channels: 1,
+        channelLabels: channelLabelCombinations,
+        multiValueDimNames,
+      }
+    }
+
+    const packedData = new Float32Array(fetchWidth * fetchHeight * numChannels)
+    for (let c = 0; c < numChannels; c++) {
+      const sliceArgs = [...baseSliceArgs]
+      const combo = channelCombinations[c]
+      for (let i = 0; i < multiValueDims.length; i++) {
+        sliceArgs[multiValueDims[i].dimIndex] = combo[i]
+      }
+
+      const bandData = (await zarr.get(
+        level.zarrArray,
+        sliceArgs,
+        getOpts
+      )) as { data: ArrayLike<number> }
+      for (let pixIdx = 0; pixIdx < fetchWidth * fetchHeight; pixIdx++) {
+        packedData[pixIdx * numChannels + c] = bandData.data[pixIdx]
+      }
+    }
+
+    return {
+      data: packedData,
+      width: fetchWidth,
+      height: fetchHeight,
+      channels: numChannels,
+      channelLabels: channelLabelCombinations,
+      multiValueDimNames,
+    }
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') throw err
+    console.error('Error fetching query data:', err)
+    return null
+  }
+}
+
+/** Query data for point or region geometries. */
+export async function queryData(
+  context: QueryContext,
+  geometry: QueryGeometry,
+  selector?: Selector,
+  options?: QueryOptions
+): Promise<QueryResult> {
+  const desc = context.zarrStore.describe()
+  const sourceBounds: Bounds | null = context.xyLimits
+    ? [
+        context.xyLimits.xMin,
+        context.xyLimits.yMin,
+        context.xyLimits.xMax,
+        context.xyLimits.yMax,
+      ]
+    : null
+  const { yDim: emptyYDim, xDim: emptyXDim } = findSpatialDimNames(
+    desc.dimensions,
+    desc.dimIndices
+  )
+  const emptyResult = (): QueryResult => ({
+    [context.variable]: [],
+    dimensions: [],
+    coordinates: { [emptyYDim]: [], [emptyXDim]: [] },
+  })
+
+  const level = context.level
+  if (!context.mercatorBounds || !level || !sourceBounds) {
+    return emptyResult()
+  }
+  const projectionDef = context.projection.def
+  if (!projectionDef) return emptyResult()
+
+  const normalizedSelector = selector
+    ? normalizeSelector(selector)
+    : context.selector
+  const currentLevel = context.levels[level.index]
+  const transforms = {
+    scaleFactor: currentLevel?.scaleFactor ?? desc.scaleFactor,
+    addOffset: currentLevel?.addOffset ?? desc.addOffset,
+    fillValue: currentLevel?.fillValue ?? desc.fill_value,
+  }
+
+  // Closure for running a single pixel-bounds strip query.
+  // Captures request-scoped locals (not instance state) to avoid races
+  // when queryData is called concurrently on the same instance.
+  const runStrip = async (
+    geom: QueryGeometry,
+    pixelBounds: PixelRect,
+    opts?: QueryOptions
+  ): Promise<QueryResult | null> => {
+    const fetched = await fetchQueryData(
+      context,
+      level,
+      normalizedSelector,
+      pixelBounds,
+      opts?.signal
+    )
+    if (!fetched) return null
+
+    const { minX, minY, maxX, maxY } = pixelBounds
+    const [xMin0, yMin0] = pixelToSourceCRS(
+      minX,
+      minY,
+      sourceBounds,
+      level.width,
+      level.height,
+      context.latIsAscending
+    )
+    const [xMax0, yMax0] = pixelToSourceCRS(
+      maxX,
+      maxY,
+      sourceBounds,
+      level.width,
+      level.height,
+      context.latIsAscending
+    )
+    const subsetSourceBounds: Bounds = [
+      Math.min(xMin0, xMax0),
+      Math.min(yMin0, yMax0),
+      Math.max(xMin0, xMax0),
+      Math.max(yMin0, yMax0),
+    ]
+
+    return queryRegionUntiled(
+      context.variable,
+      geom,
+      normalizedSelector,
+      fetched.data,
+      fetched.width,
+      fetched.height,
+      desc.dimensions,
+      desc.coordinates,
+      subsetSourceBounds,
+      projectionDef,
+      fetched.channels,
+      fetched.channelLabels,
+      fetched.multiValueDimNames,
+      context.latIsAscending,
+      transforms,
+      opts,
+      desc.dimIndices,
+      context.projection.toWGS84 ?? undefined
+    )
+  }
+
+  const singleFetch = async (geom: QueryGeometry): Promise<QueryResult> => {
+    const pixelBounds = computePixelBoundsFromGeometry(
+      geom,
+      sourceBounds,
+      level.width,
+      level.height,
+      projectionDef,
+      context.latIsAscending,
+      context.projection.toWGS84 ?? undefined
+    )
+    if (!pixelBounds) return emptyResult()
+    const result = await runStrip(geom, pixelBounds, options)
+    return result ?? emptyResult()
+  }
+
+  const { geometry: processedGeometry, bbox: wrappedBbox } =
+    preprocessQueryGeometry(geometry)
+  const supportsWrappedLongitude =
+    context.projection.kind === 'epsg4326' ||
+    context.projection.kind === 'epsg3857'
+  const queryGeometry = supportsWrappedLongitude ? processedGeometry : geometry
+
+  if (!wrappedBbox.crossesAntimeridian) return singleFetch(queryGeometry)
+
+  if (!supportsWrappedLongitude) {
+    if (!context.antimeridianWarnings.has('proj4-crossing')) {
+      context.antimeridianWarnings.add('proj4-crossing')
+      console.warn(
+        'Antimeridian-crossing polygon queries are not supported for proj4 projections; results may be incorrect'
+      )
+    }
+    return singleFetch(queryGeometry)
+  }
+
+  // Crossing: raster extent guard (EPSG:4326 only — 3857 xyLimits are in meters)
+  if (
+    context.projection.kind === 'epsg4326' &&
+    rasterExtentCrossesAntimeridian('EPSG:4326', context.xyLimits)
+  ) {
+    if (!context.antimeridianWarnings.has('raster-extent-crossing')) {
+      context.antimeridianWarnings.add('raster-extent-crossing')
+      console.warn(
+        'Antimeridian-crossing polygon queries are not supported for rasters whose own extent crosses the antimeridian; results may be incorrect'
+      )
+    }
+    return singleFetch(geometry)
+  }
+
+  // Crossing: two-strip fetch
+  const spans = wrappedBboxToPixelSpans(
+    wrappedBbox,
+    sourceBounds,
+    level.width,
+    level.height,
+    projectionDef,
+    context.latIsAscending,
+    context.projection.toWGS84 ?? undefined
+  )
+  const westResult = spans.west
+    ? await runStrip(processedGeometry, spans.west, options)
+    : null
+  const eastResult = spans.east
+    ? await runStrip(processedGeometry, spans.east, options)
+    : null
+
+  // If either requested strip failed, return empty rather than partial data
+  if ((spans.west && !westResult) || (spans.east && !eastResult)) {
+    return emptyResult()
+  }
+  if (!westResult && !eastResult) return emptyResult()
+  if (!westResult || !eastResult) return (westResult ?? eastResult)!
+
+  const { yDim, xDim } = findSpatialDimNames(desc.dimensions, desc.dimIndices)
+  return mergeQueryResults(westResult, eastResult, context.variable, yDim, xDim)
+}
+
+/**
+ * Merge two QueryResult objects from west and east strips.
+ *
+ * Ordering: west-strip pixels first, then east-strip pixels. This does NOT
+ * preserve row-major scan order. The QueryResult contract provides parallel
+ * coordinate arrays so consumers index by position, not implicit grid layout.
+ *
+ * Spatial coordinate arrays (yDim, xDim) are concatenated.
+ * Non-spatial coordinate arrays are taken from the first result unchanged.
+ */
+export function mergeQueryResults(
+  a: QueryResult,
+  b: QueryResult,
+  variable: string,
+  yDim: string,
+  xDim: string
+): QueryResult {
+  const spatialKeys = new Set([yDim, xDim])
+
+  // Merge coordinates: concatenate spatial, take first for non-spatial
+  const coordinates: Record<string, (number | string)[]> = {}
+  for (const key of Object.keys(a.coordinates)) {
+    coordinates[key] = spatialKeys.has(key)
+      ? [...a.coordinates[key], ...b.coordinates[key]]
+      : a.coordinates[key]
+  }
+
+  const aVals = a[variable] as QueryDataValues
+  const bVals = b[variable] as QueryDataValues
+  let merged: QueryDataValues
+  if (Array.isArray(aVals) && Array.isArray(bVals)) {
+    merged = [...aVals, ...bVals]
+  } else if (!Array.isArray(aVals) && !Array.isArray(bVals)) {
+    merged = mergeNestedValues(aVals as NestedValues, bVals as NestedValues)
+  } else {
+    merged = aVals // Mismatched types: take first
+  }
+
+  return { [variable]: merged, dimensions: a.dimensions, coordinates }
+}
+
+/** Recursively merge two NestedValues objects by concatenating leaf arrays. */
+export function mergeNestedValues(
+  a: NestedValues,
+  b: NestedValues
+): NestedValues {
+  const result: NestedValues = {}
+  for (const key of Object.keys(a)) {
+    const aVal = a[key]
+    const bVal = b[key]
+    if (Array.isArray(aVal) && Array.isArray(bVal)) {
+      result[key] = [...aVal, ...bVal]
+    } else if (
+      aVal &&
+      bVal &&
+      !Array.isArray(aVal) &&
+      !Array.isArray(bVal) &&
+      typeof aVal === 'object' &&
+      typeof bVal === 'object'
+    ) {
+      result[key] = mergeNestedValues(
+        aVal as NestedValues,
+        bVal as NestedValues
+      )
+    } else {
+      result[key] = aVal
+    }
+  }
+  // Include keys only in b
+  for (const key of Object.keys(b)) {
+    if (!(key in result)) result[key] = b[key]
+  }
+  return result
+}

--- a/src/query/query-utils.test.ts
+++ b/src/query/query-utils.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildScanlineTable,
+  preprocessQueryGeometry,
+  transformGeometryToPixelSpace,
+  computePixelBoundsFromGeometry,
+} from './query-utils'
+import type { QueryGeometry } from './types'
+import type { Bounds } from '../types'
+import { WEB_MERCATOR_EXTENT } from '../constants'
+import {
+  rect,
+  squareWithHole,
+  antimeridianPolygon,
+} from '../__fixtures__/geometry'
+
+describe('buildScanlineTable', () => {
+  it('returns the two edge crossings for a simple square', () => {
+    const square = rect(2, 2, 8, 8) as QueryGeometry
+    const row5 = buildScanlineTable(square, 0, 10).get(5)
+    expect(row5).toBeDefined()
+    expect(row5!.map((x) => Math.round(x))).toEqual([2, 8])
+  })
+
+  it('uses center-based sampling (row + 0.5)', () => {
+    // Triangle whose tip is at y=2.6: row 2 center (2.5) is above the tip and
+    // excluded; row 3 center (3.5) is inside.
+    const triangle: QueryGeometry = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [5, 2.6],
+          [10, 8],
+          [0, 8],
+          [5, 2.6],
+        ],
+      ],
+    }
+    const table = buildScanlineTable(triangle, 0, 10)
+    expect(table.has(2)).toBe(false)
+    expect(table.has(3)).toBe(true)
+  })
+
+  it('produces four crossings across a polygon with a hole', () => {
+    const row10 = buildScanlineTable(
+      squareWithHole as QueryGeometry,
+      0,
+      20
+    ).get(10)
+    expect(row10).toBeDefined()
+    expect(row10!.map((x) => Math.round(x))).toEqual([0, 5, 15, 20])
+  })
+
+  it('unions disjoint multipolygon members into separate intervals', () => {
+    const disjoint: QueryGeometry = {
+      type: 'MultiPolygon',
+      coordinates: [
+        rect(0, 0, 2, 10).coordinates,
+        rect(5, 0, 7, 10).coordinates,
+      ],
+    }
+    const row5 = buildScanlineTable(disjoint, 0, 10).get(5)
+    expect(row5!.map((x) => Math.round(x))).toEqual([0, 2, 5, 7])
+  })
+
+  it('merges overlapping multipolygon members into a single interval', () => {
+    const overlapping: QueryGeometry = {
+      type: 'MultiPolygon',
+      coordinates: [
+        rect(0, 0, 5, 10).coordinates,
+        rect(3, 0, 8, 10).coordinates,
+      ],
+    }
+    const row5 = buildScanlineTable(overlapping, 0, 10).get(5)
+    expect(row5!.map((x) => Math.round(x))).toEqual([0, 8])
+  })
+})
+
+describe('preprocessQueryGeometry', () => {
+  it('passes a non-crossing polygon through and closes its ring', () => {
+    const { geometry, bbox } = preprocessQueryGeometry(rect(-10, -10, 10, 10))
+    expect(bbox.crossesAntimeridian).toBe(false)
+    expect(geometry.type).toBe('Polygon')
+  })
+
+  it('detects an antimeridian crossing and splits into west/east strips', () => {
+    const { geometry, bbox } = preprocessQueryGeometry(antimeridianPolygon)
+    expect(bbox.crossesAntimeridian).toBe(true)
+    // west (170) > east (-170) is the crossing invariant.
+    expect(bbox.west).toBeCloseTo(170, 6)
+    expect(bbox.east).toBeCloseTo(-170, 6)
+    expect(geometry.type).toBe('MultiPolygon')
+    if (geometry.type === 'MultiPolygon') {
+      expect(geometry.coordinates).toHaveLength(2)
+    }
+  })
+
+  it('returns a point unchanged', () => {
+    const point: QueryGeometry = { type: 'Point', coordinates: [5, 6] }
+    const { geometry, bbox } = preprocessQueryGeometry(point)
+    expect(geometry).toEqual(point)
+    expect(bbox).toMatchObject({
+      west: 5,
+      east: 5,
+      south: 6,
+      north: 6,
+      crossesAntimeridian: false,
+    })
+  })
+})
+
+describe('transformGeometryToPixelSpace', () => {
+  const worldBounds: Bounds = [-180, -90, 180, 90]
+
+  it('maps a polygon linearly under EPSG:4326', () => {
+    const result = transformGeometryToPixelSpace(
+      rect(-90, -45, 90, 45),
+      worldBounds,
+      360,
+      180,
+      'EPSG:4326',
+      false // north at top
+    )
+    expect(result).not.toBeNull()
+    expect(result!.type).toBe('Polygon')
+    // lon -90 -> x 90, lon 90 -> x 270; lat 45 -> y 45 (north), lat -45 -> y 135.
+    const ring = (result as { coordinates: number[][][] }).coordinates[0]
+    const xs = ring.map((p) => p[0])
+    const ys = ring.map((p) => p[1])
+    expect(Math.min(...xs)).toBeCloseTo(90, 6)
+    expect(Math.max(...xs)).toBeCloseTo(270, 6)
+    expect(Math.min(...ys)).toBeCloseTo(45, 6)
+    expect(Math.max(...ys)).toBeCloseTo(135, 6)
+  })
+
+  it('keeps a polygon past the mercator pole limit finite and non-collapsed', () => {
+    // lat 86 is past the mercator limit (~85.05°); the projection must clamp
+    // rather than blow up to infinity. EPSG:3857 bounds are in meters, so the
+    // source-CRS forward output and the bounds share units (a realistic call).
+    const E = WEB_MERCATOR_EXTENT
+    const nearPole: QueryGeometry = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 85],
+          [10, 85],
+          [10, 86],
+          [0, 86],
+          [0, 85],
+        ],
+      ],
+    }
+    const result = transformGeometryToPixelSpace(
+      nearPole,
+      [-E, -E, E, E],
+      100,
+      100,
+      'EPSG:3857'
+    )
+    // transformGeometryToPixelSpace *drops* non-finite vertices, so a bare
+    // "no NaN in output" check is vacuous — a singularity would silently
+    // collapse the ring (or null the result) instead of emitting NaN. Assert
+    // the ring actually survived, then that every surviving vertex is finite.
+    expect(result).not.toBeNull()
+    expect(result!.type).toBe('Polygon')
+    const rings = (result as { coordinates: number[][][] }).coordinates
+    expect(rings[0].length).toBeGreaterThanOrEqual(4)
+    for (const ring of rings) {
+      for (const [x, y] of ring) {
+        expect(Number.isFinite(x)).toBe(true)
+        expect(Number.isFinite(y)).toBe(true)
+      }
+    }
+  })
+})
+
+describe('computePixelBoundsFromGeometry', () => {
+  const worldBounds: Bounds = [-180, -90, 180, 90]
+
+  it('returns a single-pixel rect for a point', () => {
+    const point: QueryGeometry = { type: 'Point', coordinates: [0, 0] }
+    const r = computePixelBoundsFromGeometry(
+      point,
+      worldBounds,
+      360,
+      180,
+      'EPSG:4326',
+      false
+    )
+    expect(r).toEqual({ minX: 180, maxX: 181, minY: 90, maxY: 91 })
+  })
+
+  it('computes a tight bbox for a polygon', () => {
+    const r = computePixelBoundsFromGeometry(
+      rect(-90, -45, 90, 45),
+      worldBounds,
+      360,
+      180,
+      'EPSG:4326',
+      false
+    )
+    expect(r).not.toBeNull()
+    expect(r!.minX).toBe(90)
+    expect(r!.minY).toBe(45)
+    expect(r!.maxX).toBeGreaterThanOrEqual(270)
+    expect(r!.maxY).toBeGreaterThanOrEqual(135)
+  })
+})

--- a/src/query/region-query.test.ts
+++ b/src/query/region-query.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest'
+import { queryRegionUntiled, findSpatialDimNames } from './region-query'
+import type { QueryGeometry } from './types'
+import type { Bounds, DimIndicesProps } from '../types'
+import { indexRamp, indexToXY } from '../__fixtures__/grids'
+import { rect } from '../__fixtures__/geometry'
+
+const WORLD: Bounds = [-180, -90, 180, 90]
+
+/**
+ * Query an `indexRamp` grid and return the selected pixels as [x, y] pairs.
+ * Because each pixel's value is its own flat index, the returned values map
+ * back to exactly which pixels the query selected.
+ */
+function selectedPixels(
+  geometry: QueryGeometry,
+  width: number,
+  height: number
+): Array<[number, number]> {
+  const { data } = indexRamp(width, height)
+  const result = queryRegionUntiled(
+    'v',
+    geometry,
+    {},
+    data,
+    width,
+    height,
+    ['lat', 'lon'],
+    {},
+    WORLD,
+    'EPSG:4326',
+    1,
+    undefined,
+    undefined,
+    false // latIsAscending = false (north at top)
+  )
+  return (result.v as number[]).map((value) =>
+    indexToXY(Math.round(value), width)
+  )
+}
+
+describe('queryRegionUntiled — coverage', () => {
+  it('selects every pixel for a whole-world polygon', () => {
+    const pixels = selectedPixels(rect(-180, -90, 180, 90), 10, 10)
+    expect(pixels).toHaveLength(100)
+  })
+
+  it('selects the interior (center-based) for an inset polygon', () => {
+    // rect maps to the pixel box [1,1]..[9,9]; centers inside cover x,y in 1..8.
+    const pixels = selectedPixels(rect(-144, -72, 144, 72), 10, 10)
+    expect(pixels).toHaveLength(64)
+    expect(pixels).toContainEqual([5, 5])
+    expect(pixels).not.toContainEqual([0, 0])
+    expect(pixels).not.toContainEqual([9, 9])
+  })
+
+  it('selects nothing for a polygon smaller than one pixel', () => {
+    // ~0.01° box near the origin — no pixel center falls inside.
+    const pixels = selectedPixels(rect(-0.005, -0.005, 0.005, 0.005), 10, 10)
+    expect(pixels).toHaveLength(0)
+  })
+
+  it('reads the single pixel under a point', () => {
+    const { data } = indexRamp(10, 10)
+    const point: QueryGeometry = { type: 'Point', coordinates: [0, 0] }
+    const result = queryRegionUntiled(
+      'v',
+      point,
+      {},
+      data,
+      10,
+      10,
+      ['lat', 'lon'],
+      {},
+      WORLD,
+      'EPSG:4326',
+      1,
+      undefined,
+      undefined,
+      false
+    )
+    // Origin maps to pixel (5, 5) -> flat index 55.
+    expect(result.v).toEqual([55])
+  })
+})
+
+describe('queryRegionUntiled — value handling', () => {
+  it('filters fill values / NaN and applies scale + offset', () => {
+    const data = new Float32Array([10, -9999, 20, NaN]) // 2x2, row-major
+    const result = queryRegionUntiled(
+      'v',
+      rect(-180, -90, 180, 90),
+      {},
+      data,
+      2,
+      2,
+      ['lat', 'lon'],
+      {},
+      WORLD,
+      'EPSG:4326',
+      1,
+      undefined,
+      undefined,
+      false,
+      { scaleFactor: 2, addOffset: 1, fillValue: -9999 }
+    )
+    // 10*2+1 = 21, 20*2+1 = 41; -9999 (fill) and NaN dropped.
+    expect(result.v).toEqual([21, 41])
+  })
+
+  it('reports spatial dimension names and coordinate arrays', () => {
+    const { data } = indexRamp(4, 4)
+    const result = queryRegionUntiled(
+      'v',
+      rect(-180, -90, 180, 90),
+      {},
+      data,
+      4,
+      4,
+      ['lat', 'lon'],
+      {},
+      WORLD,
+      'EPSG:4326',
+      1,
+      undefined,
+      undefined,
+      false
+    )
+    expect(result.dimensions).toEqual(['lat', 'lon'])
+    expect(result.coordinates).toHaveProperty('lat')
+    expect(result.coordinates).toHaveProperty('lon')
+    expect((result.coordinates.lat as number[]).length).toBe(
+      (result.v as number[]).length
+    )
+  })
+
+  it('returns an empty result for null data', () => {
+    const result = queryRegionUntiled(
+      'v',
+      rect(-10, -10, 10, 10),
+      {},
+      null,
+      10,
+      10,
+      ['lat', 'lon'],
+      {},
+      WORLD,
+      'EPSG:4326'
+    )
+    expect(result.v).toEqual([])
+  })
+})
+
+describe('findSpatialDimNames', () => {
+  it('matches common spatial aliases', () => {
+    expect(findSpatialDimNames(['lat', 'lon'])).toEqual({
+      yDim: 'lat',
+      xDim: 'lon',
+    })
+    expect(findSpatialDimNames(['latitude', 'longitude'])).toEqual({
+      yDim: 'latitude',
+      xDim: 'longitude',
+    })
+    expect(findSpatialDimNames(['y', 'x'])).toEqual({ yDim: 'y', xDim: 'x' })
+  })
+
+  it('falls back to lat/lon when no alias matches', () => {
+    expect(findSpatialDimNames(['time', 'band'])).toEqual({
+      yDim: 'lat',
+      xDim: 'lon',
+    })
+  })
+
+  it('prefers dimIndices overrides', () => {
+    const dimIndices: DimIndicesProps = {
+      lat: { name: 'south_north', index: 0, array: null },
+      lon: { name: 'west_east', index: 1, array: null },
+    }
+    expect(
+      findSpatialDimNames(['south_north', 'west_east'], dimIndices)
+    ).toEqual({
+      yDim: 'south_north',
+      xDim: 'west_east',
+    })
+  })
+})

--- a/src/query/selector-utils.test.ts
+++ b/src/query/selector-utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { setObjectValues } from './selector-utils'
+import type { QueryDataValues } from './types'
+
+describe('setObjectValues', () => {
+  it('pushes onto a flat array for empty keys', () => {
+    const obj: QueryDataValues = []
+    setObjectValues(obj, [], 5)
+    expect(obj).toEqual([5])
+  })
+
+  it('accumulates values under a single key', () => {
+    const obj: QueryDataValues = {}
+    setObjectValues(obj, ['a'], 5)
+    setObjectValues(obj, ['a'], 6)
+    expect(obj).toEqual({ a: [5, 6] })
+  })
+
+  it('builds nested structure for multi-level keys', () => {
+    const obj: QueryDataValues = {}
+    setObjectValues(obj, ['a', 'b'], 5)
+    expect(obj).toEqual({ a: { b: [5] } })
+  })
+})

--- a/src/region-cache.test.ts
+++ b/src/region-cache.test.ts
@@ -102,6 +102,30 @@ describe('isRegionGpuReady', () => {
     expect(isRegionGpuReady(r)).toBe(false)
   })
 
+  it('requires the band textures a custom shader will sample', () => {
+    const r = cpuReadyRegion()
+    r.textureUploaded = true
+    r.geometryUploaded = true
+    // The main texture is resident, but a band-sampling shader draws from
+    // textures that do not exist yet, so the region is not drawable.
+    expect(isRegionGpuReady(r, ['red', 'green'])).toBe(false)
+
+    r.bandTexturesUploaded.add('red')
+    expect(isRegionGpuReady(r, ['red', 'green'])).toBe(false)
+
+    r.bandTexturesUploaded.add('green')
+    expect(isRegionGpuReady(r, ['red', 'green'])).toBe(true)
+  })
+
+  it('ignores the main texture when bands are required', () => {
+    const r = cpuReadyRegion()
+    r.geometryUploaded = true
+    r.bandTexturesUploaded.add('red')
+    // Band rendering never creates a main texture.
+    expect(r.textureUploaded).toBe(false)
+    expect(isRegionGpuReady(r, ['red'])).toBe(true)
+  })
+
   it('goes stale again when a refetch marks the uploads dirty', () => {
     const r = cpuReadyRegion()
     r.textureUploaded = true

--- a/src/region-cache.test.ts
+++ b/src/region-cache.test.ts
@@ -4,7 +4,8 @@ import {
   RegionCache,
   createRegionState,
   disposeRegion,
-  isRegionValid,
+  isRegionCpuReady,
+  isRegionGpuReady,
   makeRegionKey,
 } from './region-cache'
 import type { RegionState } from './region-state'
@@ -57,28 +58,59 @@ describe('createRegionState', () => {
   })
 })
 
-describe('isRegionValid', () => {
+function cpuReadyRegion() {
+  const r = region(0, 0, 0)
+  r.data = new Float32Array(4)
+  r.vertexArr = new Float32Array(8)
+  r.pixCoordArr = new Float32Array(8)
+  r.mercatorBounds = { x0: 0, y0: 0, x1: 1, y1: 1 }
+  r.levelMeta = { width: 2, height: 2, regionSize: [2, 2] }
+  return r
+}
+
+describe('isRegionCpuReady', () => {
   it('requires CPU-side data, geometry arrays, bounds, and level meta', () => {
-    const r = region(0, 0, 0)
-    expect(isRegionValid(r)).toBe(false)
-    r.data = new Float32Array(4)
-    r.vertexArr = new Float32Array(8)
-    r.pixCoordArr = new Float32Array(8)
-    r.mercatorBounds = { x0: 0, y0: 0, x1: 1, y1: 1 }
-    r.levelMeta = { width: 2, height: 2, regionSize: [2, 2] }
-    expect(isRegionValid(r)).toBe(true)
+    expect(isRegionCpuReady(region(0, 0, 0))).toBe(false)
+    expect(isRegionCpuReady(cpuReadyRegion())).toBe(true)
   })
 
   it('does not require GPU resources (uploads happen lazily at render)', () => {
-    const r = region(0, 0, 0)
-    r.data = new Float32Array(4)
-    r.vertexArr = new Float32Array(8)
-    r.pixCoordArr = new Float32Array(8)
-    r.mercatorBounds = { x0: 0, y0: 0, x1: 1, y1: 1 }
-    r.levelMeta = { width: 2, height: 2, regionSize: [2, 2] }
+    const r = cpuReadyRegion()
     expect(r.texture).toBeNull()
     expect(r.vertexBuffer).toBeNull()
-    expect(isRegionValid(r)).toBe(true)
+    expect(isRegionCpuReady(r)).toBe(true)
+  })
+})
+
+describe('isRegionGpuReady', () => {
+  it('requires both uploads on top of CPU readiness', () => {
+    const r = cpuReadyRegion()
+    expect(isRegionGpuReady(r)).toBe(false)
+
+    r.textureUploaded = true
+    expect(isRegionGpuReady(r)).toBe(false)
+
+    r.geometryUploaded = true
+    expect(isRegionGpuReady(r)).toBe(true)
+  })
+
+  it('is false for an uploaded region whose data was dropped', () => {
+    const r = cpuReadyRegion()
+    r.textureUploaded = true
+    r.geometryUploaded = true
+    r.data = null
+    expect(isRegionGpuReady(r)).toBe(false)
+  })
+
+  it('goes stale again when a refetch marks the uploads dirty', () => {
+    const r = cpuReadyRegion()
+    r.textureUploaded = true
+    r.geometryUploaded = true
+
+    // A refetch clears the texture flag; a regenerated mesh clears the other.
+    r.textureUploaded = false
+    expect(isRegionGpuReady(r)).toBe(false)
+    expect(isRegionCpuReady(r)).toBe(true)
   })
 })
 

--- a/src/region-cache.test.ts
+++ b/src/region-cache.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  MAX_CACHED_REGIONS,
+  RegionCache,
+  createRegionState,
+  disposeRegion,
+  isRegionValid,
+  makeRegionKey,
+} from './region-cache'
+import type { RegionState } from './region-state'
+
+/**
+ * Contract tests for the region cache: FIFO eviction under a hard cap,
+ * viewport-driven protection, and GL resource disposal. Protection semantics
+ * pin the eviction fix (PR #75 review): the protected set is rebuilt from the
+ * current viewport each update, never accumulated, so panning at a fixed zoom
+ * can't grow the cache without bound.
+ */
+
+function fakeGl() {
+  return {
+    deleteTexture: vi.fn(),
+    deleteBuffer: vi.fn(),
+  } as unknown as WebGL2RenderingContext
+}
+
+function region(levelIndex: number, x: number, y: number): RegionState {
+  return createRegionState(levelIndex, x, y, false, 0)
+}
+
+function fill(cache: RegionCache, count: number, levelIndex = 0): string[] {
+  const keys: string[] = []
+  for (let i = 0; i < count; i++) {
+    const r = region(levelIndex, i, 0)
+    cache.set(r.key, r)
+    keys.push(r.key)
+  }
+  return keys
+}
+
+describe('makeRegionKey', () => {
+  it('encodes level and coordinates', () => {
+    expect(makeRegionKey(3, 7, 2)).toBe('3:7,2')
+  })
+})
+
+describe('createRegionState', () => {
+  it('stamps orientation and selector version with empty resources', () => {
+    const r = createRegionState(2, 1, 4, true, 7)
+    expect(r.key).toBe('2:1,4')
+    expect(r.latIsAscending).toBe(true)
+    expect(r.selectorVersion).toBe(7)
+    expect(r.data).toBeNull()
+    expect(r.texture).toBeNull()
+    expect(r.vertexBuffer).toBeNull()
+    expect(r.loading).toBe(false)
+  })
+})
+
+describe('isRegionValid', () => {
+  it('requires CPU-side data, geometry arrays, bounds, and level meta', () => {
+    const r = region(0, 0, 0)
+    expect(isRegionValid(r)).toBe(false)
+    r.data = new Float32Array(4)
+    r.vertexArr = new Float32Array(8)
+    r.pixCoordArr = new Float32Array(8)
+    r.mercatorBounds = { x0: 0, y0: 0, x1: 1, y1: 1 }
+    r.levelMeta = { width: 2, height: 2, regionSize: [2, 2] }
+    expect(isRegionValid(r)).toBe(true)
+  })
+
+  it('does not require GPU resources (uploads happen lazily at render)', () => {
+    const r = region(0, 0, 0)
+    r.data = new Float32Array(4)
+    r.vertexArr = new Float32Array(8)
+    r.pixCoordArr = new Float32Array(8)
+    r.mercatorBounds = { x0: 0, y0: 0, x1: 1, y1: 1 }
+    r.levelMeta = { width: 2, height: 2, regionSize: [2, 2] }
+    expect(r.texture).toBeNull()
+    expect(r.vertexBuffer).toBeNull()
+    expect(isRegionValid(r)).toBe(true)
+  })
+})
+
+describe('disposeRegion', () => {
+  it('deletes the texture, geometry buffers, and band textures', () => {
+    const gl = fakeGl()
+    const r = region(0, 0, 0)
+    r.texture = {} as WebGLTexture
+    r.vertexBuffer = {} as WebGLBuffer
+    r.pixCoordBuffer = {} as WebGLBuffer
+    r.indexBuffer = {} as WebGLBuffer
+    r.bandTextures.set('a', {} as WebGLTexture)
+    r.bandTextures.set('b', {} as WebGLTexture)
+
+    disposeRegion(gl, r)
+    expect(gl.deleteTexture).toHaveBeenCalledTimes(3) // main + 2 bands
+    expect(gl.deleteBuffer).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('RegionCache.evict', () => {
+  it('prunes oldest-first down to the cap', () => {
+    const cache = new RegionCache()
+    const keys = fill(cache, MAX_CACHED_REGIONS + 10)
+    cache.evict(fakeGl())
+
+    expect(cache.size).toBe(MAX_CACHED_REGIONS)
+    // The 10 oldest (insertion order) are gone; the newest all survive.
+    for (const key of keys.slice(0, 10)) expect(cache.get(key)).toBeUndefined()
+    for (const key of keys.slice(10)) expect(cache.get(key)).toBeDefined()
+  })
+
+  it('skips protected regions and evicts the oldest unprotected instead', () => {
+    const cache = new RegionCache()
+    const keys = fill(cache, MAX_CACHED_REGIONS + 5)
+    cache.rebuildProtection(keys.slice(0, 5), { retainKeysNotMatching: '' })
+    cache.evict(fakeGl())
+
+    expect(cache.size).toBe(MAX_CACHED_REGIONS)
+    for (const key of keys.slice(0, 5)) expect(cache.get(key)).toBeDefined()
+    for (const key of keys.slice(5, 10)) expect(cache.get(key)).toBeUndefined()
+  })
+
+  it('stops when every region is protected (low-zoom safety valve)', () => {
+    const cache = new RegionCache()
+    const keys = fill(cache, MAX_CACHED_REGIONS + 20)
+    cache.rebuildProtection(keys, { retainKeysNotMatching: '' })
+    cache.evict(fakeGl())
+    expect(cache.size).toBe(MAX_CACHED_REGIONS + 20)
+  })
+
+  it('disposes GL resources on eviction', () => {
+    const gl = fakeGl()
+    const cache = new RegionCache()
+    const keys = fill(cache, MAX_CACHED_REGIONS + 1)
+    const oldest = cache.get(keys[0])!
+    oldest.texture = {} as WebGLTexture
+    cache.evict(gl)
+    expect(gl.deleteTexture).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('RegionCache.rebuildProtection', () => {
+  it('replaces protection with the visible set when the level covers the viewport', () => {
+    const cache = new RegionCache()
+    cache.rebuildProtection(['0:0,0', '1:5,5'], { retainKeysNotMatching: '' })
+    // Covered viewport: retain nothing from before (every key matches '').
+    cache.rebuildProtection(['1:1,1', '1:2,1'], { retainKeysNotMatching: '' })
+
+    expect(cache.isProtected('1:1,1')).toBe(true)
+    expect(cache.isProtected('1:2,1')).toBe(true)
+    expect(cache.isProtected('0:0,0')).toBe(false)
+    expect(cache.isProtected('1:5,5')).toBe(false)
+  })
+
+  it('retains cross-level fallback keys while the level is not covered', () => {
+    const cache = new RegionCache()
+    cache.rebuildProtection(['0:0,0', '1:5,5'], { retainKeysNotMatching: '' })
+    // Now level 1 is current but not yet covering: keep other levels' keys,
+    // drop level-1 keys that are no longer visible.
+    cache.rebuildProtection(['1:1,1'], { retainKeysNotMatching: '1:' })
+
+    expect(cache.isProtected('1:1,1')).toBe(true)
+    expect(cache.isProtected('0:0,0')).toBe(true) // other-level fallback kept
+    expect(cache.isProtected('1:5,5')).toBe(false) // same-level, not visible
+  })
+})
+
+describe('RegionCache.clear', () => {
+  it('disposes everything and resets protection', () => {
+    const gl = fakeGl()
+    const cache = new RegionCache()
+    const keys = fill(cache, 3)
+    for (const key of keys) cache.get(key)!.texture = {} as WebGLTexture
+    cache.rebuildProtection(keys, { retainKeysNotMatching: '' })
+
+    cache.clear(gl)
+    expect(cache.size).toBe(0)
+    expect(gl.deleteTexture).toHaveBeenCalledTimes(3)
+    for (const key of keys) expect(cache.isProtected(key)).toBe(false)
+  })
+})

--- a/src/region-cache.ts
+++ b/src/region-cache.ts
@@ -53,15 +53,22 @@ export function createRegionState(
 }
 
 /**
+ * The region's pixels have arrived, in whichever form the active shader
+ * reads them. Band-sampling regions carry no interleaved copy, so `data`
+ * alone is not the test for whether a region still needs fetching.
+ */
+export function hasRegionData(region: RegionState): boolean {
+  return !!region.data || region.bandData.size > 0
+}
+
+/**
  * The region has everything an upload needs. Gates whether
  * `ensureRegionGpuResources` is worth attempting — not whether the region can
  * be drawn, which also requires that upload to have succeeded.
  */
 export function isRegionCpuReady(region: RegionState): boolean {
-  // Band-sampling regions carry no interleaved copy; their pixels live in
-  // bandData instead.
   return !!(
-    (region.data || region.bandData.size > 0) &&
+    hasRegionData(region) &&
     region.vertexArr &&
     region.pixCoordArr &&
     region.mercatorBounds &&

--- a/src/region-cache.ts
+++ b/src/region-cache.ts
@@ -54,11 +54,8 @@ export function createRegionState(
 export function isRegionValid(region: RegionState): boolean {
   return !!(
     region.data &&
-    region.textureUploaded &&
-    region.texture &&
-    region.vertexBuffer &&
-    region.pixCoordBuffer &&
     region.vertexArr &&
+    region.pixCoordArr &&
     region.mercatorBounds &&
     region.levelMeta
   )

--- a/src/region-cache.ts
+++ b/src/region-cache.ts
@@ -72,13 +72,20 @@ export function isRegionCpuReady(region: RegionState): boolean {
  * decide that a level covers the viewport: a level that displaces its
  * lower-resolution fallbacks on CPU state alone leaves nothing on screen if
  * its uploads then fail.
+ *
+ * `requiredBands` names the textures a custom shader samples. Pass the same
+ * list the draw call uses, or a region whose main texture is resident but
+ * whose bands are not would count towards coverage and then fail to draw.
  */
-export function isRegionGpuReady(region: RegionState): boolean {
-  return (
-    isRegionCpuReady(region) &&
-    region.textureUploaded &&
-    region.geometryUploaded
-  )
+export function isRegionGpuReady(
+  region: RegionState,
+  requiredBands?: readonly string[]
+): boolean {
+  if (!isRegionCpuReady(region) || !region.geometryUploaded) return false
+  if (requiredBands && requiredBands.length > 0) {
+    return requiredBands.every((band) => region.bandTexturesUploaded.has(band))
+  }
+  return region.textureUploaded
 }
 
 export function disposeRegion(

--- a/src/region-cache.ts
+++ b/src/region-cache.ts
@@ -34,6 +34,7 @@ export function createRegionState(
     vertexBuffer: null,
     pixCoordBuffer: null,
     indexBuffer: null,
+    geometryUploaded: false,
     vertexArr: null,
     pixCoordArr: null,
     indexArr: null,

--- a/src/region-cache.ts
+++ b/src/region-cache.ts
@@ -1,0 +1,140 @@
+import type { RegionState } from './region-state'
+
+/** Maximum number of regions to keep in cache (LRU eviction) */
+export const MAX_CACHED_REGIONS = 128
+
+export function makeRegionKey(
+  levelIndex: number,
+  regionX: number,
+  regionY: number
+): string {
+  return `${levelIndex}:${regionX},${regionY}`
+}
+
+export function createRegionState(
+  levelIndex: number,
+  regionX: number,
+  regionY: number,
+  latIsAscending: boolean,
+  selectorVersion: number
+): RegionState {
+  return {
+    key: makeRegionKey(levelIndex, regionX, regionY),
+    levelIndex,
+    regionX,
+    regionY,
+    data: null,
+    width: 0,
+    height: 0,
+    loading: false,
+    requestId: null,
+    channels: 1,
+    texture: null,
+    textureUploaded: false,
+    vertexBuffer: null,
+    pixCoordBuffer: null,
+    indexBuffer: null,
+    vertexArr: null,
+    pixCoordArr: null,
+    indexArr: null,
+    vertexCount: 0,
+    useIndexedMesh: false,
+    mercatorBounds: null,
+    wgs84Bounds: null,
+    latIsAscending,
+    selectorVersion,
+    bandData: new Map(),
+    bandTextures: new Map(),
+    bandTexturesUploaded: new Set(),
+    bandTexturesConfigured: new Set(),
+    levelMeta: null, // Set from snapshot in fetchRegion
+  }
+}
+
+export function isRegionValid(region: RegionState): boolean {
+  return !!(
+    region.data &&
+    region.textureUploaded &&
+    region.texture &&
+    region.vertexBuffer &&
+    region.pixCoordBuffer &&
+    region.vertexArr &&
+    region.mercatorBounds &&
+    region.levelMeta
+  )
+}
+
+export function disposeRegion(
+  gl: WebGL2RenderingContext | WebGLRenderingContext,
+  region: RegionState
+): void {
+  if (region.texture) gl.deleteTexture(region.texture)
+  if (region.vertexBuffer) gl.deleteBuffer(region.vertexBuffer)
+  if (region.pixCoordBuffer) gl.deleteBuffer(region.pixCoordBuffer)
+  if (region.indexBuffer) gl.deleteBuffer(region.indexBuffer)
+  for (const tex of region.bandTextures.values()) gl.deleteTexture(tex)
+}
+
+export class RegionCache {
+  private regions = new Map<string, RegionState>()
+  private protectedKeys = new Set<string>()
+
+  get size(): number {
+    return this.regions.size
+  }
+  get(key: string): RegionState | undefined {
+    return this.regions.get(key)
+  }
+  set(key: string, region: RegionState): void {
+    this.regions.set(key, region)
+  }
+  delete(key: string): boolean {
+    return this.regions.delete(key)
+  }
+  values(): MapIterator<RegionState> {
+    return this.regions.values()
+  }
+  entries(): MapIterator<[string, RegionState]> {
+    return this.regions.entries()
+  }
+  [Symbol.iterator](): MapIterator<[string, RegionState]> {
+    return this.regions[Symbol.iterator]()
+  }
+  isProtected(key: string): boolean {
+    return this.protectedKeys.has(key)
+  }
+
+  rebuildProtection(
+    visibleKeys: Iterable<string>,
+    { retainKeysNotMatching }: { retainKeysNotMatching: string }
+  ): void {
+    const nextProtected = new Set(visibleKeys)
+    for (const key of this.protectedKeys) {
+      if (!key.startsWith(retainKeysNotMatching)) nextProtected.add(key)
+    }
+    this.protectedKeys = nextProtected
+  }
+
+  evict(gl: WebGL2RenderingContext): void {
+    // Uses Map iteration order (oldest first). Never evicts currently visible regions.
+    while (this.regions.size > MAX_CACHED_REGIONS) {
+      let evictedKey: string | null = null
+      for (const key of this.regions.keys()) {
+        if (!this.protectedKeys.has(key)) {
+          evictedKey = key
+          break
+        }
+      }
+      if (!evictedKey) break // All regions are visible, stop
+      const region = this.regions.get(evictedKey)
+      if (region) disposeRegion(gl, region)
+      this.regions.delete(evictedKey)
+    }
+  }
+
+  clear(gl: WebGL2RenderingContext | WebGLRenderingContext): void {
+    for (const region of this.regions.values()) disposeRegion(gl, region)
+    this.regions.clear()
+    this.protectedKeys.clear()
+  }
+}

--- a/src/region-cache.ts
+++ b/src/region-cache.ts
@@ -52,13 +52,32 @@ export function createRegionState(
   }
 }
 
-export function isRegionValid(region: RegionState): boolean {
+/**
+ * The region has everything an upload needs. Gates whether
+ * `ensureRegionGpuResources` is worth attempting — not whether the region can
+ * be drawn, which also requires that upload to have succeeded.
+ */
+export function isRegionCpuReady(region: RegionState): boolean {
   return !!(
     region.data &&
     region.vertexArr &&
     region.pixCoordArr &&
     region.mercatorBounds &&
     region.levelMeta
+  )
+}
+
+/**
+ * The region is drawable right now. Use this, never `isRegionCpuReady`, to
+ * decide that a level covers the viewport: a level that displaces its
+ * lower-resolution fallbacks on CPU state alone leaves nothing on screen if
+ * its uploads then fail.
+ */
+export function isRegionGpuReady(region: RegionState): boolean {
+  return (
+    isRegionCpuReady(region) &&
+    region.textureUploaded &&
+    region.geometryUploaded
   )
 }
 

--- a/src/region-cache.ts
+++ b/src/region-cache.ts
@@ -58,8 +58,10 @@ export function createRegionState(
  * be drawn, which also requires that upload to have succeeded.
  */
 export function isRegionCpuReady(region: RegionState): boolean {
+  // Band-sampling regions carry no interleaved copy; their pixels live in
+  // bandData instead.
   return !!(
-    region.data &&
+    (region.data || region.bandData.size > 0) &&
     region.vertexArr &&
     region.pixCoordArr &&
     region.mercatorBounds &&

--- a/src/region-fetcher.test.ts
+++ b/src/region-fetcher.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi } from 'vitest'
+import { RegionFetcher, type RegionFetcherContext } from './region-fetcher'
+import { RegionCache, makeRegionKey } from './region-cache'
+import { createProjectionContext } from './projection-utils'
+import { createRequestCanceller, cancelAllRequests } from './region-utils'
+import { ZarrStore } from './zarr-store'
+import { buildMemoryZarrStore } from './__fixtures__/memory-zarr'
+import type { LevelRuntime } from './region-state'
+
+/**
+ * Integration tests for the (GL-free) fetch pipeline against the in-memory
+ * Zarr fixture: a real ZarrStore, real zarrita reads, and the real cache.
+ * Geometry creation is injected as a spy; GPU upload is out of scope (it
+ * happens lazily at render time).
+ */
+
+// 4-lat x 8-lon index ramp split into 2x4 chunks -> a 2x2 region grid.
+const HEIGHT = 4
+const WIDTH = 8
+const REGION: [number, number] = [2, 4]
+
+function chunkData(chunkY: number, chunkX: number): number[] {
+  const out: number[] = []
+  for (let y = chunkY * 2; y < chunkY * 2 + 2; y++) {
+    for (let x = chunkX * 4; x < chunkX * 4 + 4; x++) {
+      out.push(y * WIDTH + x)
+    }
+  }
+  return out
+}
+
+function makeMemoryStore(attributes: Record<string, unknown> = {}) {
+  return buildMemoryZarrStore({
+    arrays: [
+      {
+        name: 'temperature',
+        shape: [HEIGHT, WIDTH],
+        chunkShape: REGION,
+        dimensionNames: ['lat', 'lon'],
+        attributes,
+        chunks: {
+          '0/0': chunkData(0, 0),
+          '0/1': chunkData(0, 1),
+          '1/0': chunkData(1, 0),
+          '1/1': chunkData(1, 1),
+        },
+      },
+    ],
+  })
+}
+
+async function makeHarness(
+  opts: {
+    attributes?: Record<string, unknown>
+    gateReads?: boolean
+  } = {}
+) {
+  const memory = makeMemoryStore(opts.attributes)
+  let releaseReads = () => {}
+  const readsReleased = new Promise<void>((res) => {
+    releaseReads = res
+  })
+  // Optionally hold chunk reads open so tests can abort/invalidate mid-fetch.
+  const customStore = opts.gateReads
+    ? {
+        get: async (key: string) => {
+          if (key.includes('/c/')) await readsReleased
+          return memory.get(key)
+        },
+      }
+    : memory
+
+  const store = new ZarrStore({
+    customStore,
+    variable: 'temperature',
+    version: 3,
+    bounds: [-180, -90, 180, 90],
+    latIsAscending: false,
+  })
+  await store.initialized
+  const zarrArray = await store.getArray()
+
+  let level: LevelRuntime | null = {
+    index: 0,
+    zarrArray,
+    width: WIDTH,
+    height: HEIGHT,
+    regionSize: REGION,
+    baseSliceArgs: [0, 0],
+    baseMultiValueDims: [],
+  }
+  let selectorVersion = 0
+
+  const cache = new RegionCache()
+  const requestCanceller = createRequestCanceller()
+  const invalidate = vi.fn()
+  const createRegionGeometry = vi.fn()
+
+  const context: RegionFetcherContext = {
+    zarrStore: store,
+    dimIndices: store.describe().dimIndices,
+    levels: [],
+    projection: createProjectionContext({
+      crs: 'EPSG:4326',
+      proj4def: null,
+      xyLimits: { xMin: -180, xMax: 180, yMin: -90, yMax: 90 },
+    }),
+    xyLimits: { xMin: -180, xMax: 180, yMin: -90, yMax: 90 },
+    latIsAscending: false,
+    fixedDataScale: 1,
+    regionCache: cache,
+    requestCanceller,
+    loadingDebouncer: { show: () => {}, hide: () => {} },
+    getActiveLevel: () => level,
+    getSelectorVersion: () => selectorVersion,
+    getBandNames: () => ['temperature'],
+    isRemoved: () => false,
+    getRegionBounds: () => ({ xMin: 0, xMax: 1, yMin: 0, yMax: 1 }),
+    computeRegionMercatorBounds: () => ({ x0: 0, y0: 0, x1: 1, y1: 1 }),
+    createRegionGeometry,
+    invalidate,
+  }
+
+  return {
+    fetcher: new RegionFetcher(context),
+    context,
+    cache,
+    requestCanceller,
+    invalidate,
+    createRegionGeometry,
+    releaseReads,
+    setLevel: (next: LevelRuntime | null) => {
+      level = next
+    },
+    getLevel: () => level,
+    setSelectorVersion: (v: number) => {
+      selectorVersion = v
+    },
+  }
+}
+
+describe('RegionFetcher', () => {
+  it('fetches region chunks into CPU-side state', async () => {
+    const { fetcher, cache, createRegionGeometry, invalidate } =
+      await makeHarness()
+    await fetcher.fetchRegions([
+      { regionX: 0, regionY: 0 },
+      { regionX: 1, regionY: 1 },
+    ])
+
+    const topLeft = cache.get(makeRegionKey(0, 0, 0))!
+    expect(Array.from(topLeft.data!)).toEqual(chunkData(0, 0))
+    expect(topLeft.width).toBe(4)
+    expect(topLeft.height).toBe(2)
+    expect(topLeft.loading).toBe(false)
+    expect(topLeft.requestId).toBeNull()
+    expect(topLeft.levelMeta).toEqual({
+      width: WIDTH,
+      height: HEIGHT,
+      regionSize: REGION,
+    })
+
+    const bottomRight = cache.get(makeRegionKey(0, 1, 1))!
+    expect(Array.from(bottomRight.data!)).toEqual(chunkData(1, 1))
+
+    expect(createRegionGeometry).toHaveBeenCalledTimes(2)
+    expect(invalidate).toHaveBeenCalled()
+  })
+
+  it('leaves GPU upload to render time', async () => {
+    const { fetcher, cache } = await makeHarness()
+    await fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+
+    const region = cache.get(makeRegionKey(0, 0, 0))!
+    expect(region.texture).toBeNull()
+    expect(region.textureUploaded).toBe(false)
+    expect(region.bandData.get('temperature')).toBeDefined()
+    expect(region.bandTexturesUploaded.size).toBe(0)
+  })
+
+  it('applies scale/offset to raw values', async () => {
+    const { fetcher, cache } = await makeHarness({
+      attributes: { scale_factor: 2, add_offset: 10 },
+    })
+    await fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+
+    const region = cache.get(makeRegionKey(0, 0, 0))!
+    expect(Array.from(region.data!)).toEqual(
+      chunkData(0, 0).map((v) => v * 2 + 10)
+    )
+  })
+
+  it('never lets an older fetch overwrite newer region data', async () => {
+    const { fetcher, cache } = await makeHarness()
+    // A region already refreshed by a newer selector version...
+    const key = makeRegionKey(0, 0, 0)
+    await fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+    const region = cache.get(key)!
+    region.selectorVersion = 5
+    region.data = null
+
+    // ...must ignore a fetch batch stamped with the old version.
+    await fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+    expect(region.data).toBeNull()
+    expect(region.selectorVersion).toBe(5)
+  })
+
+  it('cancels the whole batch when the level changed before dispatch', async () => {
+    const { fetcher, cache, context, getLevel } = await makeHarness()
+    // The getter serves the old level to the snapshot, then the new one to
+    // the pre-flight staleness check.
+    const original = getLevel()!
+    const swapped: LevelRuntime = { ...original, index: 1 }
+    let calls = 0
+    context.getActiveLevel = () => (calls++ === 0 ? original : swapped)
+
+    await fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+    const region = cache.get(makeRegionKey(0, 0, 0))!
+    expect(region.data).toBeNull()
+    expect(region.loading).toBe(false)
+  })
+
+  it('drops data when the level changes mid-fetch', async () => {
+    const harness = await makeHarness({ gateReads: true })
+    const { fetcher, cache, setLevel, getLevel, releaseReads } = harness
+    const original = getLevel()!
+
+    const batch = fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+    setLevel({ ...original, index: 1 })
+    releaseReads()
+    await batch
+
+    const region = cache.get(makeRegionKey(0, 0, 0))!
+    expect(region.data).toBeNull()
+    expect(region.loading).toBe(false)
+    expect(region.requestId).toBeNull()
+  })
+
+  it('aborts silently and re-invalidates so regions refetch on return', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const harness = await makeHarness({ gateReads: true })
+      const { fetcher, cache, requestCanceller, invalidate, releaseReads } =
+        harness
+
+      const batch = fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+      cancelAllRequests(requestCanceller)
+      releaseReads()
+      await batch
+
+      const region = cache.get(makeRegionKey(0, 0, 0))!
+      expect(region.data).toBeNull()
+      expect(region.loading).toBe(false)
+      expect(region.requestId).toBeNull()
+      expect(requestCanceller.controllers.size).toBe(0)
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(invalidate).toHaveBeenCalled()
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+
+  it('does nothing without a committed level', async () => {
+    const harness = await makeHarness()
+    const { fetcher, cache, setLevel } = harness
+    setLevel(null)
+    await fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+    expect(cache.size).toBe(0)
+  })
+})

--- a/src/region-fetcher.test.ts
+++ b/src/region-fetcher.test.ts
@@ -267,4 +267,86 @@ describe('RegionFetcher', () => {
     await fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
     expect(cache.size).toBe(0)
   })
+
+  it('fetches multi-value dims as parallel channels and interleaves them', async () => {
+    // 2-time x 4-lat x 8-lon ramp: value = t*32 + y*8 + x. Selecting both
+    // time steps packs two channels per pixel.
+    const memory = buildMemoryZarrStore({
+      arrays: [
+        {
+          name: 'temperature',
+          shape: [2, HEIGHT, WIDTH],
+          chunkShape: [2, HEIGHT, WIDTH],
+          dimensionNames: ['time', 'lat', 'lon'],
+          chunks: { '0/0/0': Array.from({ length: 64 }, (_, i) => i) },
+        },
+      ],
+    })
+    const store = new ZarrStore({
+      customStore: memory,
+      variable: 'temperature',
+      version: 3,
+      bounds: [-180, -90, 180, 90],
+      latIsAscending: false,
+    })
+    await store.initialized
+    const zarrArray = await store.getArray()
+
+    const level: LevelRuntime = {
+      index: 0,
+      zarrArray,
+      width: WIDTH,
+      height: HEIGHT,
+      regionSize: REGION,
+      baseSliceArgs: [0, 0, 0],
+      baseMultiValueDims: [
+        { dimIndex: 0, dimName: 'time', values: [0, 1], labels: [10, 20] },
+      ],
+    }
+    const cache = new RegionCache()
+    const fetcher = new RegionFetcher({
+      zarrStore: store,
+      dimIndices: store.describe().dimIndices,
+      levels: [],
+      projection: createProjectionContext({
+        crs: 'EPSG:4326',
+        proj4def: null,
+        xyLimits: { xMin: -180, xMax: 180, yMin: -90, yMax: 90 },
+      }),
+      xyLimits: { xMin: -180, xMax: 180, yMin: -90, yMax: 90 },
+      latIsAscending: false,
+      fixedDataScale: 1,
+      regionCache: cache,
+      requestCanceller: createRequestCanceller(),
+      loadingDebouncer: { show: () => {}, hide: () => {} },
+      getActiveLevel: () => level,
+      getSelectorVersion: () => 0,
+      // One name provided: the second channel falls back to band_<index>.
+      getBandNames: () => ['t10'],
+      isRemoved: () => false,
+      getRegionBounds: () => ({ xMin: 0, xMax: 1, yMin: 0, yMax: 1 }),
+      computeRegionMercatorBounds: () => ({ x0: 0, y0: 0, x1: 1, y1: 1 }),
+      createRegionGeometry: vi.fn(),
+      invalidate: vi.fn(),
+    })
+
+    await fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+    const region = cache.get(makeRegionKey(0, 0, 0))!
+
+    expect(region.channels).toBe(2)
+    const t0 = chunkData(0, 0)
+    expect(Array.from(region.bandData.get('t10')!)).toEqual(t0)
+    expect(Array.from(region.bandData.get('band_1')!)).toEqual(
+      t0.map((v) => v + 32)
+    )
+    // Interleaved pixel-major: [c0[0], c1[0], c0[1], c1[1], ...].
+    const interleaved = Array.from(region.data!)
+    expect(interleaved).toHaveLength(t0.length * 2)
+    expect(interleaved.slice(0, 4)).toEqual([
+      t0[0],
+      t0[0] + 32,
+      t0[1],
+      t0[1] + 32,
+    ])
+  })
 })

--- a/src/region-fetcher.test.ts
+++ b/src/region-fetcher.test.ts
@@ -430,8 +430,10 @@ describe('RegionFetcher', () => {
     expect(Array.from(region.bandData.get('band_1')!)).toEqual(
       t0.map((v) => v + 32)
     )
-    // data aliases the first band rather than allocating a second array.
-    expect(region.data).toBe(region.bandData.get('t10'))
-    expect(region.channels).toBe(1)
+    // Left null rather than aliased to one band: a stand-in here would be
+    // drawn as the whole dataset if the shader switched back to the main
+    // texture before the refetch landed.
+    expect(region.data).toBeNull()
+    expect(region.channels).toBe(2)
   })
 })

--- a/src/region-fetcher.test.ts
+++ b/src/region-fetcher.test.ts
@@ -60,15 +60,18 @@ async function makeHarness(
   const readsReleased = new Promise<void>((res) => {
     releaseReads = res
   })
-  // Optionally hold chunk reads open so tests can abort/invalidate mid-fetch.
-  const customStore = opts.gateReads
-    ? {
-        get: async (key: string) => {
-          if (key.includes('/c/')) await readsReleased
-          return memory.get(key)
-        },
+  // Chunk reads are counted so tests can assert a batch never dispatched, and
+  // optionally held open so tests can abort/invalidate mid-fetch.
+  const chunkReads: string[] = []
+  const customStore = {
+    get: async (key: string) => {
+      if (key.includes('/c/')) {
+        chunkReads.push(key)
+        if (opts.gateReads) await readsReleased
       }
-    : memory
+      return memory.get(key)
+    },
+  }
 
   const store = new ZarrStore({
     customStore,
@@ -96,6 +99,11 @@ async function makeHarness(
   const invalidate = vi.fn()
   const createRegionGeometry = vi.fn()
 
+  // fetchRegions runs synchronously up to its pre-flight staleness check, so
+  // `show()` is the one hook a test can use to simulate a level or selector
+  // change landing in that window.
+  let onBatchStart = () => {}
+
   const context: RegionFetcherContext = {
     zarrStore: store,
     dimIndices: store.describe().dimIndices,
@@ -110,7 +118,10 @@ async function makeHarness(
     fixedDataScale: 1,
     regionCache: cache,
     requestCanceller,
-    loadingDebouncer: { show: () => {}, hide: () => {} },
+    loadingDebouncer: {
+      show: () => onBatchStart(),
+      hide: () => {},
+    },
     getActiveLevel: () => level,
     getSelectorVersion: () => selectorVersion,
     getBandNames: () => ['temperature'],
@@ -129,12 +140,16 @@ async function makeHarness(
     invalidate,
     createRegionGeometry,
     releaseReads,
+    chunkReads,
     setLevel: (next: LevelRuntime | null) => {
       level = next
     },
     getLevel: () => level,
     setSelectorVersion: (v: number) => {
       selectorVersion = v
+    },
+    onBatchStart: (fn: () => void) => {
+      onBatchStart = fn
     },
   }
 }
@@ -190,6 +205,24 @@ describe('RegionFetcher', () => {
     )
   })
 
+  it('regenerates geometry when a refetch changes the region size', async () => {
+    const { fetcher, cache, createRegionGeometry, getLevel, setLevel } =
+      await makeHarness()
+    await fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+    const region = cache.get(makeRegionKey(0, 0, 0))!
+    expect(region.width).toBe(4)
+    expect(createRegionGeometry).toHaveBeenCalledTimes(1)
+
+    // Same level index and cache key, larger regions: the cached region's mesh
+    // no longer matches its data, so it has to be rebuilt (and re-uploaded).
+    setLevel({ ...getLevel()!, regionSize: [HEIGHT, WIDTH] })
+    await fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+
+    expect(region.width).toBe(WIDTH)
+    expect(region.height).toBe(HEIGHT)
+    expect(createRegionGeometry).toHaveBeenCalledTimes(2)
+  })
+
   it('never lets an older fetch overwrite newer region data', async () => {
     const { fetcher, cache } = await makeHarness()
     // A region already refreshed by a newer selector version...
@@ -206,15 +239,27 @@ describe('RegionFetcher', () => {
   })
 
   it('cancels the whole batch when the level changed before dispatch', async () => {
-    const { fetcher, cache, context, getLevel } = await makeHarness()
-    // The getter serves the old level to the snapshot, then the new one to
-    // the pre-flight staleness check.
+    const { fetcher, cache, chunkReads, getLevel, setLevel, onBatchStart } =
+      await makeHarness()
     const original = getLevel()!
-    const swapped: LevelRuntime = { ...original, index: 1 }
-    let calls = 0
-    context.getActiveLevel = () => (calls++ === 0 ? original : swapped)
+    onBatchStart(() => setLevel({ ...original, index: 1 }))
 
     await fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+    // No read is issued at all: the pre-flight check drops the batch before
+    // dispatch rather than letting each fetch discard its own result.
+    expect(chunkReads).toEqual([])
+    const region = cache.get(makeRegionKey(0, 0, 0))!
+    expect(region.data).toBeNull()
+    expect(region.loading).toBe(false)
+  })
+
+  it('cancels the whole batch when the selector changed before dispatch', async () => {
+    const { fetcher, cache, chunkReads, setSelectorVersion, onBatchStart } =
+      await makeHarness()
+    onBatchStart(() => setSelectorVersion(1))
+
+    await fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+    expect(chunkReads).toEqual([])
     const region = cache.get(makeRegionKey(0, 0, 0))!
     expect(region.data).toBeNull()
     expect(region.loading).toBe(false)

--- a/src/region-fetcher.test.ts
+++ b/src/region-fetcher.test.ts
@@ -125,6 +125,7 @@ async function makeHarness(
     getActiveLevel: () => level,
     getSelectorVersion: () => selectorVersion,
     getBandNames: () => ['temperature'],
+    usesBandTextures: () => false,
     isRemoved: () => false,
     getRegionBounds: () => ({ xMin: 0, xMax: 1, yMin: 0, yMax: 1 }),
     computeRegionMercatorBounds: () => ({ x0: 0, y0: 0, x1: 1, y1: 1 }),
@@ -330,9 +331,9 @@ describe('RegionFetcher', () => {
     expect(cache.size).toBe(0)
   })
 
-  it('fetches multi-value dims as parallel channels and interleaves them', async () => {
-    // 2-time x 4-lat x 8-lon ramp: value = t*32 + y*8 + x. Selecting both
-    // time steps packs two channels per pixel.
+  // 2-time x 4-lat x 8-lon ramp: value = t*32 + y*8 + x. Selecting both time
+  // steps produces two channels.
+  async function makeMultibandHarness(usesBandTextures: boolean) {
     const memory = buildMemoryZarrStore({
       arrays: [
         {
@@ -385,13 +386,18 @@ describe('RegionFetcher', () => {
       getSelectorVersion: () => 0,
       // One name provided: the second channel falls back to band_<index>.
       getBandNames: () => ['t10'],
+      usesBandTextures: () => usesBandTextures,
       isRemoved: () => false,
       getRegionBounds: () => ({ xMin: 0, xMax: 1, yMin: 0, yMax: 1 }),
       computeRegionMercatorBounds: () => ({ x0: 0, y0: 0, x1: 1, y1: 1 }),
       createRegionGeometry: vi.fn(),
       invalidate: vi.fn(),
     })
+    return { fetcher, cache }
+  }
 
+  it('fetches multi-value dims as parallel channels and interleaves them', async () => {
+    const { fetcher, cache } = await makeMultibandHarness(false)
     await fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
     const region = cache.get(makeRegionKey(0, 0, 0))!
 
@@ -410,5 +416,22 @@ describe('RegionFetcher', () => {
       t0[1],
       t0[1] + 32,
     ])
+  })
+
+  it('skips the interleaved copy when the shader samples band textures', async () => {
+    const { fetcher, cache } = await makeMultibandHarness(true)
+    await fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+    const region = cache.get(makeRegionKey(0, 0, 0))!
+
+    // Every band is still fetched and kept; only the interleaved copy that
+    // would feed the unread main texture is skipped.
+    const t0 = chunkData(0, 0)
+    expect(Array.from(region.bandData.get('t10')!)).toEqual(t0)
+    expect(Array.from(region.bandData.get('band_1')!)).toEqual(
+      t0.map((v) => v + 32)
+    )
+    // data aliases the first band rather than allocating a second array.
+    expect(region.data).toBe(region.bandData.get('t10'))
+    expect(region.channels).toBe(1)
   })
 })

--- a/src/region-fetcher.test.ts
+++ b/src/region-fetcher.test.ts
@@ -260,6 +260,23 @@ describe('RegionFetcher', () => {
     }
   })
 
+  it('an aborted fetch does not clobber a newer request that took over the region', async () => {
+    const harness = await makeHarness({ gateReads: true })
+    const { fetcher, cache, requestCanceller, releaseReads } = harness
+
+    const batch = fetcher.fetchRegions([{ regionX: 0, regionY: 0 }])
+    const region = cache.get(makeRegionKey(0, 0, 0))!
+    cancelAllRequests(requestCanceller)
+    // A newer request takes over the region while the aborted one unwinds.
+    region.requestId = 999
+    region.loading = true
+    releaseReads()
+    await batch
+
+    expect(region.requestId).toBe(999)
+    expect(region.loading).toBe(true)
+  })
+
   it('does nothing without a committed level', async () => {
     const harness = await makeHarness()
     const { fetcher, cache, setLevel } = harness

--- a/src/region-fetcher.ts
+++ b/src/region-fetcher.ts
@@ -393,8 +393,12 @@ export class RegionFetcher {
         console.error(`[fetchRegion] Error fetching region ${key}:`, err)
       }
     } finally {
-      region.loading = false
-      region.requestId = null
+      // Only clear flags if this request still owns the region — a newer
+      // request may have taken over while an aborted one was unwinding.
+      if (region.requestId === requestId) {
+        region.loading = false
+        region.requestId = null
+      }
       this.context.requestCanceller.controllers.delete(requestId)
       // Re-evaluate visible regions after abort so panned-back regions get re-fetched.
       if (controller.signal.aborted && !this.context.isRemoved()) {

--- a/src/region-fetcher.ts
+++ b/src/region-fetcher.ts
@@ -362,12 +362,15 @@ export class RegionFetcher {
         normalizedBands.push(bandNormalized)
       }
 
-      // Construct interleaved data from normalized bands. Band-sampling
-      // shaders never read the main texture, so point it at the first band
-      // rather than allocating an interleaved copy of every channel.
+      // Interleaved data exists only to feed the main texture. Band-sampling
+      // shaders never read it, so skip the copy entirely rather than leaving
+      // a partial stand-in: if the shader later switches back to the main
+      // texture, a stand-in would be uploaded and drawn as if it were the
+      // whole dataset until the refetch lands. Null keeps the region
+      // undrawable through that path instead.
       const bandRendering = this.context.usesBandTextures()
       region.data = bandRendering
-        ? normalizedBands[0]
+        ? null
         : interleaveBands(normalizedBands, numChannels)
 
       // Check if geometry needs to be (re)created before updating dimensions
@@ -379,7 +382,7 @@ export class RegionFetcher {
 
       region.width = actualW
       region.height = actualH
-      region.channels = bandRendering ? 1 : numChannels
+      region.channels = numChannels
       region.loading = false
 
       // Store level-specific dimensions from snapshot for geometry creation.

--- a/src/region-fetcher.ts
+++ b/src/region-fetcher.ts
@@ -1,0 +1,405 @@
+import * as zarr from 'zarrita'
+import type { DimIndicesProps, UntiledLevel } from './types'
+import type { XYLimits } from './map-utils'
+import type { ProjectionContext } from './projection-utils'
+import type {
+  LevelMeta,
+  LevelRuntime,
+  LevelSnapshot,
+  RegionState,
+} from './region-state'
+import type { ZarrStore } from './zarr-store'
+import { buildChannelCombinations } from './selector-resolution'
+import { interleaveBands, normalizeDataForTexture } from './webgl-utils'
+import {
+  type ChunkLoadingDebouncer,
+  type RequestCanceller,
+  cancelAllRequests,
+  hasActiveRequests,
+} from './region-utils'
+import { RegionCache, createRegionState, makeRegionKey } from './region-cache'
+
+export type RegionFetcherContext = {
+  zarrStore: ZarrStore
+  dimIndices: DimIndicesProps
+  levels: UntiledLevel[]
+  projection: ProjectionContext
+  xyLimits: XYLimits | null
+  latIsAscending: boolean
+  fixedDataScale: number
+  regionCache: RegionCache
+  requestCanceller: RequestCanceller
+  loadingDebouncer: ChunkLoadingDebouncer
+  getActiveLevel: () => LevelRuntime | null
+  getSelectorVersion: () => number
+  getBandNames: () => string[]
+  isRemoved: () => boolean
+  getRegionBounds: (
+    regionX: number,
+    regionY: number,
+    levelMeta: LevelMeta
+  ) => {
+    xMin: number
+    xMax: number
+    yMin: number
+    yMax: number
+  }
+  computeRegionMercatorBounds: (bounds: {
+    xMin: number
+    xMax: number
+    yMin: number
+    yMax: number
+  }) => { x0: number; y0: number; x1: number; y1: number }
+  createRegionGeometry: (
+    regionX: number,
+    regionY: number,
+    region: RegionState
+  ) => void
+  invalidate: () => void
+}
+
+export class RegionFetcher {
+  constructor(private context: RegionFetcherContext) {}
+
+  /**
+   * Clear loading flags for queued-but-not-started regions in a batch.
+   * Only touches regions where requestId is null (pre-marked as loading
+   * but no fetch was started). In-flight regions (requestId set) are
+   * cleaned up by their own finally block.
+   */
+  private clearBatchLoadingFlags(
+    regions: Array<{ regionX: number; regionY: number }>,
+    levelIndex: number
+  ): void {
+    for (const { regionX, regionY } of regions) {
+      const region = this.context.regionCache.get(
+        makeRegionKey(levelIndex, regionX, regionY)
+      )
+      if (region && region.requestId === null) region.loading = false
+    }
+  }
+
+  /**
+   * Fetch multiple regions with limited concurrency to avoid overwhelming the browser.
+   */
+  async fetchRegions(
+    regions: Array<{ regionX: number; regionY: number }>
+  ): Promise<void> {
+    // Can't fetch without a committed level.
+    const level = this.context.getActiveLevel()
+    if (!level) return
+
+    // Capture ALL level-dependent state at start to pass to fetchRegion.
+    // This prevents races where a later `loadLevel` (zoom switch or
+    // selector rebuild) swaps `this.activeLevel` mid-batch.
+    const snapshot: LevelSnapshot = {
+      index: level.index,
+      zarrArray: level.zarrArray,
+      baseSliceArgs: [...level.baseSliceArgs],
+      width: level.width,
+      height: level.height,
+      regionSize: level.regionSize,
+      selectorVersion: this.context.getSelectorVersion(),
+      bandNames: [...this.context.getBandNames()],
+      baseMultiValueDims: level.baseMultiValueDims.map((dim) => ({
+        dimIndex: dim.dimIndex,
+        dimName: dim.dimName,
+        values: [...dim.values],
+        labels: [...dim.labels],
+      })),
+    }
+
+    this.context.loadingDebouncer.show()
+
+    // Mark ALL regions as loading upfront to prevent duplicate fetches
+    // from subsequent update() calls before we've processed them all
+    for (const { regionX, regionY } of regions) {
+      const key = makeRegionKey(snapshot.index, regionX, regionY)
+      let region = this.context.regionCache.get(key)
+      if (!region) {
+        region = createRegionState(
+          snapshot.index,
+          regionX,
+          regionY,
+          this.context.latIsAscending,
+          this.context.getSelectorVersion()
+        )
+        this.context.regionCache.set(key, region)
+      }
+      region.loading = true
+    }
+
+    // Pre-flight staleness check. Mid-flight changes are handled by the
+    // `cancelAllRequests` in `loadLevel`/`setSelector`, which aborts the
+    // signals that fetchRegion threads through every await.
+    if (
+      (this.context.getActiveLevel()?.index ?? -1) !== snapshot.index ||
+      this.context.getSelectorVersion() !== snapshot.selectorVersion
+    ) {
+      cancelAllRequests(this.context.requestCanceller)
+      this.clearBatchLoadingFlags(regions, snapshot.index)
+    } else {
+      // Kick off every region synchronously so their underlying chunk reads
+      // land in one microtask drain — that's what lets the range coalescer
+      // (icechunk-js + zarrita) merge them into a handful of HTTP fetches
+      // instead of one per region. Browser HTTP queueing handles back-
+      // pressure on the connection pool; throttling fetchRegion calls here
+      // just fragments the coalescer's same-tick batch window.
+      const fetches = regions.map(({ regionX, regionY }) =>
+        this.fetchRegion(regionX, regionY, snapshot)
+      )
+      await Promise.allSettled(fetches)
+    }
+
+    // Only update loading state if we're still on the same level
+    if (!hasActiveRequests(this.context.requestCanceller)) {
+      this.context.loadingDebouncer.hide()
+
+      this.context.invalidate()
+    }
+  }
+
+  /**
+   * Fetch data for a single region.
+   * Handles multi-band extraction when selector has multi-value dimensions.
+   * @param snapshot - Captured level state from when fetch batch started (prevents race conditions)
+   */
+  private async fetchRegion(
+    regionX: number,
+    regionY: number,
+    snapshot: LevelSnapshot
+  ): Promise<void> {
+    if ((this.context.getActiveLevel()?.index ?? -1) !== snapshot.index) {
+      return
+    }
+
+    if (this.context.isRemoved()) {
+      return
+    }
+
+    const key = makeRegionKey(snapshot.index, regionX, regionY)
+    const requestId = ++this.context.requestCanceller.currentVersion
+    const fetchSelectorVersion = snapshot.selectorVersion
+
+    const controller = new AbortController()
+    this.context.requestCanceller.controllers.set(requestId, controller)
+
+    let region = this.context.regionCache.get(key)
+    if (!region) {
+      region = createRegionState(
+        snapshot.index,
+        regionX,
+        regionY,
+        this.context.latIsAscending,
+        this.context.getSelectorVersion()
+      )
+      this.context.regionCache.set(key, region)
+    }
+    region.loading = true
+    region.requestId = requestId
+
+    const [regionH, regionW] = snapshot.regionSize
+
+    // Calculate pixel bounds for this region
+    const yStart = regionY * regionH
+    const yEnd = Math.min(yStart + regionH, snapshot.height)
+    const xStart = regionX * regionW
+    const xEnd = Math.min(xStart + regionW, snapshot.width)
+    const actualW = xEnd - xStart
+    const actualH = yEnd - yStart
+
+    try {
+      // Build base slice args with spatial region bounds
+      const baseSliceArgs = [...snapshot.baseSliceArgs]
+      const latIdx = this.context.dimIndices.lat.index
+      const lonIdx = this.context.dimIndices.lon.index
+      baseSliceArgs[latIdx] = zarr.slice(yStart, yEnd)
+      baseSliceArgs[lonIdx] = zarr.slice(xStart, xEnd)
+
+      const desc = this.context.zarrStore.describe()
+      // Use per-level metadata if available (for heterogeneous pyramids)
+      const currentLevel = this.context.levels[snapshot.index]
+      const fillValue = currentLevel?.fillValue ?? desc.fill_value
+
+      const { combinations: channelCombinations } = buildChannelCombinations(
+        snapshot.baseMultiValueDims
+      )
+      const numChannels = channelCombinations.length || 1
+
+      // Fetch data for all channels
+      const bandArrays: Float32Array[] = []
+
+      const isStale = () =>
+        controller.signal.aborted ||
+        this.context.isRemoved() ||
+        (this.context.getActiveLevel()?.index ?? -1) !== snapshot.index
+
+      if (numChannels === 1) {
+        // Single channel - simple fetch
+        if (isStale()) return
+
+        const result = (await zarr.get(snapshot.zarrArray, baseSliceArgs, {
+          signal: controller.signal,
+        })) as { data: ArrayLike<number> }
+
+        if (isStale()) return
+
+        const rawData = new Float32Array(result.data as ArrayLike<number>)
+        bandArrays.push(rawData)
+      } else {
+        // Multi-channel - fetch all channels in parallel
+        if (isStale()) return
+
+        // Build slice args for all channels upfront
+        const allSliceArgs: (number | zarr.Slice)[][] = []
+        for (let c = 0; c < numChannels; c++) {
+          const sliceArgs = [...baseSliceArgs]
+          const combo = channelCombinations[c]
+
+          // Apply channel-specific indices to multi-value dimensions
+          for (let i = 0; i < snapshot.baseMultiValueDims.length; i++) {
+            sliceArgs[snapshot.baseMultiValueDims[i].dimIndex] = combo[i]
+          }
+          allSliceArgs.push(sliceArgs)
+        }
+
+        // Fetch all bands in parallel
+        const results = await Promise.all(
+          allSliceArgs.map((sliceArgs) =>
+            zarr.get(snapshot.zarrArray, sliceArgs, {
+              signal: controller.signal,
+            })
+          )
+        )
+
+        if (isStale()) return
+
+        // Process results in order
+        for (let c = 0; c < numChannels; c++) {
+          const result = results[c] as { data: ArrayLike<number> }
+          const bandData = new Float32Array(result.data as ArrayLike<number>)
+          bandArrays.push(bandData)
+        }
+      }
+
+      // Only render if this is newer than what's already rendered for this region
+      if (fetchSelectorVersion < region.selectorVersion) return
+
+      // Update region's selector version
+      region.selectorVersion = fetchSelectorVersion
+
+      // GPU handles reprojection. Source-projected data uses an adaptive mesh
+      // (source CRS → WGS84), then the GPU projects to Mercator or ECEF.
+      const needsProj4MercBounds =
+        this.context.projection.def && this.context.projection.toMercator
+
+      if (
+        needsProj4MercBounds &&
+        this.context.xyLimits &&
+        !region.mercatorBounds
+      ) {
+        const levelMeta: LevelMeta = {
+          width: snapshot.width,
+          height: snapshot.height,
+          regionSize: snapshot.regionSize,
+        }
+        const geoBounds = this.context.getRegionBounds(
+          regionX,
+          regionY,
+          levelMeta
+        )
+        region.mercatorBounds =
+          this.context.computeRegionMercatorBounds(geoBounds)
+      }
+
+      // Apply per-level scale/offset to convert raw values to physical units
+      // Fall back to dataset-level scale/offset for pyramids that only define them at the root
+      const scaleFactor = currentLevel?.scaleFactor ?? desc.scaleFactor
+      const addOffset = currentLevel?.addOffset ?? desc.addOffset
+
+      // Normalize bands (single pass) and collect for interleaving
+      region.bandData.clear()
+      region.bandTexturesUploaded.clear()
+      const normalizedBands: Float32Array[] = []
+
+      for (let c = 0; c < bandArrays.length; c++) {
+        const bandName = snapshot.bandNames[c] || `band_${c}`
+        let bandData = bandArrays[c]
+
+        // Apply scale/offset if needed (converts raw to physical values)
+        if (scaleFactor !== 1 || addOffset !== 0) {
+          const scaled = new Float32Array(bandData.length)
+          for (let i = 0; i < bandData.length; i++) {
+            const raw = bandData[i]
+            // Scale all values including fill - normalizeDataForTexture will filter by scaled fill
+            if (!Number.isFinite(raw)) {
+              scaled[i] = raw // Keep NaN/Inf as-is
+            } else {
+              scaled[i] = raw * scaleFactor + addOffset
+            }
+          }
+          bandData = scaled
+        }
+
+        // Compute the fill value in the same space as the data
+        const effectiveFillValue =
+          fillValue !== null && (scaleFactor !== 1 || addOffset !== 0)
+            ? fillValue * scaleFactor + addOffset
+            : fillValue
+
+        const { normalized: bandNormalized } = normalizeDataForTexture(
+          bandData,
+          effectiveFillValue,
+          this.context.fixedDataScale
+        )
+        region.bandData.set(bandName, bandNormalized)
+        normalizedBands.push(bandNormalized)
+      }
+
+      // Construct interleaved data from normalized bands
+      region.data = interleaveBands(normalizedBands, numChannels)
+
+      // Check if geometry needs to be (re)created before updating dimensions
+      // The adaptive mesh only depends on spatial bounds and dimensions, not the selector
+      const needsGeometry =
+        !region.vertexArr ||
+        region.width !== actualW ||
+        region.height !== actualH
+
+      region.width = actualW
+      region.height = actualH
+      region.channels = numChannels
+      region.loading = false
+
+      // Store level-specific dimensions from snapshot for geometry creation.
+      // Must use snapshot (not this.*) to avoid races with level switching.
+      // Set before createRegionGeometry is called below.
+      region.levelMeta = {
+        width: snapshot.width,
+        height: snapshot.height,
+        regionSize: [...snapshot.regionSize] as [number, number],
+      }
+
+      region.textureUploaded = false
+
+      // Create geometry only if needed (new region or dimensions changed)
+      if (needsGeometry) {
+        this.context.createRegionGeometry(regionX, regionY, region)
+      }
+
+      this.context.invalidate()
+    } catch (err) {
+      if (!(err instanceof DOMException && err.name === 'AbortError')) {
+        console.error(`[fetchRegion] Error fetching region ${key}:`, err)
+      }
+    } finally {
+      region.loading = false
+      region.requestId = null
+      this.context.requestCanceller.controllers.delete(requestId)
+      // Re-evaluate visible regions after abort so panned-back regions get re-fetched.
+      if (controller.signal.aborted && !this.context.isRemoved()) {
+        this.context.invalidate()
+      }
+    }
+  }
+}

--- a/src/region-fetcher.ts
+++ b/src/region-fetcher.ts
@@ -33,6 +33,12 @@ export type RegionFetcherContext = {
   getActiveLevel: () => LevelRuntime | null
   getSelectorVersion: () => number
   getBandNames: () => string[]
+  /**
+   * True when a custom shader samples the per-band textures. The main texture
+   * is then never bound, so the interleaved copy of every channel that feeds
+   * it is dead weight (12 bands at 128x128 is 786 KB per region).
+   */
+  usesBandTextures: () => boolean
   isRemoved: () => boolean
   getRegionBounds: (
     regionX: number,
@@ -356,8 +362,13 @@ export class RegionFetcher {
         normalizedBands.push(bandNormalized)
       }
 
-      // Construct interleaved data from normalized bands
-      region.data = interleaveBands(normalizedBands, numChannels)
+      // Construct interleaved data from normalized bands. Band-sampling
+      // shaders never read the main texture, so point it at the first band
+      // rather than allocating an interleaved copy of every channel.
+      const bandRendering = this.context.usesBandTextures()
+      region.data = bandRendering
+        ? normalizedBands[0]
+        : interleaveBands(normalizedBands, numChannels)
 
       // Check if geometry needs to be (re)created before updating dimensions
       // The adaptive mesh only depends on spatial bounds and dimensions, not the selector
@@ -368,7 +379,7 @@ export class RegionFetcher {
 
       region.width = actualW
       region.height = actualH
-      region.channels = numChannels
+      region.channels = bandRendering ? 1 : numChannels
       region.loading = false
 
       // Store level-specific dimensions from snapshot for geometry creation.

--- a/src/region-math.test.ts
+++ b/src/region-math.test.ts
@@ -8,6 +8,7 @@ import {
   getVisibleRegions,
   longitudeWorldFraction,
   selectLevelForZoom,
+  type RegionCoordinate,
 } from './region-math'
 import { createProjectionContext } from './projection-utils'
 import { boundsToMercatorNorm } from './map-utils'
@@ -166,33 +167,102 @@ describe('getCandidateRegions', () => {
     latIsAscending: false,
   }
 
-  it('returns a margin-padded block around the viewport', () => {
-    const candidates = getCandidateRegions({
-      ...grid,
-      west: -10,
-      south: -10,
-      east: 10,
-      north: 10,
-    })
+  /**
+   * Candidates are always a solid rectangle of the region grid, so its extent
+   * plus the count pins the exact block — including the prefetch margin, which
+   * a min/max range assertion would let drift to zero unnoticed.
+   */
+  const block = (candidates: RegionCoordinate[]) => {
     const xs = candidates.map((c) => c.regionX)
     const ys = candidates.map((c) => c.regionY)
-    // Viewport around the grid center, well away from the edges.
-    expect(Math.min(...xs)).toBeGreaterThan(10)
-    expect(Math.max(...xs)).toBeLessThan(30)
-    expect(Math.min(...ys)).toBeGreaterThan(2)
-    expect(Math.max(...ys)).toBeLessThan(18)
+    return {
+      xMin: Math.min(...xs),
+      xMax: Math.max(...xs),
+      yMin: Math.min(...ys),
+      yMax: Math.max(...ys),
+      count: candidates.length,
+    }
+  }
+
+  it('returns the viewport block padded by the prefetch margin', () => {
+    // lon -10..10 -> px 1700..1900 -> columns 18..21, padded by 2 -> 16..23.
+    // lat -10..10 north-first -> px rows 800..1000 -> rows 8..11 -> 6..13.
+    expect(
+      block(
+        getCandidateRegions({
+          ...grid,
+          west: -10,
+          south: -10,
+          east: 10,
+          north: 10,
+        })
+      )
+    ).toEqual({ xMin: 16, xMax: 23, yMin: 6, yMax: 13, count: 8 * 8 })
+  })
+
+  it('mirrors the row block for ascending latitude', () => {
+    // Asymmetric viewport: a box centered on the equator maps to the same rows
+    // under either orientation, so it can't distinguish them.
+    const northern = { ...grid, west: -10, south: 10, east: 10, north: 50 }
+    expect(block(getCandidateRegions(northern))).toMatchObject({
+      yMin: 2,
+      yMax: 10,
+    })
+    expect(
+      block(getCandidateRegions({ ...northern, latIsAscending: true }))
+    ).toMatchObject({ yMin: 9, yMax: 17 })
+  })
+
+  it('widens the margin when some viewport samples fail to project', () => {
+    // Samples above lat 5 fall outside the projection's valid domain, so the
+    // sampled extent understates the viewport and the margin grows 2 -> 8.
+    const partial = {
+      forward: (lon: number, lat: number): [number, number] =>
+        lat > 5 ? [NaN, NaN] : [lon, lat],
+    }
+    expect(
+      block(
+        getCandidateRegions({
+          ...grid,
+          transformer: partial,
+          west: -10,
+          south: -10,
+          east: 10,
+          north: 10,
+        })
+      )
+    ).toEqual({ xMin: 10, xMax: 29, yMin: 1, yMax: 19, count: 20 * 19 })
   })
 
   it('widens to every X column when the viewport crosses the antimeridian', () => {
-    const candidates = getCandidateRegions({
-      ...grid,
-      west: 170,
-      south: -10,
-      east: -170,
-      north: 10,
-    })
-    const xs = new Set(candidates.map((c) => c.regionX))
-    expect(xs.size).toBe(grid.numRegionsX)
+    // Unwrapped bounds (east past +180) are the discriminating case: the
+    // sampled X span is narrow and would otherwise yield only the far-east
+    // columns, but the projection folds source X back on itself so that span
+    // no longer bounds the visible columns.
+    const { xMin, xMax, yMin, yMax } = block(
+      getCandidateRegions({
+        ...grid,
+        west: 170,
+        south: -10,
+        east: 190,
+        north: 10,
+      })
+    )
+    expect([xMin, xMax]).toEqual([0, grid.numRegionsX - 1])
+    // Rows stay bounded by the viewport — only the X span is widened.
+    expect([yMin, yMax]).toEqual([6, 13])
+
+    // Wrapped bounds (east < west) get the same treatment.
+    const wrapped = block(
+      getCandidateRegions({
+        ...grid,
+        west: 170,
+        south: -10,
+        east: -170,
+        north: 10,
+      })
+    )
+    expect([wrapped.xMin, wrapped.xMax]).toEqual([0, grid.numRegionsX - 1])
   })
 
   it('falls back to every region when no viewport sample projects', () => {
@@ -269,6 +339,17 @@ describe('getVisibleRegions', () => {
         xyLimits: WORLD,
         levelMeta: null,
         projection,
+        latIsAscending: false,
+      })
+    ).toEqual([])
+    // Region indices computed without a source transformer would be wrong, so
+    // the caller renders nothing rather than a misleading partial result.
+    expect(
+      getVisibleRegions({
+        map: mapAt(-10, -10, 10, 10),
+        xyLimits: WORLD,
+        levelMeta,
+        projection: { ...projection, toWGS84: null },
         latIsAscending: false,
       })
     ).toEqual([])

--- a/src/region-math.test.ts
+++ b/src/region-math.test.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect } from 'vitest'
+import type * as zarr from 'zarrita'
+import {
+  computeRegionMercatorBounds,
+  getCandidateRegions,
+  getRegionBounds,
+  getRegionSize,
+  getVisibleRegions,
+  longitudeWorldFraction,
+  selectLevelForZoom,
+} from './region-math'
+import { createProjectionContext } from './projection-utils'
+import { boundsToMercatorNorm } from './map-utils'
+import type { UntiledLevel } from './types'
+
+/**
+ * Pure viewport/level math: region grid enumeration, pixel↔geo bounds,
+ * resolution-matched level selection. These functions take all state as
+ * explicit inputs, so the tests double as a signature spec.
+ */
+
+const WORLD = { xMin: -180, xMax: 180, yMin: -90, yMax: 90 }
+
+const identityTransformer = {
+  forward: (lon: number, lat: number): [number, number] => [lon, lat],
+  inverse: (x: number, y: number): [number, number] => [x, y],
+}
+
+function fakeArray(spec: {
+  shape: number[]
+  chunks?: number[]
+  codecs?: unknown[]
+}): zarr.Array<zarr.DataType> {
+  return {
+    shape: spec.shape,
+    chunks: spec.chunks,
+    codecs: spec.codecs ?? [],
+  } as unknown as zarr.Array<zarr.DataType>
+}
+
+const LATLON_INDICES = {
+  lat: { index: 0, name: 'lat', array: null },
+  lon: { index: 1, name: 'lon', array: null },
+}
+
+describe('getRegionSize', () => {
+  it('uses the chunk shape when chunks subdivide the array', () => {
+    const array = fakeArray({ shape: [100, 200], chunks: [50, 100] })
+    expect(getRegionSize(array, LATLON_INDICES)).toEqual([50, 100])
+  })
+
+  it('prefers the shard shape from a sharding codec', () => {
+    const array = fakeArray({
+      shape: [100, 200],
+      chunks: [10, 10],
+      codecs: [
+        {
+          name: 'sharding_indexed',
+          configuration: { chunk_shape: [64, 128] },
+        },
+      ],
+    })
+    expect(getRegionSize(array, LATLON_INDICES)).toEqual([64, 128])
+  })
+
+  it('returns null for a single-chunk array', () => {
+    const array = fakeArray({ shape: [100, 200], chunks: [100, 200] })
+    expect(getRegionSize(array, LATLON_INDICES)).toBeNull()
+  })
+
+  it('returns null without spatial dimension indices', () => {
+    const array = fakeArray({ shape: [100, 200], chunks: [50, 100] })
+    expect(getRegionSize(array, {})).toBeNull()
+  })
+})
+
+describe('longitudeWorldFraction', () => {
+  it('is 1 for global and degenerate extents', () => {
+    expect(longitudeWorldFraction({ xMin: -180, xMax: 180 })).toBe(1)
+    expect(longitudeWorldFraction({ xMin: 0, xMax: 360 })).toBe(1)
+    expect(longitudeWorldFraction({ xMin: 10, xMax: 10 })).toBe(1)
+    expect(longitudeWorldFraction({ xMin: NaN, xMax: 10 })).toBe(1)
+  })
+
+  it('is the longitude span over 360 for regional extents', () => {
+    expect(longitudeWorldFraction({ xMin: -90, xMax: 90 })).toBeCloseTo(0.5, 12)
+  })
+
+  it('unwraps antimeridian-crossing extents', () => {
+    expect(longitudeWorldFraction({ xMin: 170, xMax: -170 })).toBeCloseTo(
+      20 / 360,
+      12
+    )
+  })
+})
+
+describe('getRegionBounds', () => {
+  const levelMeta = {
+    width: 360,
+    height: 180,
+    regionSize: [90, 180] as [number, number],
+  }
+
+  it('maps region (0,0) to the north-west corner when lat is descending', () => {
+    const b = getRegionBounds({
+      regionX: 0,
+      regionY: 0,
+      levelMeta,
+      xyLimits: WORLD,
+      latIsAscending: false,
+    })
+    expect(b).toEqual({ xMin: -180, xMax: 0, yMin: 0, yMax: 90 })
+  })
+
+  it('maps region (0,0) to the south-west corner when lat is ascending', () => {
+    const b = getRegionBounds({
+      regionX: 0,
+      regionY: 0,
+      levelMeta,
+      xyLimits: WORLD,
+      latIsAscending: true,
+    })
+    expect(b).toEqual({ xMin: -180, xMax: 0, yMin: -90, yMax: 0 })
+  })
+
+  it('clamps edge regions to the array extent', () => {
+    const meta = {
+      width: 300,
+      height: 180,
+      regionSize: [90, 180] as [number, number],
+    }
+    const b = getRegionBounds({
+      regionX: 1,
+      regionY: 0,
+      levelMeta: meta,
+      xyLimits: WORLD,
+      latIsAscending: false,
+    })
+    // Pixel columns 180..300 of a 300px world span.
+    expect(b.xMin).toBeCloseTo(-180 + (180 / 300) * 360, 9)
+    expect(b.xMax).toBeCloseTo(180, 9)
+  })
+
+  it('falls back to the unit square without xyLimits', () => {
+    const b = getRegionBounds({
+      regionX: 0,
+      regionY: 0,
+      levelMeta,
+      xyLimits: null,
+      latIsAscending: false,
+    })
+    expect(b).toEqual({ xMin: 0, xMax: 1, yMin: 0, yMax: 1 })
+  })
+})
+
+describe('getCandidateRegions', () => {
+  const grid = {
+    transformer: identityTransformer,
+    numRegionsX: 40,
+    numRegionsY: 20,
+    regionW: 90,
+    regionH: 90,
+    width: 3600,
+    height: 1800,
+    xyLimits: WORLD,
+    latIsAscending: false,
+  }
+
+  it('returns a margin-padded block around the viewport', () => {
+    const candidates = getCandidateRegions({
+      ...grid,
+      west: -10,
+      south: -10,
+      east: 10,
+      north: 10,
+    })
+    const xs = candidates.map((c) => c.regionX)
+    const ys = candidates.map((c) => c.regionY)
+    // Viewport around the grid center, well away from the edges.
+    expect(Math.min(...xs)).toBeGreaterThan(10)
+    expect(Math.max(...xs)).toBeLessThan(30)
+    expect(Math.min(...ys)).toBeGreaterThan(2)
+    expect(Math.max(...ys)).toBeLessThan(18)
+  })
+
+  it('widens to every X column when the viewport crosses the antimeridian', () => {
+    const candidates = getCandidateRegions({
+      ...grid,
+      west: 170,
+      south: -10,
+      east: -170,
+      north: 10,
+    })
+    const xs = new Set(candidates.map((c) => c.regionX))
+    expect(xs.size).toBe(grid.numRegionsX)
+  })
+
+  it('falls back to every region when no viewport sample projects', () => {
+    const candidates = getCandidateRegions({
+      ...grid,
+      transformer: { forward: () => [NaN, NaN] },
+      west: -10,
+      south: -10,
+      east: 10,
+      north: 10,
+    })
+    expect(candidates).toHaveLength(grid.numRegionsX * grid.numRegionsY)
+  })
+})
+
+describe('getVisibleRegions', () => {
+  const projection = createProjectionContext({
+    crs: 'EPSG:4326',
+    proj4def: null,
+    xyLimits: WORLD,
+  })
+  const levelMeta = {
+    width: 360,
+    height: 180,
+    regionSize: [90, 90] as [number, number],
+  }
+  const mapAt = (west: number, south: number, east: number, north: number) =>
+    ({
+      getBounds: () => ({
+        toArray: () => [
+          [west, south],
+          [east, north],
+        ],
+      }),
+    } as never)
+
+  it('returns exactly the regions overlapping the viewport', () => {
+    const regions = getVisibleRegions({
+      map: mapAt(-10, -10, 10, 10),
+      xyLimits: WORLD,
+      levelMeta,
+      projection,
+      latIsAscending: false,
+    })
+    // 4x2 grid of 90° regions; a viewport straddling (0,0) touches the two
+    // middle columns in both rows.
+    const keys = regions.map((r) => `${r.regionX},${r.regionY}`).sort()
+    expect(keys).toEqual(['1,0', '1,1', '2,0', '2,1'])
+  })
+
+  it('returns empty without bounds, limits, level, or transformer', () => {
+    const noBoundsMap = { getBounds: () => undefined } as never
+    expect(
+      getVisibleRegions({
+        map: noBoundsMap,
+        xyLimits: WORLD,
+        levelMeta,
+        projection,
+        latIsAscending: false,
+      })
+    ).toEqual([])
+    expect(
+      getVisibleRegions({
+        map: mapAt(-10, -10, 10, 10),
+        xyLimits: null,
+        levelMeta,
+        projection,
+        latIsAscending: false,
+      })
+    ).toEqual([])
+    expect(
+      getVisibleRegions({
+        map: mapAt(-10, -10, 10, 10),
+        xyLimits: WORLD,
+        levelMeta: null,
+        projection,
+        latIsAscending: false,
+      })
+    ).toEqual([])
+  })
+})
+
+describe('selectLevelForZoom', () => {
+  const level = (asset: string, lonSize: number): UntiledLevel => ({
+    asset,
+    scale: [1, 1],
+    translation: [0, 0],
+    shape: [lonSize / 2, lonSize],
+  })
+  const projection4326 = createProjectionContext({
+    crs: 'EPSG:4326',
+    proj4def: null,
+    xyLimits: null,
+  })
+
+  it('matches slippy zoom levels for a 256px global pyramid', () => {
+    // Levels 0..3 of a 256px-tile pyramid: lon sizes 256, 512, 1024, 2048.
+    const levels = [0, 1, 2, 3].map((i) => level(String(i), 256 * 2 ** i))
+    for (const zoom of [0, 1, 2, 3]) {
+      expect(
+        selectLevelForZoom({
+          mapZoom: zoom,
+          xyLimits: WORLD,
+          levels,
+          projection: projection4326,
+          lonIndex: 1,
+        })
+      ).toBe(zoom)
+    }
+  })
+
+  it('picks one level finer for a 128px pyramid', () => {
+    const levels = [0, 1, 2, 3].map((i) => level(String(i), 128 * 2 ** i))
+    expect(
+      selectLevelForZoom({
+        mapZoom: 1,
+        xyLimits: WORLD,
+        levels,
+        projection: projection4326,
+        lonIndex: 1,
+      })
+    ).toBe(2)
+  })
+
+  it('scales resolution by the longitude world fraction for regional data', () => {
+    // Half-world data: each pixel covers half the ground, so effective
+    // resolution doubles and a coarser level suffices at the same zoom.
+    const levels = [0, 1, 2].map((i) => level(String(i), 256 * 2 ** i))
+    const regional = { xMin: -90, xMax: 90, yMin: -45, yMax: 45 }
+    expect(
+      selectLevelForZoom({
+        mapZoom: 1,
+        xyLimits: regional,
+        levels,
+        projection: projection4326,
+        lonIndex: 1,
+      })
+    ).toBe(0)
+  })
+
+  it('returns the finest level when the zoom exceeds every level', () => {
+    const levels = [0, 1].map((i) => level(String(i), 256 * 2 ** i))
+    expect(
+      selectLevelForZoom({
+        mapZoom: 10,
+        xyLimits: WORLD,
+        levels,
+        projection: projection4326,
+        lonIndex: 1,
+      })
+    ).toBe(1)
+  })
+
+  it('uses meter extents for EPSG:3857 data', () => {
+    const E = 20037508.342789244
+    const projection3857 = createProjectionContext({
+      crs: 'EPSG:3857',
+      proj4def: null,
+      xyLimits: null,
+    })
+    const levels = [0, 1, 2].map((i) => level(String(i), 256 * 2 ** i))
+    expect(
+      selectLevelForZoom({
+        mapZoom: 2,
+        xyLimits: { xMin: -E, xMax: E, yMin: -E, yMax: E },
+        levels,
+        projection: projection3857,
+        lonIndex: 1,
+      })
+    ).toBe(2)
+  })
+
+  it('returns level 0 without limits or levels', () => {
+    expect(
+      selectLevelForZoom({
+        mapZoom: 3,
+        xyLimits: null,
+        levels: [],
+        projection: projection4326,
+        lonIndex: 1,
+      })
+    ).toBe(0)
+  })
+})
+
+describe('computeRegionMercatorBounds', () => {
+  it('matches boundsToMercatorNorm for the builtin CRSes', () => {
+    const bounds = { xMin: -90, xMax: 90, yMin: -45, yMax: 45 }
+    const p4326 = createProjectionContext({
+      crs: 'EPSG:4326',
+      proj4def: null,
+      xyLimits: WORLD,
+    })
+    expect(computeRegionMercatorBounds(bounds, p4326)).toEqual(
+      boundsToMercatorNorm(bounds, 'EPSG:4326')
+    )
+
+    const E = 20037508.342789244
+    const meters = { xMin: -E / 2, xMax: E / 2, yMin: -E / 2, yMax: E / 2 }
+    const p3857 = createProjectionContext({
+      crs: 'EPSG:3857',
+      proj4def: null,
+      xyLimits: null,
+    })
+    expect(computeRegionMercatorBounds(meters, p3857)).toEqual(
+      boundsToMercatorNorm(meters, 'EPSG:3857')
+    )
+  })
+})

--- a/src/region-math.ts
+++ b/src/region-math.ts
@@ -1,0 +1,406 @@
+import type * as zarr from 'zarrita'
+import { WEB_MERCATOR_EXTENT } from './constants'
+import {
+  boundsToMercatorNorm,
+  lonRangeOverlaps,
+  type MercatorBounds,
+  type XYLimits,
+} from './map-utils'
+import type { ProjectionContext } from './projection-utils'
+import { sampleEdgesToMercatorBounds } from './projection-utils'
+import type { LevelMeta } from './region-state'
+import type { DimIndicesProps, MapLike, UntiledLevel } from './types'
+
+export type RegionCoordinate = { regionX: number; regionY: number }
+type SourceBounds = { xMin: number; xMax: number; yMin: number; yMax: number }
+
+/** Detect optimal region size from array metadata. */
+export function getRegionSize(
+  array: zarr.Array<zarr.DataType>,
+  dimIndices: DimIndicesProps
+): [number, number] | null {
+  const latIdx = dimIndices.lat?.index
+  const lonIdx = dimIndices.lon?.index
+  if (latIdx === undefined || lonIdx === undefined) return null
+  const codecs = (array as any).codecs || []
+  for (const codec of codecs) {
+    if (codec.name === 'sharding_indexed' && codec.configuration?.chunk_shape) {
+      const shardShape = codec.configuration.chunk_shape as number[]
+      return [shardShape[latIdx], shardShape[lonIdx]]
+    }
+  }
+  const chunks = array.chunks as number[] | undefined
+  if (chunks && chunks.length > Math.max(latIdx, lonIdx)) {
+    const chunkH = chunks[latIdx]
+    const chunkW = chunks[lonIdx]
+    // Only use region-based loading if chunks are smaller than the array
+    const shape = array.shape as number[]
+    if (chunkH < shape[latIdx] || chunkW < shape[lonIdx]) {
+      return [chunkH, chunkW]
+    }
+  }
+  return null // No chunking or single chunk
+}
+
+export function getVisibleRegions({
+  map,
+  xyLimits,
+  levelMeta,
+  projection,
+  latIsAscending,
+}: {
+  map: MapLike
+  xyLimits: XYLimits | null
+  levelMeta: LevelMeta | null
+  projection: ProjectionContext
+  latIsAscending: boolean
+}): RegionCoordinate[] {
+  const bounds = map.getBounds?.()?.toArray?.()
+  if (!bounds || !xyLimits || !levelMeta) return []
+  if (!projection.def || !projection.toWGS84) {
+    // No proj4 transformer was set up — either because the CRS isn't
+    // one proj4js handles natively and no `proj4` prop was supplied
+    // (constructor warned), or because proj4 init threw on a malformed
+    // string. Either way, computing region indices here would be wrong;
+    // skip rather than render a misleading partial result.
+    return []
+  }
+  const { width, height, regionSize } = levelMeta
+  const [[west, south], [east, north]] = bounds
+  const [regionH, regionW] = regionSize
+  // For projected data, use a two-pass approach:
+  // 1. Forward-transform viewport edges to source CRS to find candidate
+  //    regions via index math (O(1) proj4 cost, may include false
+  //    positives for non-bijective projections like UTM outside their zone)
+  // 2. Inverse-transform candidate region bounds to WGS84 for precise overlap
+  const transformer = projection.toWGS84
+  const candidates = getCandidateRegions({
+    west,
+    south,
+    east,
+    north,
+    transformer,
+    numRegionsX: Math.ceil(width / regionW),
+    numRegionsY: Math.ceil(height / regionH),
+    regionW,
+    regionH,
+    width,
+    height,
+    xyLimits,
+    latIsAscending,
+  })
+
+  // Verify candidates via inverse transform to WGS84 for precise overlap.
+  // This handles non-bijective projections where forward transforms can
+  // produce false positives.
+  const regions: RegionCoordinate[] = []
+  for (const { regionX, regionY } of candidates) {
+    const regBounds = getRegionBounds({
+      regionX,
+      regionY,
+      levelMeta,
+      xyLimits,
+      latIsAscending,
+    })
+    const xMid = (regBounds.xMin + regBounds.xMax) / 2
+    const yMid = (regBounds.yMin + regBounds.yMax) / 2
+    const samplePoints = [
+      transformer.inverse(regBounds.xMin, regBounds.yMin),
+      transformer.inverse(regBounds.xMax, regBounds.yMin),
+      transformer.inverse(regBounds.xMax, regBounds.yMax),
+      transformer.inverse(regBounds.xMin, regBounds.yMax),
+      transformer.inverse(xMid, regBounds.yMin),
+      transformer.inverse(xMid, regBounds.yMax),
+      transformer.inverse(regBounds.xMin, yMid),
+      transformer.inverse(regBounds.xMax, yMid),
+    ]
+    let regWest = Infinity
+    let regEast = -Infinity
+    let regSouth = Infinity
+    let regNorth = -Infinity
+    let hasValid = false
+    for (const [lon, lat] of samplePoints) {
+      if (!isFinite(lon) || !isFinite(lat)) continue
+      hasValid = true
+      regWest = Math.min(regWest, lon)
+      regEast = Math.max(regEast, lon)
+      regSouth = Math.min(regSouth, lat)
+      regNorth = Math.max(regNorth, lat)
+    }
+    if (
+      hasValid &&
+      lonRangeOverlaps(west, east, regWest, regEast) &&
+      regNorth >= south &&
+      regSouth <= north
+    ) {
+      regions.push({ regionX, regionY })
+    }
+  }
+  return regions
+}
+
+/** Fast projected viewport prefilter; callers verify inverse overlap. */
+export function getCandidateRegions({
+  west,
+  south,
+  east,
+  north,
+  transformer,
+  numRegionsX,
+  numRegionsY,
+  regionW,
+  regionH,
+  width,
+  height,
+  xyLimits,
+  latIsAscending,
+}: {
+  west: number
+  south: number
+  east: number
+  north: number
+  transformer: { forward: (lon: number, lat: number) => [number, number] }
+  numRegionsX: number
+  numRegionsY: number
+  regionW: number
+  regionH: number
+  width: number
+  height: number
+  xyLimits: XYLimits
+  latIsAscending: boolean
+}): RegionCoordinate[] {
+  const { xMin, xMax, yMin, yMax } = xyLimits
+  const edgeSamples = 16
+  let srcXMin = Infinity
+  let srcXMax = -Infinity
+  let srcYMin = Infinity
+  let srcYMax = -Infinity
+  let validCount = 0
+  let totalCount = 0
+  const record = ([x, y]: [number, number]) => {
+    totalCount++
+    if (!isFinite(x) || !isFinite(y)) return
+    validCount++
+    srcXMin = Math.min(srcXMin, x)
+    srcXMax = Math.max(srcXMax, x)
+    srcYMin = Math.min(srcYMin, y)
+    srcYMax = Math.max(srcYMax, y)
+  }
+  // Densely sample viewport edges and interior to capture projection curvature
+  // and extrema that may fall inside the viewport (e.g., pole in polar stereo).
+  for (let i = 0; i <= edgeSamples; i++) {
+    const t = i / edgeSamples
+    const lon = west + t * (east - west)
+    const lat = south + t * (north - south)
+    record(transformer.forward(lon, south))
+    record(transformer.forward(lon, north))
+    record(transformer.forward(west, lat))
+    record(transformer.forward(east, lat))
+  }
+  // Sample interior grid to catch extrema inside viewport (e.g., pole in polar stereo)
+  const interiorSamples = 4
+  for (let iy = 1; iy <= interiorSamples; iy++) {
+    for (let ix = 1; ix <= interiorSamples; ix++) {
+      record(
+        transformer.forward(
+          west + (ix / (interiorSamples + 1)) * (east - west),
+          south + (iy / (interiorSamples + 1)) * (north - south)
+        )
+      )
+    }
+  }
+  // No valid points — fall back to all regions
+  if (validCount === 0) {
+    const all: RegionCoordinate[] = []
+    for (let ry = 0; ry < numRegionsY; ry++)
+      for (let rx = 0; rx < numRegionsX; rx++)
+        all.push({ regionX: rx, regionY: ry })
+    return all
+  }
+  // Widen margin when some samples failed (projection boundary)
+  const margin = validCount < totalCount ? 8 : 2
+  const pxXMin = ((srcXMin - xMin) / (xMax - xMin)) * width
+  const pxXMax = ((srcXMax - xMin) / (xMax - xMin)) * width
+  const pxYMin = ((srcYMin - yMin) / (yMax - yMin)) * height
+  const pxYMax = ((srcYMax - yMin) / (yMax - yMin)) * height
+  let rYMin = Math.floor(pxYMin / regionH) - margin
+  let rYMax = Math.floor(pxYMax / regionH) + margin
+  if (!latIsAscending) {
+    rYMin = Math.floor((height - pxYMax) / regionH) - margin
+    rYMax = Math.floor((height - pxYMin) / regionH) + margin
+  }
+  let rXMin = Math.max(0, Math.floor(pxXMin / regionW) - margin)
+  let rXMax = Math.min(numRegionsX - 1, Math.floor(pxXMax / regionW) + margin)
+  rYMin = Math.max(0, rYMin)
+  rYMax = Math.min(numRegionsY - 1, rYMax)
+  // When the viewport straddles the antimeridian, forward-projecting the
+  // sampled longitudes folds source X back on itself (e.g. proj4 adjust_lon),
+  // so the srcX min/max span no longer bounds the visible columns. Treat
+  // every X region as a candidate; the antimeridian-aware overlap check in
+  // getVisibleRegions then keeps only the columns that are actually visible,
+  // so this widens the search without over-fetching the result (issue #64).
+  if (east < west || east > 180 || west < -180) {
+    rXMin = 0
+    rXMax = numRegionsX - 1
+  }
+  const candidates: RegionCoordinate[] = []
+  for (let ry = rYMin; ry <= rYMax; ry++)
+    for (let rx = rXMin; rx <= rXMax; rx++)
+      candidates.push({ regionX: rx, regionY: ry })
+  return candidates
+}
+
+export function getRegionBounds({
+  regionX,
+  regionY,
+  levelMeta,
+  xyLimits,
+  latIsAscending,
+}: {
+  regionX: number
+  regionY: number
+  levelMeta: LevelMeta
+  xyLimits: XYLimits | null
+  latIsAscending: boolean
+}): SourceBounds {
+  const { width, height, regionSize } = levelMeta
+  // xyLimits is assumed constant across all multiscale levels (same geographic extent).
+  // If per-level bounds are ever needed, add xyLimits to LevelMeta type.
+  if (!xyLimits) return { xMin: 0, xMax: 1, yMin: 0, yMax: 1 }
+  const [regionH, regionW] = regionSize
+  const { xMin, xMax, yMin, yMax } = xyLimits
+  const pxXStart = regionX * regionW
+  const pxXEnd = Math.min(pxXStart + regionW, width)
+  const pxYStart = regionY * regionH
+  const pxYEnd = Math.min(pxYStart + regionH, height)
+  const geoXMin = xMin + (pxXStart / width) * (xMax - xMin)
+  const geoXMax = xMin + (pxXEnd / width) * (xMax - xMin)
+  let geoYMin: number
+  let geoYMax: number
+  if (!latIsAscending) {
+    geoYMax = yMax - (pxYStart / height) * (yMax - yMin)
+    geoYMin = yMax - (pxYEnd / height) * (yMax - yMin)
+  } else {
+    geoYMin = yMin + (pxYStart / height) * (yMax - yMin)
+    geoYMax = yMin + (pxYEnd / height) * (yMax - yMin)
+  }
+  return { xMin: geoXMin, xMax: geoXMax, yMin: geoYMin, yMax: geoYMax }
+}
+
+export function longitudeWorldFraction(bounds: { xMin: number; xMax: number }) {
+  const rawSpan = bounds.xMax - bounds.xMin
+  if (!Number.isFinite(rawSpan) || rawSpan === 0 || Math.abs(rawSpan) >= 360)
+    return 1
+  const span = rawSpan > 0 ? rawSpan : rawSpan + 360
+  return Math.max(span / 360, Number.EPSILON)
+}
+
+export function selectLevelForZoom({
+  mapZoom,
+  xyLimits,
+  levels,
+  projection,
+  lonIndex,
+}: {
+  mapZoom: number
+  xyLimits: XYLimits | null
+  levels: UntiledLevel[]
+  projection: ProjectionContext
+  lonIndex?: number
+}): number {
+  if (!xyLimits || levels.length === 0) return 0
+  const mapPixelsPerWorld = 256 * Math.pow(2, mapZoom)
+  let worldFraction: number
+  if (projection.kind === 'epsg4326') {
+    // proj4's adjust_lon folds inputs outside [-180, 180] back into range
+    // (e.g. forward(360,·)→0, forward(190,·)→-170), which collapses or
+    // distorts the width for 0-360° stores and antimeridian-crossing
+    // extents. Use the source longitude span for level selection because
+    // render bounds may conservatively expand antimeridian-crossing regions
+    // to full-world X for tile intersection.
+    worldFraction = longitudeWorldFraction(xyLimits)
+  } else if (projection.kind === 'epsg3857') {
+    worldFraction = (xyLimits.xMax - xyLimits.xMin) / (2 * WEB_MERCATOR_EXTENT)
+  } else if (projection.def && projection.toMercator) {
+    const [minMercX] = projection.toMercator.forward(
+      xyLimits.xMin,
+      xyLimits.yMin
+    )
+    const [maxMercX] = projection.toMercator.forward(
+      xyLimits.xMax,
+      xyLimits.yMax
+    )
+    let dataWidthMeters = Math.abs(maxMercX - minMercX)
+    const fullWorldMeters = 2 * WEB_MERCATOR_EXTENT
+    // worldFraction > 1 means the corner projection failed: for projections
+    // like MODIS sinusoidal the rectangular bbox corners fall outside the
+    // valid CRS domain (near-polar latitudes give out-of-domain longitudes),
+    // yielding a garbage or non-finite width. Fall back to the equatorial
+    // strip (y=0), which stays in-domain for any cylindrical-like projection
+    // and gives the correct horizontal extent.
+    if (!isFinite(dataWidthMeters) || dataWidthMeters > fullWorldMeters) {
+      const [eqMinX] = projection.toMercator.forward(xyLimits.xMin, 0)
+      const [eqMaxX] = projection.toMercator.forward(xyLimits.xMax, 0)
+      dataWidthMeters = Math.abs(eqMaxX - eqMinX)
+    }
+    worldFraction = Math.min(1, dataWidthMeters / fullWorldMeters)
+  } else {
+    worldFraction = (xyLimits.xMax - xyLimits.xMin) / 360
+  }
+  const levelResolutions: Array<{ index: number; effectivePixels: number }> = []
+  for (let i = 0; i < levels.length; i++) {
+    const shape = levels[i].shape
+    if (!shape) continue
+    const index = lonIndex ?? shape.length - 1
+    levelResolutions.push({
+      index: i,
+      effectivePixels: shape[index] / worldFraction,
+    })
+  }
+  if (levelResolutions.length === 0) return levels.length - 1
+  levelResolutions.sort((a, b) => a.effectivePixels - b.effectivePixels)
+  for (const level of levelResolutions)
+    if (level.effectivePixels >= mapPixelsPerWorld) return level.index
+  return levelResolutions[levelResolutions.length - 1].index
+}
+
+export function computeMercatorBoundsFromProjection(
+  xyLimits: XYLimits | null,
+  projection: ProjectionContext
+): MercatorBounds {
+  if (!xyLimits) return { x0: 0, y0: 0, x1: 1, y1: 1 }
+  if (projection.kind === 'epsg4326')
+    return boundsToMercatorNorm(xyLimits, 'EPSG:4326')
+  if (projection.kind === 'epsg3857')
+    return boundsToMercatorNorm(xyLimits, 'EPSG:3857')
+  if (!projection.def || !projection.toMercator)
+    return { x0: 0, y0: 0, x1: 1, y1: 1 }
+  const result = sampleEdgesToMercatorBounds(
+    xyLimits,
+    projection.toMercator,
+    20
+  )
+  if (!result) {
+    console.warn('computeMercatorBoundsFromProjection: No valid samples found')
+    return { x0: 0, y0: 0, x1: 1, y1: 1 }
+  }
+  return result
+}
+
+export function computeRegionMercatorBounds(
+  bounds: SourceBounds,
+  projection: ProjectionContext
+): MercatorBounds {
+  if (projection.kind === 'epsg4326')
+    return boundsToMercatorNorm(bounds, 'EPSG:4326')
+  if (projection.kind === 'epsg3857')
+    return boundsToMercatorNorm(bounds, 'EPSG:3857')
+  if (!projection.def || !projection.toMercator)
+    return { x0: 0, y0: 0, x1: 1, y1: 1 }
+  const result = sampleEdgesToMercatorBounds(bounds, projection.toMercator, 5)
+  if (!result) {
+    console.warn('computeRegionMercatorBounds: No valid samples found')
+    return { x0: 0, y0: 0, x1: 1, y1: 1 }
+  }
+  return result
+}

--- a/src/region-renderer.render-path.test.ts
+++ b/src/region-renderer.render-path.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, vi } from 'vitest'
+import { RegionRenderer } from './region-renderer'
+import { createRegionState, type RegionCache } from './region-cache'
+import { ZarrStore } from './zarr-store'
+import { buildMemoryZarrStore } from './__fixtures__/memory-zarr'
+import { createRecordingGl, FAKE_SHADER_DATA } from './__fixtures__/fake-gl'
+import {
+  createShaderProgram,
+  resolveProjectionMode,
+  type ShaderProgram,
+} from './shader-program'
+import { maplibreFragmentShaderSource } from './shaders'
+import type { RenderContext } from './renderer-types'
+import type { ZarrRenderer } from './zarr-renderer'
+import type { RegionState } from './region-state'
+
+/**
+ * Per-frame render-path selection: the branch in RegionRenderer.render() that
+ * turns "which map is this, in which projection, drawn how" into a shader
+ * variant, a world-offset list, and an eye-coords matrix.
+ *
+ * These are the settings that produce visual-only regressions — a globe that
+ * renders flat, a mercator map that draws duplicate copies, terrain that loses
+ * the layer — because nothing throws when the wrong variant is picked. The
+ * inputs the branch reads are all in RenderContext plus onProjectionChange:
+ *
+ *   provider    context.mapbox present (Mapbox) or absent (MapLibre)
+ *   globe       MapLibre: projectionData.projectionTransition > 0
+ *               Mapbox:   onProjectionChange(true) + mapbox.directGlobePathActive
+ *   terrain     Mapbox with terrain stays draped, so directGlobePathActive is
+ *               false and the frame must not take the ECEF path
+ *
+ * The stub renderer compiles the variant it is asked for against the recording
+ * GL, so uniform locations are the ones the real program would expose and the
+ * assertions below see the uploads that actually reach the GPU.
+ */
+
+const MATRIX = Array.from({ length: 16 }, (_, i) => i + 1)
+const MAIN_MATRIX = Array.from({ length: 16 }, (_, i) => 100 + i)
+
+async function makeRenderer() {
+  const memory = buildMemoryZarrStore({
+    arrays: [
+      {
+        name: 'temperature',
+        shape: [4, 8],
+        chunkShape: [2, 4],
+        dimensionNames: ['lat', 'lon'],
+        chunks: {
+          '0/0': [0, 1, 2, 3, 4, 5, 6, 7],
+          '0/1': [8, 9, 10, 11, 12, 13, 14, 15],
+          '1/0': [16, 17, 18, 19, 20, 21, 22, 23],
+          '1/1': [24, 25, 26, 27, 28, 29, 30, 31],
+        },
+      },
+    ],
+  })
+  const store = new ZarrStore({
+    customStore: memory,
+    variable: 'temperature',
+    version: 3,
+    bounds: [-180, -90, 180, 90],
+    latIsAscending: false,
+  })
+  await store.initialized
+
+  const renderer = new RegionRenderer(store, 'temperature', {}, vi.fn())
+  await renderer.initialize()
+  return renderer
+}
+
+type Seam = { regionCache: RegionCache }
+
+/**
+ * A drawable region carrying a source-projected mesh. Seeded rather than
+ * fetched: the path selection under test runs off the render context, not off
+ * how the region's data arrived.
+ */
+function seedRegion(renderer: RegionRenderer): RegionState {
+  const region = createRegionState(0, 0, 0, false, 0)
+  region.data = new Float32Array([1, 2, 3, 4])
+  region.width = 2
+  region.height = 2
+  region.vertexArr = new Float32Array(8)
+  region.pixCoordArr = new Float32Array(8)
+  region.indexArr = new Uint32Array([0, 1, 2])
+  region.useIndexedMesh = true
+  region.vertexCount = 3
+  region.mercatorBounds = {
+    x0: 0,
+    y0: 0,
+    x1: 1,
+    y1: 1,
+    latMin: -85,
+    latMax: 85,
+  }
+  region.wgs84Bounds = { x0: 0, y0: 0, x1: 1, y1: 1 }
+  region.levelMeta = { width: 2, height: 2, regionSize: [2, 2] }
+
+  const cache = (renderer as unknown as Seam).regionCache
+  cache.set(region.key, region)
+  cache.rebuildProtection([region.key], { retainKeysNotMatching: '' })
+  return region
+}
+
+/**
+ * Stands in for ZarrRenderer, recording the variant selection while returning
+ * a real program compiled for that variant.
+ */
+function stubRenderer(gl: ReturnType<typeof createRecordingGl>) {
+  const requests: Array<{
+    useMapbox: boolean
+    useWgs84: boolean
+    useDirectEcef: boolean
+  }> = []
+  let program: ShaderProgram | null = null
+
+  const renderer = {
+    gl,
+    getProgram: (
+      shaderData: unknown,
+      customShaderConfig: unknown,
+      useMapbox = false,
+      useWgs84 = false,
+      useDirectEcef = false
+    ) => {
+      requests.push({ useMapbox, useWgs84, useDirectEcef })
+      const built = createShaderProgram(gl, {
+        fragmentShaderSource: maplibreFragmentShaderSource,
+        shaderData: FAKE_SHADER_DATA,
+        projectionMode: resolveProjectionMode(
+          useMapbox,
+          useWgs84,
+          useDirectEcef
+        ),
+      })
+      program = built.shaderProgram
+      return built.shaderProgram
+    },
+    applyCommonUniforms: vi.fn(),
+  }
+
+  return {
+    renderer: renderer as unknown as ZarrRenderer,
+    requests,
+    mode: () => program?.projectionMode,
+  }
+}
+
+const uniforms: RenderContext['uniforms'] = {
+  clim: [0, 1],
+  opacity: 1,
+  fillValue: null,
+  scaleFactor: 1,
+  offset: 0,
+  fixedDataScale: 1,
+}
+
+function maplibreContext(
+  gl: WebGL2RenderingContext,
+  projectionTransition: number,
+  worldOffsets = [0]
+): RenderContext {
+  return {
+    gl,
+    matrix: MAIN_MATRIX,
+    uniforms,
+    colormapTexture: {} as WebGLTexture,
+    worldOffsets,
+    shaderData: FAKE_SHADER_DATA,
+    projectionData: {
+      mainMatrix: MAIN_MATRIX,
+      fallbackMatrix: MATRIX,
+      tileMercatorCoords: [0, 0, 1, 1],
+      clippingPlane: [0, 0, 1, 0],
+      projectionTransition,
+    },
+  }
+}
+
+function mapboxContext(
+  gl: WebGL2RenderingContext,
+  {
+    globe = false,
+    directGlobePathActive = false,
+    worldOffsets = [0],
+  }: {
+    globe?: boolean
+    directGlobePathActive?: boolean
+    worldOffsets?: number[]
+  } = {}
+): RenderContext {
+  return {
+    gl,
+    matrix: MATRIX,
+    uniforms,
+    colormapTexture: {} as WebGLTexture,
+    worldOffsets,
+    mapbox: {
+      projection: { name: globe ? 'globe' : 'mercator' },
+      globeToMercatorMatrix: new Float32Array(16),
+      transition: globe ? 0 : 1,
+      directGlobePathActive,
+    },
+  }
+}
+
+/** World offsets actually drawn, read back off the u_worldXOffset uploads. */
+const drawnWorldOffsets = (gl: ReturnType<typeof createRecordingGl>) =>
+  gl.calls
+    .filter((call) => call.args[0] === 'u_worldXOffset')
+    .map((call) => call.args[1])
+
+const eyeMatrixUpload = (gl: ReturnType<typeof createRecordingGl>) =>
+  gl.calls.find((call) => call.args[0] === 'u_eye_matrix')?.args[1]
+
+async function frame(
+  build: (gl: ReturnType<typeof createRecordingGl>) => RenderContext,
+  { isGlobe = false }: { isGlobe?: boolean } = {}
+) {
+  const renderer = await makeRenderer()
+  seedRegion(renderer)
+  renderer.onProjectionChange(isGlobe)
+
+  const gl = createRecordingGl()
+  const stub = stubRenderer(gl)
+  const context = build(gl)
+  // Uploads happen on the first pass; clear so assertions see the draw frame.
+  renderer.render(stub.renderer, context)
+  gl.calls.length = 0
+  renderer.render(stub.renderer, context)
+
+  return { gl, mode: stub.mode(), requests: stub.requests }
+}
+
+describe('MapLibre render path', () => {
+  it('uses the flat source-projected variant in mercator', async () => {
+    const { mode } = await frame((gl) => maplibreContext(gl, 0))
+    expect(mode).toBe('maplibre-proj4')
+  })
+
+  it('switches to ECEF as soon as the globe transition starts', async () => {
+    // MapLibre morphs continuously; any nonzero transition means part of the
+    // frame is on the sphere, and mercator-space vertices clip at the poles.
+    const { mode } = await frame((gl) => maplibreContext(gl, 0.01))
+    expect(mode).toBe('maplibre-ecef')
+  })
+
+  it('stays flat at transition exactly zero', async () => {
+    const { mode } = await frame((gl) => maplibreContext(gl, 0))
+    expect(mode).not.toBe('maplibre-ecef')
+  })
+
+  it('never asks for a mapbox variant', async () => {
+    for (const transition of [0, 0.5, 1]) {
+      const { requests } = await frame((gl) => maplibreContext(gl, transition))
+      expect(requests.every((r) => !r.useMapbox)).toBe(true)
+    }
+  })
+
+  it('draws every world copy in mercator', async () => {
+    const { gl } = await frame((g) => maplibreContext(g, 0, [-1, 0, 1]))
+    expect(drawnWorldOffsets(gl)).toEqual([-1, 0, 1])
+  })
+
+  it('collapses to one world copy on the globe', async () => {
+    // isGlobeProjection can flip to false before the transition reaches 0, so
+    // the context can still carry wrapped offsets while ECEF is active.
+    // Drawing them would stack duplicate geometry on the sphere.
+    const { gl } = await frame((g) => maplibreContext(g, 0.5, [-1, 0, 1]))
+    expect(drawnWorldOffsets(gl)).toEqual([0])
+  })
+
+  it('anchors the flat path on the projection main matrix', async () => {
+    // MapLibre's flat view-projection lives in projectionData.mainMatrix; the
+    // per-region anchor is computed from it at full precision.
+    const { gl } = await frame((g) => maplibreContext(g, 0))
+    expect(eyeMatrixUpload(gl)).toEqual(new Float32Array(MAIN_MATRIX))
+  })
+
+  it('uploads no eye matrix on the globe', async () => {
+    const { gl } = await frame((g) => maplibreContext(g, 0.5))
+    expect(eyeMatrixUpload(gl)).toBeUndefined()
+  })
+})
+
+describe('Mapbox render path', () => {
+  it('uses the flat source-projected variant in mercator', async () => {
+    const { mode } = await frame((gl) => mapboxContext(gl))
+    expect(mode).toBe('mapbox-proj4')
+  })
+
+  it('takes the direct ECEF path when the layer has undraped itself', async () => {
+    const { mode } = await frame(
+      (gl) => mapboxContext(gl, { globe: true, directGlobePathActive: true }),
+      { isGlobe: true }
+    )
+    expect(mode).toBe('mapbox-ecef')
+  })
+
+  it('stays draped on the globe while the layer is still draped', async () => {
+    // This is the terrain case and the zoom-morph case: the layer keeps
+    // renderToTile, so Mapbox drives the projection and the direct ECEF
+    // program would fight it for depth.
+    const { mode } = await frame(
+      (gl) => mapboxContext(gl, { globe: true, directGlobePathActive: false }),
+      { isGlobe: true }
+    )
+    expect(mode).toBe('mapbox-proj4')
+  })
+
+  it('ignores the direct-path flag when the map is not on the globe', async () => {
+    const { mode } = await frame(
+      (gl) => mapboxContext(gl, { globe: false, directGlobePathActive: true }),
+      { isGlobe: false }
+    )
+    expect(mode).toBe('mapbox-proj4')
+  })
+
+  it('never asks for a maplibre variant', async () => {
+    const { requests } = await frame((gl) => mapboxContext(gl))
+    expect(requests.every((r) => r.useMapbox)).toBe(true)
+  })
+
+  it('anchors the flat path on the mapbox custom-layer matrix', async () => {
+    // Mapbox passes its matrix directly rather than in a projection-data block.
+    const { gl } = await frame((g) => mapboxContext(g))
+    expect(eyeMatrixUpload(gl)).toEqual(new Float32Array(MATRIX))
+  })
+
+  it('collapses to one world copy on the direct globe path', async () => {
+    const { gl } = await frame(
+      (g) =>
+        mapboxContext(g, {
+          globe: true,
+          directGlobePathActive: true,
+          worldOffsets: [-1, 0, 1],
+        }),
+      { isGlobe: true }
+    )
+    expect(drawnWorldOffsets(gl)).toEqual([0])
+  })
+
+  it('keeps world copies while draped in mercator', async () => {
+    const { gl } = await frame((g) =>
+      mapboxContext(g, { worldOffsets: [0, 1] })
+    )
+    expect(drawnWorldOffsets(gl)).toEqual([0, 1])
+  })
+})
+
+describe('per-region anchor across world copies', () => {
+  it('recomputes the anchor for each world copy', async () => {
+    // A wrapped copy has to anchor on its own origin; reusing the unwrapped
+    // anchor makes the eye-coords sum cancel two near-world-sized clip values
+    // and reintroduces high-zoom jitter on the wrapped side.
+    const { gl } = await frame((g) => maplibreContext(g, 0, [0, 1]))
+    const anchors = gl.calls
+      .filter((call) => call.args[0] === 'u_anchor_clip')
+      .map((call) => call.args.slice(1))
+    expect(anchors).toHaveLength(2)
+    expect(anchors[0]).not.toEqual(anchors[1])
+  })
+})

--- a/src/region-renderer.test.ts
+++ b/src/region-renderer.test.ts
@@ -343,6 +343,32 @@ describe('RegionRenderer', () => {
     expect(gl.texImage2D).toHaveBeenCalledTimes(1)
   })
 
+  it('draws nothing from a band-mode region until the shader switch refetches', async () => {
+    const { renderer, gl, map } = await makeRenderer()
+    renderer.update(map, gl)
+    await settle()
+    await renderer.setSelector({ time: { selected: [10, 20], type: 'value' } })
+    renderer.setRendersFromBandTextures(true)
+    renderer.update(map, gl)
+    await settle()
+    expect(seam(renderer).getRegionStates(gl)).toHaveLength(4)
+
+    // Switching back to the main texture leaves cached regions holding band
+    // data only. Drawing them through the main path would put one band's
+    // values on screen as if they were the whole dataset.
+    renderer.setRendersFromBandTextures(false)
+    expect(seam(renderer).getRegionStates(gl)).toEqual([])
+
+    // The refetch triggered by the switch restores them.
+    renderer.update(map, gl)
+    await settle()
+    const states = seam(renderer).getRegionStates(gl)
+    expect(states).toHaveLength(4)
+    for (const state of states) {
+      expect(state.texture).not.toBeNull()
+    }
+  })
+
   it('keeps fallback coverage when a band texture cannot be allocated', async () => {
     const { renderer, map } = await makeRenderer()
     const working = fakeGl()
@@ -406,8 +432,7 @@ describe('RegionRenderer', () => {
 
     const refetched = seam(renderer).regionCache.get('0:0,0')!
     expect(refetched.bandData.size).toBe(2)
-    expect(refetched.data).toBe(refetched.bandData.get('time_10'))
-    expect(refetched.channels).toBe(1)
+    expect(refetched.data).toBeNull()
 
     // Rendering uploads the bands and no main texture at all, which is only
     // true if the renderer passes its band list down to the upload.

--- a/src/region-renderer.test.ts
+++ b/src/region-renderer.test.ts
@@ -136,10 +136,26 @@ function seedFallbackRegion(
   return region
 }
 
-/** Let the fire-and-forget fetch chain started by update() settle. */
-async function settle(): Promise<void> {
-  for (let i = 0; i < 20; i++) await Promise.resolve()
-  await new Promise((resolve) => setTimeout(resolve, 0))
+/**
+ * Let the fire-and-forget fetch chain started by update() run to quiescence.
+ * `fetchRegions` marks its batch loading before it yields, so an in-flight
+ * batch is already visible here. Hopping the macrotask queue until nothing is
+ * loading keeps the tests independent of how many awaits deep the chain runs.
+ */
+async function settle(
+  renderer: RegionRenderer,
+  timeoutMs = 2000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  const fetching = () => {
+    for (const region of seam(renderer).regionCache.values()) {
+      if (region.loading) return true
+    }
+    return false
+  }
+  do {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  } while (fetching() && Date.now() < deadline)
 }
 
 async function makeRenderer() {
@@ -199,7 +215,7 @@ describe('RegionRenderer', () => {
     const { renderer, invalidate, gl, map } = await makeRenderer()
 
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
 
     // 2x2 region grid, all visible at a whole-world viewport.
     expect(seam(renderer).getRegionStates(gl)).toHaveLength(4)
@@ -210,7 +226,7 @@ describe('RegionRenderer', () => {
     const { renderer, gl, map } = await makeRenderer()
 
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
     // Fetch is complete, but nothing has been drawn yet.
     expect(gl.createTexture).not.toHaveBeenCalled()
     expect(gl.texImage2D).not.toHaveBeenCalled()
@@ -232,7 +248,7 @@ describe('RegionRenderer', () => {
     const { renderer, gl, map } = await makeRenderer()
 
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
     seam(renderer).getRegionStates(gl)
     seam(renderer).getRegionStates(gl)
     seam(renderer).getRegionStates(gl)
@@ -251,7 +267,7 @@ describe('RegionRenderer', () => {
   it('serves queries from the same level the renderer committed', async () => {
     const { renderer, gl, map } = await makeRenderer()
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
 
     // Pixel (0, 0) of the 8x4 grid: lon -157.5, lat 67.5.
     const first = await renderer.queryData(
@@ -270,14 +286,14 @@ describe('RegionRenderer', () => {
   it('refetches and re-uploads every region after a selector change', async () => {
     const { renderer, gl, map } = await makeRenderer()
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
     seam(renderer).getRegionStates(gl)
     expect(gl.texImage2D).toHaveBeenCalledTimes(4)
     const geometryUploads = gl.bufferData.mock.calls.length
 
     await renderer.setSelector({ time: { selected: 20, type: 'value' } })
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
 
     const states = seam(renderer).getRegionStates(gl)
     expect(states).toHaveLength(4)
@@ -291,7 +307,7 @@ describe('RegionRenderer', () => {
   it('sends regenerated geometry to the GPU on the next frame', async () => {
     const { renderer, gl, map } = await makeRenderer()
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
     seam(renderer).getRegionStates(gl)
     const uploadsBefore = gl.bufferData.mock.calls.length
 
@@ -314,7 +330,7 @@ describe('RegionRenderer', () => {
   it('recomputes mercator bounds with the regenerated geometry', async () => {
     const { renderer, gl, map } = await makeRenderer()
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
     const region = seam(renderer).regionCache.get('0:0,0')!
     // A quarter of the world: the north-west region of a 2x2 grid.
     expect(region.mercatorBounds).toMatchObject({ x0: 0, x1: 0.5 })
@@ -334,7 +350,7 @@ describe('RegionRenderer', () => {
     const { renderer, map } = await makeRenderer()
     const gl = fakeGl({ failTextures: true })
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
     const fallback = seedFallbackRegion(renderer)
 
     // The current level has data but its textures won't allocate. Dropping the
@@ -359,11 +375,11 @@ describe('RegionRenderer', () => {
   it('draws nothing from a band-mode region until the shader switch refetches', async () => {
     const { renderer, gl, map } = await makeRenderer()
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
     await renderer.setSelector({ time: { selected: [10, 20], type: 'value' } })
     renderer.setRendersFromBandTextures(true)
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
     expect(seam(renderer).getRegionStates(gl)).toHaveLength(4)
 
     // Switching back to the main texture leaves cached regions holding band
@@ -374,7 +390,7 @@ describe('RegionRenderer', () => {
 
     // The refetch triggered by the switch restores them.
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
     const states = seam(renderer).getRegionStates(gl)
     expect(states).toHaveLength(4)
     for (const state of states) {
@@ -385,11 +401,11 @@ describe('RegionRenderer', () => {
   it('stops fetching once band-mode regions have their data', async () => {
     const { renderer, invalidate, gl, map } = await makeRenderer()
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
     await renderer.setSelector({ time: { selected: [10, 20], type: 'value' } })
     renderer.setRendersFromBandTextures(true)
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
 
     // Every fetch batch ends in invalidate(), so a settled viewport that keeps
     // invalidating is redispatching. Store reads can't see this: the decoded
@@ -400,7 +416,7 @@ describe('RegionRenderer', () => {
     // only looks at `data` queues every visible region on every frame.
     for (let frame = 0; frame < 3; frame++) {
       renderer.update(map, gl)
-      await settle()
+      await settle(renderer)
     }
     expect(invalidate).not.toHaveBeenCalled()
   })
@@ -409,11 +425,11 @@ describe('RegionRenderer', () => {
     const { renderer, map } = await makeRenderer()
     const working = fakeGl()
     renderer.update(map, working)
-    await settle()
+    await settle(renderer)
     await renderer.setSelector({ time: { selected: [10, 20], type: 'value' } })
     renderer.setRendersFromBandTextures(true)
     renderer.update(map, working)
-    await settle()
+    await settle(renderer)
 
     const fallback = seedFallbackRegion(renderer, {
       bands: ['time_10', 'time_20'],
@@ -430,7 +446,7 @@ describe('RegionRenderer', () => {
   it('holds other-level eviction protection until the level is drawable', async () => {
     const { renderer, gl, map } = await makeRenderer()
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
     const fallback = seedFallbackRegion(renderer)
     const cache = seam(renderer).regionCache
 
@@ -450,10 +466,10 @@ describe('RegionRenderer', () => {
     // setSelector rebuilds the level only once a gl context has been cached,
     // so the first update has to land before the multi-value selector.
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
     await renderer.setSelector({ time: { selected: [10, 20], type: 'value' } })
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
 
     const region = seam(renderer).regionCache.get('0:0,0')!
     expect(region.channels).toBe(2)
@@ -464,7 +480,7 @@ describe('RegionRenderer', () => {
     // main texture, so the interleaved copy stops being built.
     renderer.setRendersFromBandTextures(true)
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
 
     const refetched = seam(renderer).regionCache.get('0:0,0')!
     expect(refetched.bandData.size).toBe(2)
@@ -485,7 +501,7 @@ describe('RegionRenderer', () => {
   it('disposes GPU resources and stops rendering after dispose', async () => {
     const { renderer, gl, map } = await makeRenderer()
     renderer.update(map, gl)
-    await settle()
+    await settle(renderer)
     seam(renderer).getRegionStates(gl)
 
     renderer.dispose(gl)

--- a/src/region-renderer.test.ts
+++ b/src/region-renderer.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, vi } from 'vitest'
+import { RegionRenderer } from './region-renderer'
+import { createRegionState, type RegionCache } from './region-cache'
+import { ZarrStore } from './zarr-store'
+import { buildMemoryZarrStore } from './__fixtures__/memory-zarr'
+import type { MapLike } from './types'
+import type { RegionRenderState } from './renderer-types'
+import type { RegionState } from './region-state'
+
+/**
+ * Wiring tests for the orchestrator: a real ZarrStore over the in-memory Zarr
+ * fixture driven through the public surface (initialize / update / setSelector
+ * / queryData / dispose), with a recording fake for the GL context. Everything
+ * update() touches is GL-free apart from resource creation and disposal, so
+ * the whole viewport -> level -> region -> fetch -> cache -> upload path runs
+ * here; only the draw call itself is out of reach.
+ */
+
+// 2-time x 4-lat x 8-lon ramp, value = t*32 + y*8 + x, chunked 2x4 in lat/lon
+// so the level is a 2x2 region grid and both time steps share a chunk.
+const HEIGHT = 4
+const WIDTH = 8
+
+function chunk(chunkY: number, chunkX: number): number[] {
+  const out: number[] = []
+  for (let t = 0; t < 2; t++) {
+    for (let y = chunkY * 2; y < chunkY * 2 + 2; y++) {
+      for (let x = chunkX * 4; x < chunkX * 4 + 4; x++) {
+        out.push(t * 32 + y * WIDTH + x)
+      }
+    }
+  }
+  return out
+}
+
+function fakeGl({ failTextures = false }: { failTextures?: boolean } = {}) {
+  let textures = 0
+  let buffers = 0
+  return {
+    TEXTURE0: 0x84c0,
+    TEXTURE_2D: 0x0de1,
+    createTexture: vi.fn(() => (failTextures ? null : { tex: ++textures })),
+    createBuffer: vi.fn(() => ({ buf: ++buffers })),
+    deleteTexture: vi.fn(),
+    deleteBuffer: vi.fn(),
+    bindTexture: vi.fn(),
+    bindBuffer: vi.fn(),
+    bufferData: vi.fn(),
+    texImage2D: vi.fn(),
+    texParameteri: vi.fn(),
+    activeTexture: vi.fn(),
+  } as unknown as WebGL2RenderingContext & {
+    createTexture: ReturnType<typeof vi.fn>
+    deleteTexture: ReturnType<typeof vi.fn>
+    texImage2D: ReturnType<typeof vi.fn>
+    bufferData: ReturnType<typeof vi.fn>
+  }
+}
+
+const mapAt = (
+  west: number,
+  south: number,
+  east: number,
+  north: number
+): MapLike => ({
+  getBounds: () => ({
+    getWest: () => west,
+    getEast: () => east,
+    toArray: () => [
+      [west, south],
+      [east, north],
+    ],
+  }),
+  getZoom: () => 0,
+})
+
+/**
+ * getRegionStates is the render seam — the point where CPU-side regions become
+ * draw-ready GPU state. Reaching it through render() would need a real
+ * ZarrRenderer and a compiled program, so the test calls it directly.
+ */
+type RenderSeam = {
+  getRegionStates(gl: WebGL2RenderingContext): RegionRenderState[]
+  createRegionGeometry(
+    regionX: number,
+    regionY: number,
+    region: RegionState
+  ): void
+  regionCache: RegionCache
+}
+const seam = (renderer: RegionRenderer) => renderer as unknown as RenderSeam
+
+/**
+ * A drawable region from another level, standing in for coverage left over
+ * from before a zoom change. Seeded directly because reaching this state
+ * needs a second level to have been fetched, uploaded, and then zoomed away
+ * from.
+ */
+function seedFallbackRegion(
+  renderer: RegionRenderer,
+  {
+    levelIndex = 1,
+    uploaded = true,
+  }: { levelIndex?: number; uploaded?: boolean } = {}
+) {
+  const region = createRegionState(levelIndex, 0, 0, false, 0)
+  region.data = new Float32Array([1, 2, 3, 4])
+  region.width = 2
+  region.height = 2
+  region.vertexArr = new Float32Array(8)
+  region.pixCoordArr = new Float32Array(8)
+  region.mercatorBounds = { x0: 0, y0: 0, x1: 1, y1: 1 }
+  region.levelMeta = { width: 2, height: 2, regionSize: [2, 2] }
+  if (uploaded) {
+    region.texture = {} as WebGLTexture
+    region.vertexBuffer = {} as WebGLBuffer
+    region.pixCoordBuffer = {} as WebGLBuffer
+    region.textureUploaded = true
+    region.geometryUploaded = true
+  }
+
+  const cache = seam(renderer).regionCache
+  cache.set(region.key, region)
+  cache.rebuildProtection([region.key], { retainKeysNotMatching: '' })
+  return region
+}
+
+/** Let the fire-and-forget fetch chain started by update() settle. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 20; i++) await Promise.resolve()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+async function makeRenderer() {
+  const memory = buildMemoryZarrStore({
+    arrays: [
+      {
+        name: 'temperature',
+        shape: [2, HEIGHT, WIDTH],
+        chunkShape: [2, 2, 4],
+        dimensionNames: ['time', 'lat', 'lon'],
+        chunks: {
+          '0/0/0': chunk(0, 0),
+          '0/0/1': chunk(0, 1),
+          '0/1/0': chunk(1, 0),
+          '0/1/1': chunk(1, 1),
+        },
+      },
+      {
+        name: 'time',
+        shape: [2],
+        chunkShape: [2],
+        dimensionNames: ['time'],
+        chunks: { '0': [10, 20] },
+      },
+    ],
+  })
+  const store = new ZarrStore({
+    customStore: memory,
+    variable: 'temperature',
+    version: 3,
+    bounds: [-180, -90, 180, 90],
+    latIsAscending: false,
+  })
+  await store.initialized
+
+  const invalidate = vi.fn()
+  const renderer = new RegionRenderer(store, 'temperature', {}, invalidate)
+  await renderer.initialize()
+  return { renderer, invalidate, gl: fakeGl(), map: mapAt(-180, -85, 180, 85) }
+}
+
+describe('RegionRenderer', () => {
+  it('fetches the visible regions of the committed level on update', async () => {
+    const { renderer, invalidate, gl, map } = await makeRenderer()
+
+    renderer.update(map, gl)
+    await settle()
+
+    // 2x2 region grid, all visible at a whole-world viewport.
+    expect(seam(renderer).getRegionStates(gl)).toHaveLength(4)
+    expect(invalidate).toHaveBeenCalled()
+  })
+
+  it('holds GPU uploads until the render seam asks for them', async () => {
+    const { renderer, gl, map } = await makeRenderer()
+
+    renderer.update(map, gl)
+    await settle()
+    // Fetch is complete, but nothing has been drawn yet.
+    expect(gl.createTexture).not.toHaveBeenCalled()
+    expect(gl.texImage2D).not.toHaveBeenCalled()
+
+    const states = seam(renderer).getRegionStates(gl)
+    expect(gl.createTexture).toHaveBeenCalledTimes(4)
+    expect(gl.texImage2D).toHaveBeenCalledTimes(4)
+    for (const state of states) {
+      expect(state.texture).toBeTruthy()
+      expect(state.vertexBuffer).toBeTruthy()
+      expect(state.pixCoordBuffer).toBeTruthy()
+      expect(state.mercatorBounds).toBeTruthy()
+      expect(state.width).toBe(4)
+      expect(state.height).toBe(2)
+    }
+  })
+
+  it('reuses uploaded resources across frames', async () => {
+    const { renderer, gl, map } = await makeRenderer()
+
+    renderer.update(map, gl)
+    await settle()
+    seam(renderer).getRegionStates(gl)
+    seam(renderer).getRegionStates(gl)
+    seam(renderer).getRegionStates(gl)
+
+    expect(gl.createTexture).toHaveBeenCalledTimes(4)
+    expect(gl.texImage2D).toHaveBeenCalledTimes(4)
+  })
+
+  it('renders nothing before a level is committed', async () => {
+    const { renderer, gl } = await makeRenderer()
+    // No update() yet: regions were never requested.
+    expect(seam(renderer).getRegionStates(gl)).toEqual([])
+    expect(gl.createTexture).not.toHaveBeenCalled()
+  })
+
+  it('serves queries from the same level the renderer committed', async () => {
+    const { renderer, gl, map } = await makeRenderer()
+    renderer.update(map, gl)
+    await settle()
+
+    // Pixel (0, 0) of the 8x4 grid: lon -157.5, lat 67.5.
+    const first = await renderer.queryData(
+      { type: 'Point', coordinates: [-157.5, 67.5] },
+      { time: 10 }
+    )
+    expect(first.temperature).toEqual([0])
+    // Second time step of the same pixel.
+    const second = await renderer.queryData(
+      { type: 'Point', coordinates: [-157.5, 67.5] },
+      { time: 20 }
+    )
+    expect(second.temperature).toEqual([32])
+  })
+
+  it('refetches and re-uploads every region after a selector change', async () => {
+    const { renderer, gl, map } = await makeRenderer()
+    renderer.update(map, gl)
+    await settle()
+    seam(renderer).getRegionStates(gl)
+    expect(gl.texImage2D).toHaveBeenCalledTimes(4)
+    const geometryUploads = gl.bufferData.mock.calls.length
+
+    await renderer.setSelector({ time: { selected: 20, type: 'value' } })
+    renderer.update(map, gl)
+    await settle()
+
+    const states = seam(renderer).getRegionStates(gl)
+    expect(states).toHaveLength(4)
+    // Re-uploaded in place: new data, same textures.
+    expect(gl.texImage2D).toHaveBeenCalledTimes(8)
+    expect(gl.createTexture).toHaveBeenCalledTimes(4)
+    // The mesh doesn't depend on the selector, so it isn't re-sent.
+    expect(gl.bufferData).toHaveBeenCalledTimes(geometryUploads)
+  })
+
+  it('sends regenerated geometry to the GPU on the next frame', async () => {
+    const { renderer, gl, map } = await makeRenderer()
+    renderer.update(map, gl)
+    await settle()
+    seam(renderer).getRegionStates(gl)
+    const uploadsBefore = gl.bufferData.mock.calls.length
+
+    // A refetch at new region dimensions rebuilds the mesh in place. Drawing
+    // the region afterwards has to pick up the new arrays, or fresh data ends
+    // up drawn against the previous mesh.
+    const region = seam(renderer).regionCache.get('0:0,0')!
+    seam(renderer).createRegionGeometry(0, 0, region)
+    expect(region.geometryUploaded).toBe(false)
+
+    seam(renderer).getRegionStates(gl)
+    const uploaded = gl.bufferData.mock.calls
+      .slice(uploadsBefore)
+      .map((call) => call[1])
+    expect(uploaded).toContain(region.vertexArr)
+    expect(uploaded).toContain(region.pixCoordArr)
+    expect(region.geometryUploaded).toBe(true)
+  })
+
+  it('recomputes mercator bounds with the regenerated geometry', async () => {
+    const { renderer, gl, map } = await makeRenderer()
+    renderer.update(map, gl)
+    await settle()
+    const region = seam(renderer).regionCache.get('0:0,0')!
+    // A quarter of the world: the north-west region of a 2x2 grid.
+    expect(region.mercatorBounds).toMatchObject({ x0: 0, x1: 0.5 })
+
+    // Rebuild at a region size covering the whole level, as a refetch under a
+    // changed region size would. Shader bounds have to follow the new mesh.
+    region.levelMeta = {
+      width: WIDTH,
+      height: HEIGHT,
+      regionSize: [HEIGHT, WIDTH],
+    }
+    seam(renderer).createRegionGeometry(0, 0, region)
+    expect(region.mercatorBounds).toMatchObject({ x0: 0, x1: 1 })
+  })
+
+  it('keeps drawing fallback coverage when the current level cannot upload', async () => {
+    const { renderer, map } = await makeRenderer()
+    const gl = fakeGl({ failTextures: true })
+    renderer.update(map, gl)
+    await settle()
+    const fallback = seedFallbackRegion(renderer)
+
+    // The current level has data but its textures won't allocate. Dropping the
+    // fallback here on CPU readiness alone would leave the viewport blank.
+    const states = seam(renderer).getRegionStates(gl)
+    expect(states).toHaveLength(1)
+    expect(states[0].texture).toBe(fallback.texture)
+  })
+
+  it('uploads a fallback region that was fetched but never drawn', async () => {
+    const { renderer, gl } = await makeRenderer()
+    // Nothing fetched at the current level, so the fallback carries the frame.
+    const fallback = seedFallbackRegion(renderer, { uploaded: false })
+
+    const states = seam(renderer).getRegionStates(gl)
+    expect(states).toHaveLength(1)
+    expect(states[0].texture).toBe(fallback.texture)
+    expect(fallback.texture).not.toBeNull()
+    expect(gl.texImage2D).toHaveBeenCalledTimes(1)
+  })
+
+  it('holds other-level eviction protection until the level is drawable', async () => {
+    const { renderer, gl, map } = await makeRenderer()
+    renderer.update(map, gl)
+    await settle()
+    const fallback = seedFallbackRegion(renderer)
+    const cache = seam(renderer).regionCache
+
+    // Regions are fetched but never drawn, so the level can't be shown yet and
+    // its fallback has to stay protected — eviction here is unrecoverable.
+    renderer.update(map, gl)
+    expect(cache.isProtected(fallback.key)).toBe(true)
+
+    // Once a frame uploads them, the level stands on its own.
+    seam(renderer).getRegionStates(gl)
+    renderer.update(map, gl)
+    expect(cache.isProtected(fallback.key)).toBe(false)
+  })
+
+  it('disposes GPU resources and stops rendering after dispose', async () => {
+    const { renderer, gl, map } = await makeRenderer()
+    renderer.update(map, gl)
+    await settle()
+    seam(renderer).getRegionStates(gl)
+
+    renderer.dispose(gl)
+    expect(gl.deleteTexture).toHaveBeenCalledTimes(4)
+    expect(seam(renderer).getRegionStates(gl)).toEqual([])
+  })
+})

--- a/src/region-renderer.test.ts
+++ b/src/region-renderer.test.ts
@@ -350,6 +350,33 @@ describe('RegionRenderer', () => {
     expect(cache.isProtected(fallback.key)).toBe(false)
   })
 
+  it('drops the interleaved copy once the shader samples band textures', async () => {
+    const { renderer, gl, map } = await makeRenderer()
+    // setSelector rebuilds the level only once a gl context has been cached,
+    // so the first update has to land before the multi-value selector.
+    renderer.update(map, gl)
+    await settle()
+    await renderer.setSelector({ time: { selected: [10, 20], type: 'value' } })
+    renderer.update(map, gl)
+    await settle()
+
+    const region = seam(renderer).regionCache.get('0:0,0')!
+    expect(region.channels).toBe(2)
+    expect(region.bandData.size).toBe(2)
+    expect(region.data).not.toBe(region.bandData.get('time_10'))
+
+    // The layer switches to the band-sampling shader, which never reads the
+    // main texture, so the interleaved copy stops being built.
+    renderer.setRendersFromBandTextures(true)
+    renderer.update(map, gl)
+    await settle()
+
+    const refetched = seam(renderer).regionCache.get('0:0,0')!
+    expect(refetched.bandData.size).toBe(2)
+    expect(refetched.data).toBe(refetched.bandData.get('time_10'))
+    expect(refetched.channels).toBe(1)
+  })
+
   it('disposes GPU resources and stops rendering after dispose', async () => {
     const { renderer, gl, map } = await makeRenderer()
     renderer.update(map, gl)

--- a/src/region-renderer.test.ts
+++ b/src/region-renderer.test.ts
@@ -166,8 +166,15 @@ async function makeRenderer() {
       },
     ],
   })
+  const chunkReads: string[] = []
+  const counting = {
+    get: async (key: string) => {
+      if (key.includes('/temperature/c/')) chunkReads.push(key)
+      return memory.get(key)
+    },
+  }
   const store = new ZarrStore({
-    customStore: memory,
+    customStore: counting,
     variable: 'temperature',
     version: 3,
     bounds: [-180, -90, 180, 90],
@@ -178,7 +185,13 @@ async function makeRenderer() {
   const invalidate = vi.fn()
   const renderer = new RegionRenderer(store, 'temperature', {}, invalidate)
   await renderer.initialize()
-  return { renderer, invalidate, gl: fakeGl(), map: mapAt(-180, -85, 180, 85) }
+  return {
+    renderer,
+    invalidate,
+    chunkReads,
+    gl: fakeGl(),
+    map: mapAt(-180, -85, 180, 85),
+  }
 }
 
 describe('RegionRenderer', () => {
@@ -367,6 +380,29 @@ describe('RegionRenderer', () => {
     for (const state of states) {
       expect(state.texture).not.toBeNull()
     }
+  })
+
+  it('stops fetching once band-mode regions have their data', async () => {
+    const { renderer, invalidate, gl, map } = await makeRenderer()
+    renderer.update(map, gl)
+    await settle()
+    await renderer.setSelector({ time: { selected: [10, 20], type: 'value' } })
+    renderer.setRendersFromBandTextures(true)
+    renderer.update(map, gl)
+    await settle()
+
+    // Every fetch batch ends in invalidate(), so a settled viewport that keeps
+    // invalidating is redispatching. Store reads can't see this: the decoded
+    // chunk cache serves the refetches without touching the store.
+    invalidate.mockClear()
+
+    // Band-mode regions carry no interleaved copy, so a has-data check that
+    // only looks at `data` queues every visible region on every frame.
+    for (let frame = 0; frame < 3; frame++) {
+      renderer.update(map, gl)
+      await settle()
+    }
+    expect(invalidate).not.toHaveBeenCalled()
   })
 
   it('keeps fallback coverage when a band texture cannot be allocated', async () => {

--- a/src/region-renderer.test.ts
+++ b/src/region-renderer.test.ts
@@ -101,7 +101,8 @@ function seedFallbackRegion(
   {
     levelIndex = 1,
     uploaded = true,
-  }: { levelIndex?: number; uploaded?: boolean } = {}
+    bands,
+  }: { levelIndex?: number; uploaded?: boolean; bands?: string[] } = {}
 ) {
   const region = createRegionState(levelIndex, 0, 0, false, 0)
   region.data = new Float32Array([1, 2, 3, 4])
@@ -111,12 +112,22 @@ function seedFallbackRegion(
   region.pixCoordArr = new Float32Array(8)
   region.mercatorBounds = { x0: 0, y0: 0, x1: 1, y1: 1 }
   region.levelMeta = { width: 2, height: 2, regionSize: [2, 2] }
+  // A fallback was fetched under the same selector, so it carries the same
+  // bands as the current level.
+  for (const band of bands ?? []) {
+    region.bandData.set(band, new Float32Array([1, 2, 3, 4]))
+  }
   if (uploaded) {
     region.texture = {} as WebGLTexture
     region.vertexBuffer = {} as WebGLBuffer
     region.pixCoordBuffer = {} as WebGLBuffer
     region.textureUploaded = true
     region.geometryUploaded = true
+    for (const band of bands ?? []) {
+      region.bandTextures.set(band, {} as WebGLTexture)
+      region.bandTexturesUploaded.add(band)
+      region.bandTexturesConfigured.add(band)
+    }
   }
 
   const cache = seam(renderer).regionCache
@@ -332,6 +343,28 @@ describe('RegionRenderer', () => {
     expect(gl.texImage2D).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps fallback coverage when a band texture cannot be allocated', async () => {
+    const { renderer, map } = await makeRenderer()
+    const working = fakeGl()
+    renderer.update(map, working)
+    await settle()
+    await renderer.setSelector({ time: { selected: [10, 20], type: 'value' } })
+    renderer.setRendersFromBandTextures(true)
+    renderer.update(map, working)
+    await settle()
+
+    const fallback = seedFallbackRegion(renderer, {
+      bands: ['time_10', 'time_20'],
+    })
+
+    // Band textures are what this shader samples, so failing to allocate them
+    // has to read as undrawable even though geometry uploads fine.
+    const failing = fakeGl({ failTextures: true })
+    const states = seam(renderer).getRegionStates(failing)
+    expect(states).toHaveLength(1)
+    expect(states[0].bandTextures).toBe(fallback.bandTextures)
+  })
+
   it('holds other-level eviction protection until the level is drawable', async () => {
     const { renderer, gl, map } = await makeRenderer()
     renderer.update(map, gl)
@@ -375,6 +408,17 @@ describe('RegionRenderer', () => {
     expect(refetched.bandData.size).toBe(2)
     expect(refetched.data).toBe(refetched.bandData.get('time_10'))
     expect(refetched.channels).toBe(1)
+
+    // Rendering uploads the bands and no main texture at all, which is only
+    // true if the renderer passes its band list down to the upload.
+    const states = seam(renderer).getRegionStates(gl)
+    expect(states).toHaveLength(4)
+    for (const state of states) {
+      expect(state.texture).toBeNull()
+    }
+    expect([...refetched.bandTexturesUploaded]).toEqual(['time_10', 'time_20'])
+    // Two bands per region across the 2x2 grid, no main textures.
+    expect(gl.createTexture).toHaveBeenCalledTimes(8)
   })
 
   it('disposes GPU resources and stops rendering after dispose', async () => {

--- a/src/region-renderer.test.ts
+++ b/src/region-renderer.test.ts
@@ -141,12 +141,13 @@ function seedFallbackRegion(
  * `fetchRegions` marks its batch loading before it yields, so an in-flight
  * batch is already visible here. Hopping the macrotask queue until nothing is
  * loading keeps the tests independent of how many awaits deep the chain runs.
+ *
+ * Deliberately unbounded: a wall-clock bail-out would return early whenever
+ * parallel workers slow a fetch down, turning contention into a confusing
+ * assertion failure somewhere below. Vitest's own testTimeout is the backstop,
+ * and it reports a hang as a hang.
  */
-async function settle(
-  renderer: RegionRenderer,
-  timeoutMs = 2000
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs
+async function settle(renderer: RegionRenderer): Promise<void> {
   const fetching = () => {
     for (const region of seam(renderer).regionCache.values()) {
       if (region.loading) return true
@@ -155,7 +156,7 @@ async function settle(
   }
   do {
     await new Promise((resolve) => setTimeout(resolve, 0))
-  } while (fetching() && Date.now() < deadline)
+  } while (fetching())
 }
 
 async function makeRenderer() {

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -58,6 +58,12 @@ import {
   getVisibleRegions,
   selectLevelForZoom,
 } from './region-math'
+import {
+  RegionCache,
+  createRegionState,
+  isRegionValid,
+  makeRegionKey,
+} from './region-cache'
 import { createHybridMesh } from './mesh-reprojector'
 import {
   type RequestCanceller,
@@ -73,9 +79,6 @@ import {
 } from './region-utils'
 import { setupBandTextureUniforms, uploadDataTexture } from './render-helpers'
 import { renderRegion, type RenderableRegion } from './renderable-region'
-
-/** Maximum number of regions to keep in cache (LRU eviction) */
-const MAX_CACHED_REGIONS = 128
 
 export class RegionRenderer {
   isMultiscale: boolean = false
@@ -134,12 +137,7 @@ export class RegionRenderer {
 
   // Region-based loading (for multi-level datasets with chunking/sharding)
   // Single unified cache with LRU eviction - keys include level index (e.g., "2:0,0")
-  private regionCache: Map<string, RegionState> = new Map()
-  // Keys of regions protected from eviction. Rebuilt in updateVisibleRegions()
-  // from the current viewport: the current level's visible regions, plus
-  // other-level regions retained as fallbacks until the current level covers
-  // the viewport.
-  private visibleRegionKeys: Set<string> = new Set()
+  private regionCache = new RegionCache()
   private lastVisibleRegions: Array<{ regionX: number; regionY: number }> = [] // Last computed visible regions
   private lastVisibleRegionsLevel: number = -1 // Level index that lastVisibleRegions corresponds to
   private lastViewportHash: string = ''
@@ -316,27 +314,8 @@ export class RegionRenderer {
   private clearRegionCache(
     gl: WebGL2RenderingContext | WebGLRenderingContext
   ): void {
-    for (const region of this.regionCache.values()) {
-      this.disposeRegion(region, gl)
-    }
-    this.regionCache.clear()
+    this.regionCache.clear(gl)
     this.lastViewportHash = ''
-  }
-
-  /**
-   * Dispose WebGL resources for a single region.
-   */
-  private disposeRegion(
-    region: RegionState,
-    gl: WebGL2RenderingContext | WebGLRenderingContext
-  ): void {
-    if (region.texture) gl.deleteTexture(region.texture)
-    if (region.vertexBuffer) gl.deleteBuffer(region.vertexBuffer)
-    if (region.pixCoordBuffer) gl.deleteBuffer(region.pixCoordBuffer)
-    if (region.indexBuffer) gl.deleteBuffer(region.indexBuffer)
-    for (const tex of region.bandTextures.values()) {
-      gl.deleteTexture(tex)
-    }
   }
 
   /**
@@ -345,19 +324,7 @@ export class RegionRenderer {
    * Never evicts currently visible regions.
    */
   private evictOldRegions(gl: WebGL2RenderingContext): void {
-    while (this.regionCache.size > MAX_CACHED_REGIONS) {
-      let evictedKey: string | null = null
-      for (const key of this.regionCache.keys()) {
-        if (!this.visibleRegionKeys.has(key)) {
-          evictedKey = key
-          break
-        }
-      }
-      if (!evictedKey) break // All regions are visible, stop
-      const region = this.regionCache.get(evictedKey)
-      if (region) this.disposeRegion(region, gl)
-      this.regionCache.delete(evictedKey)
-    }
+    this.regionCache.evict(gl)
   }
 
   private getVisibleRegions(
@@ -380,7 +347,7 @@ export class RegionRenderer {
     regionX: number,
     regionY: number
   ): string {
-    return `${levelIndex}:${regionX},${regionY}`
+    return makeRegionKey(levelIndex, regionX, regionY)
   }
 
   /**
@@ -391,53 +358,20 @@ export class RegionRenderer {
     regionX: number,
     regionY: number
   ): RegionState {
-    return {
-      key: this.makeRegionKey(levelIndex, regionX, regionY),
+    return createRegionState(
       levelIndex,
       regionX,
       regionY,
-      data: null,
-      width: 0,
-      height: 0,
-      loading: false,
-      requestId: null,
-      channels: 1,
-      texture: null,
-      textureUploaded: false,
-      vertexBuffer: null,
-      pixCoordBuffer: null,
-      indexBuffer: null,
-      vertexArr: null,
-      pixCoordArr: null,
-      indexArr: null,
-      vertexCount: 0,
-      useIndexedMesh: false,
-      mercatorBounds: null,
-      wgs84Bounds: null,
-      latIsAscending: this.latIsAscending,
-      selectorVersion: this.selectorVersion,
-      bandData: new Map(),
-      bandTextures: new Map(),
-      bandTexturesUploaded: new Set(),
-      bandTexturesConfigured: new Set(),
-      levelMeta: null, // Set from snapshot in fetchRegion
-    }
+      this.latIsAscending,
+      this.selectorVersion
+    )
   }
 
   /**
    * Check if a region has all required data for rendering.
    */
   private isRegionValid(region: RegionState): boolean {
-    return !!(
-      region.data &&
-      region.textureUploaded &&
-      region.texture &&
-      region.vertexBuffer &&
-      region.pixCoordBuffer &&
-      region.vertexArr &&
-      region.mercatorBounds &&
-      region.levelMeta
-    )
+    return isRegionValid(region)
   }
 
   /**
@@ -503,7 +437,7 @@ export class RegionRenderer {
       if (region.levelIndex === (this.activeLevel?.index ?? -1)) continue
       if (!this.isRegionValid(region)) continue
       // Only include regions that are protected (were visible)
-      if (!this.visibleRegionKeys.has(region.key)) continue
+      if (!this.regionCache.isProtected(region.key)) continue
       fallbacks.push(region)
     }
     return fallbacks
@@ -763,16 +697,11 @@ export class RegionRenderer {
     // state (map bounds or transformer unavailable), so keep the previous
     // set rather than unprotect regions that are still rendered.
     if (visible.length > 0) {
-      const nextProtected = new Set(visibleKeys)
-      if (!this.currentLevelCoversViewport()) {
-        const currentLevelPrefix = `${levelIndex}:`
-        for (const key of this.visibleRegionKeys) {
-          if (!key.startsWith(currentLevelPrefix)) {
-            nextProtected.add(key)
-          }
-        }
-      }
-      this.visibleRegionKeys = nextProtected
+      this.regionCache.rebuildProtection(visibleKeys, {
+        retainKeysNotMatching: this.currentLevelCoversViewport()
+          ? ''
+          : `${levelIndex}:`,
+      })
     }
 
     // Abort in-flight fetches for regions that left the viewport.

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -440,7 +440,7 @@ export class RegionRenderer {
     for (const { regionX, regionY } of this.lastVisibleRegions) {
       const key = this.makeRegionKey(levelIndex, regionX, regionY)
       const region = this.regionCache.get(key)
-      if (!region || !isRegionGpuReady(region)) {
+      if (!region || !isRegionGpuReady(region, this.requiredBands())) {
         return false
       }
     }
@@ -452,6 +452,14 @@ export class RegionRenderer {
    * These were visible before or during level transitions and provide
    * coverage while the current level loads.
    */
+  /**
+   * The band textures the active shader samples, or undefined when it reads
+   * the main texture. Readiness and uploads must agree on this.
+   */
+  private requiredBands(): string[] | undefined {
+    return this.rendersFromBandTextures ? this.bandNames : undefined
+  }
+
   private getProtectedFallbackRegions(): RegionState[] {
     const fallbacks: RegionState[] = []
     for (const region of this.regionCache.values()) {
@@ -474,10 +482,11 @@ export class RegionRenderer {
     const currentLevel = this.activeLevel?.index ?? -1
     const currentLevelRegions: RegionState[] = []
 
+    const requiredBands = this.requiredBands()
     for (const region of this.regionCache.values()) {
       if (region.levelIndex !== currentLevel) continue
       if (!isRegionCpuReady(region)) continue
-      if (!ensureRegionGpuResources(gl, region)) continue
+      if (!ensureRegionGpuResources(gl, region, requiredBands)) continue
       currentLevelRegions.push(region)
     }
 
@@ -487,7 +496,7 @@ export class RegionRenderer {
 
     // Render order: fallbacks first (beneath), current level on top
     const fallbackRegions = this.getProtectedFallbackRegions().filter(
-      (region) => ensureRegionGpuResources(gl, region)
+      (region) => ensureRegionGpuResources(gl, region, requiredBands)
     )
     return [...fallbackRegions, ...currentLevelRegions]
   }
@@ -982,7 +991,7 @@ export class RegionRenderer {
       useIndexedMesh: region.useIndexedMesh,
       wgs84Bounds: region.wgs84Bounds ?? undefined,
       latIsAscending: region.latIsAscending,
-      texture: region.texture!,
+      texture: region.texture,
       bandData: region.bandData,
       bandTextures: region.bandTextures,
       bandTexturesUploaded: region.bandTexturesUploaded,
@@ -1064,7 +1073,7 @@ export class RegionRenderer {
     }
 
     return this.getLoadedRegions(gl).map((region) => ({
-      texture: region.texture!,
+      texture: region.texture,
       vertexBuffer: region.vertexBuffer!,
       pixCoordBuffer: region.pixCoordBuffer!,
       vertexArr: region.vertexArr!,

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -15,7 +15,6 @@ import {
   WEB_MERCATOR_EXTENT,
   MIN_SUBDIVISIONS,
   MAX_SUBDIVISIONS,
-  MERCATOR_LAT_LIMIT,
 } from './constants'
 import type {
   RenderContext,
@@ -35,7 +34,6 @@ import type {
   MapLike,
   NormalizedSelector,
   Selector,
-  CRS,
   Bounds,
   DimIndicesProps,
   UntiledLevel,
@@ -46,7 +44,6 @@ import {
   lonRangeOverlaps,
   type MercatorBounds,
   type XYLimits,
-  type Wgs84Bounds,
 } from './map-utils'
 import { loadDimensionValues, normalizeSelector, getBands } from './zarr-utils'
 import { interleaveBands, normalizeDataForTexture } from './webgl-utils'
@@ -61,12 +58,18 @@ import {
   type PixelRect,
 } from './query/query-utils'
 import {
-  createTransformer,
-  createTransformerTo4326,
-  createWGS84ToSourceTransformer,
+  createProjectionContext,
   pixelToSourceCRS,
   sampleEdgesToMercatorBounds,
+  type ProjectionContext,
 } from './projection-utils'
+import type {
+  LevelMeta,
+  LevelRuntime,
+  LevelSnapshot,
+  QueryLevelSnapshot,
+  RegionState,
+} from './region-state'
 import { createHybridMesh } from './mesh-reprojector'
 import {
   type RequestCanceller,
@@ -83,109 +86,8 @@ import {
 import { setupBandTextureUniforms, uploadDataTexture } from './render-helpers'
 import { renderRegion, type RenderableRegion } from './renderable-region'
 
-/** State for a single region (chunk/shard) in region-based loading */
-interface RegionState {
-  key: string
-  levelIndex: number
-  regionX: number
-  regionY: number
-  // Data
-  data: Float32Array | null
-  width: number
-  height: number
-  loading: boolean
-  requestId: number | null
-  channels: number
-  // WebGL resources
-  texture: WebGLTexture | null
-  textureUploaded: boolean
-  vertexBuffer: WebGLBuffer | null
-  pixCoordBuffer: WebGLBuffer | null
-  indexBuffer: WebGLBuffer | null // For adaptive mesh indexed triangles
-  // Geometry arrays for this region's quad
-  vertexArr: Float32Array | null
-  pixCoordArr: Float32Array | null // Texture coordinates for sampling resampled data
-  indexArr: Uint32Array | null // Triangle indices for adaptive mesh
-  vertexCount: number // Number of vertices (for triangle strip) or indices (for indexed)
-  useIndexedMesh: boolean // Whether to use indexed triangles (adaptive mesh)
-  // Mercator bounds for this region (for shader uniforms)
-  mercatorBounds: MercatorBounds | null
-  // WGS84 bounds for vertex shader positioning (source-projected path, ECEF globe)
-  wgs84Bounds: Wgs84Bounds | null
-  // Data orientation: true = row 0 is south
-  latIsAscending: boolean
-  // Version tracking for selector changes
-  selectorVersion: number
-  // Multi-band support
-  bandData: Map<string, Float32Array>
-  bandTextures: Map<string, WebGLTexture>
-  bandTexturesUploaded: Set<string>
-  bandTexturesConfigured: Set<string>
-  // Level-specific dimensions for region geometry bounds.
-  // Set from LevelSnapshot during fetch to avoid races with level switching.
-  levelMeta: LevelMeta | null
-}
-
-/** Level-specific dimensions for geometry bounds calculation */
-type LevelMeta = {
-  width: number
-  height: number
-  regionSize: [number, number]
-  // xyLimits omitted - assumed constant across levels for now.
-  // TODO: If heterogeneous pyramids with per-level bounds are needed,
-  // add xyLimits here and store per-region.
-}
-
-type ProjectionKind = 'epsg4326' | 'epsg3857' | 'custom-proj4'
-
 /** Maximum number of regions to keep in cache (LRU eviction) */
 const MAX_CACHED_REGIONS = 128
-/** Snapshot of level state captured at fetch start to prevent race conditions */
-interface LevelSnapshot {
-  index: number
-  zarrArray: zarr.Array<zarr.DataType>
-  baseSliceArgs: (number | zarr.Slice)[]
-  baseMultiValueDims: Array<{
-    dimIndex: number
-    dimName: string
-    values: number[]
-    labels: (number | string)[]
-  }>
-  width: number
-  height: number
-  regionSize: [number, number]
-  selectorVersion: number
-  bandNames: string[]
-}
-
-/**
- * Fully-committed per-level state. Replaces six top-level fields that were
- * previously mutated independently across `initializeLevel`, `switchToLevel`,
- * `_initialize`, and `setSelector` — any of which was one `await` away from
- * a half-commit race.
- *
- * `RegionRenderer.activeLevel` is either `null` (nothing loaded) or a fully-
- * formed runtime; readers never see a partial level.
- */
-interface LevelRuntime {
-  index: number
-  zarrArray: zarr.Array<zarr.DataType>
-  width: number
-  height: number
-  regionSize: [number, number]
-  baseSliceArgs: (number | zarr.Slice)[]
-  baseMultiValueDims: Array<{
-    dimIndex: number
-    dimName: string
-    values: number[]
-    labels: (number | string)[]
-  }>
-}
-
-type QueryLevelSnapshot = Pick<
-  LevelRuntime,
-  'index' | 'zarrArray' | 'width' | 'height'
->
 
 export class RegionRenderer {
   isMultiscale: boolean = false
@@ -222,21 +124,11 @@ export class RegionRenderer {
   // Multi-level support
   private levels: UntiledLevel[] = []
   private levelMetadataFetched: Set<number> = new Set() // Tracks which levels have had metadata fetched
-  private projectionKind: ProjectionKind = 'epsg4326'
-  // Transformer definition: EPSG code for built-ins, supplied string for custom proj4.
-  private proj4def: string | null = null
-
-  // Cached transformers for proj4 reprojection (created once, reused everywhere)
-  private cachedMercatorTransformer: ReturnType<
-    typeof createTransformer
-  > | null = null
-  private cachedWGS84Transformer: ReturnType<
-    typeof createWGS84ToSourceTransformer
-  > | null = null
-  // Transformer: source CRS → EPSG:4326 (input to source-projected mesh generation)
-  private cached4326Transformer: ReturnType<
-    typeof createTransformerTo4326
-  > | null = null
+  private projection: ProjectionContext = createProjectionContext({
+    crs: 'EPSG:4326',
+    proj4def: null,
+    xyLimits: null,
+  })
 
   // Loading state
   private isRemoved: boolean = false
@@ -298,45 +190,12 @@ export class RegionRenderer {
       this.dimIndices = desc.dimIndices
       this.xyLimits = desc.xyLimits
       this.latIsAscending = desc.latIsAscending
-      this.projectionKind = resolveProjectionKind(desc.crs, desc.proj4)
-      this.proj4def = resolveProjectionDef(desc.crs, desc.proj4)
-
       // Cache transformers once for reuse (major performance optimization)
-      if (this.proj4def && this.xyLimits) {
-        const bounds: [number, number, number, number] = [
-          this.xyLimits.xMin,
-          this.xyLimits.yMin,
-          this.xyLimits.xMax,
-          this.xyLimits.yMax,
-        ]
-        const rawMercatorTransformer = createTransformer(this.proj4def, bounds)
-        // Wrap the source→3857 forward so lat=±90° inputs (common for global
-        // EPSG:4326 rasters) are clamped to ±MERCATOR_LAT_LIMIT before proj4
-        // sees them. Without this, `sampleEdgesToMercatorBounds` silently
-        // drops the polar edge samples and produces too-tight mercator bounds.
-        this.cachedMercatorTransformer =
-          this.projectionKind === 'epsg4326'
-            ? {
-                ...rawMercatorTransformer,
-                forward: (x, y) =>
-                  rawMercatorTransformer.forward(
-                    x,
-                    Math.max(
-                      -MERCATOR_LAT_LIMIT,
-                      Math.min(MERCATOR_LAT_LIMIT, y)
-                    )
-                  ),
-              }
-            : rawMercatorTransformer
-        this.cachedWGS84Transformer = createWGS84ToSourceTransformer(
-          this.proj4def
-        )
-        // Source CRS → EPSG:4326 (for WGS84 mesh vertices and ECEF projection)
-        this.cached4326Transformer = createTransformerTo4326(
-          this.proj4def,
-          bounds
-        )
-      }
+      this.projection = createProjectionContext({
+        crs: desc.crs,
+        proj4def: desc.proj4,
+        xyLimits: this.xyLimits,
+      })
 
       // Check if this is a multi-level dataset
       if (desc.untiledLevels && desc.untiledLevels.length > 0) {
@@ -356,7 +215,7 @@ export class RegionRenderer {
       }
 
       if (this.xyLimits) {
-        if (this.proj4def) {
+        if (this.projection.def) {
           this.mercatorBounds = this.computeMercatorBoundsFromProjection()
         }
       } else {
@@ -556,7 +415,7 @@ export class RegionRenderer {
   ): Array<{ regionX: number; regionY: number }> {
     const bounds = map.getBounds?.()?.toArray?.()
     if (!bounds || !this.xyLimits || !this.activeLevel) return []
-    if (!this.proj4def || !this.cachedWGS84Transformer) {
+    if (!this.projection.def || !this.projection.toWGS84) {
       // No proj4 transformer was set up — either because the CRS isn't
       // one proj4js handles natively and no `proj4` prop was supplied
       // (constructor warned), or because proj4 init threw on a malformed
@@ -574,7 +433,7 @@ export class RegionRenderer {
     //    regions via index math (O(1) proj4 cost, may include false
     //    positives for non-bijective projections like UTM outside their zone)
     // 2. Inverse-transform candidate region bounds to WGS84 for precise overlap
-    const transformer = this.cachedWGS84Transformer
+    const transformer = this.projection.toWGS84
     const numRegionsX = Math.ceil(width / regionW)
     const numRegionsY = Math.ceil(height / regionH)
 
@@ -1036,9 +895,9 @@ export class RegionRenderer {
     region.useIndexedMesh = false
 
     if (
-      !this.proj4def ||
-      !this.cached4326Transformer ||
-      !this.cachedMercatorTransformer
+      !this.projection.def ||
+      !this.projection.to4326 ||
+      !this.projection.toMercator
     ) {
       return
     }
@@ -1054,11 +913,11 @@ export class RegionRenderer {
     const centerX = (geoBounds.xMin + geoBounds.xMax) / 2
     const centerY = (geoBounds.yMin + geoBounds.yMax) / 2
     const samplePoints = [
-      this.cached4326Transformer.forward(geoBounds.xMin, geoBounds.yMin),
-      this.cached4326Transformer.forward(geoBounds.xMax, geoBounds.yMin),
-      this.cached4326Transformer.forward(geoBounds.xMin, geoBounds.yMax),
-      this.cached4326Transformer.forward(geoBounds.xMax, geoBounds.yMax),
-      this.cached4326Transformer.forward(centerX, centerY),
+      this.projection.to4326.forward(geoBounds.xMin, geoBounds.yMin),
+      this.projection.to4326.forward(geoBounds.xMax, geoBounds.yMin),
+      this.projection.to4326.forward(geoBounds.xMin, geoBounds.yMax),
+      this.projection.to4326.forward(geoBounds.xMax, geoBounds.yMax),
+      this.projection.to4326.forward(centerX, centerY),
     ]
     const validLats = samplePoints
       .map((p) => p[1])
@@ -1072,7 +931,7 @@ export class RegionRenderer {
     // would fold it via adjust_lon and understate it. Other projections have no
     // such direct measure, so use the sampled WGS84 longitudes.
     let lonSpan: number
-    if (this.projectionKind === 'epsg4326') {
+    if (this.projection.kind === 'epsg4326') {
       lonSpan = Math.min(360, Math.abs(geoBounds.xMax - geoBounds.xMin))
     } else {
       const validLons = samplePoints
@@ -1104,9 +963,9 @@ export class RegionRenderer {
       height: region.height,
       lonSubdivisions,
       latSubdivisions,
-      transformer: this.cached4326Transformer,
+      transformer: this.projection.to4326,
       latIsAscending: this.latIsAscending,
-      allowUnwrappedLongitudes: this.projectionKind === 'epsg4326',
+      allowUnwrappedLongitudes: this.projection.kind === 'epsg4326',
       // The mesh encodes vertices as deltas from a per-region mercator origin
       // (deriveLocalMercAnchor); renderRegion uploads a matching per-region
       // anchor_clip, keeping the eye origin near the on-screen region for
@@ -1628,7 +1487,7 @@ export class RegionRenderer {
       // GPU handles reprojection. Source-projected data uses an adaptive mesh
       // (source CRS → WGS84), then the GPU projects to Mercator or ECEF.
       const needsProj4MercBounds =
-        this.proj4def && this.cachedMercatorTransformer
+        this.projection.def && this.projection.toMercator
 
       if (needsProj4MercBounds && this.xyLimits && !region.mercatorBounds) {
         const levelMeta: LevelMeta = {
@@ -1923,7 +1782,7 @@ export class RegionRenderer {
 
     // Calculate what fraction of the world the data covers, accounting for CRS
     let worldFraction: number
-    if (this.projectionKind === 'epsg4326') {
+    if (this.projection.kind === 'epsg4326') {
       // proj4's adjust_lon folds inputs outside [-180, 180] back into range
       // (e.g. forward(360,·)→0, forward(190,·)→-170), which collapses or
       // distorts the width for 0-360° stores and antimeridian-crossing
@@ -1931,18 +1790,18 @@ export class RegionRenderer {
       // render bounds may conservatively expand antimeridian-crossing regions
       // to full-world X for tile intersection.
       worldFraction = longitudeWorldFraction(this.xyLimits)
-    } else if (this.projectionKind === 'epsg3857') {
+    } else if (this.projection.kind === 'epsg3857') {
       // Web Mercator: full world is ~40,075,016 meters
       const dataWidth = this.xyLimits.xMax - this.xyLimits.xMin
       const fullWorldMeters = 2 * WEB_MERCATOR_EXTENT
       worldFraction = dataWidth / fullWorldMeters
-    } else if (this.proj4def && this.cachedMercatorTransformer) {
+    } else if (this.projection.def && this.projection.toMercator) {
       // Source-projected data: transform bounds corners to mercator
-      const [minMercX] = this.cachedMercatorTransformer.forward(
+      const [minMercX] = this.projection.toMercator.forward(
         this.xyLimits.xMin,
         this.xyLimits.yMin
       )
-      const [maxMercX] = this.cachedMercatorTransformer.forward(
+      const [maxMercX] = this.projection.toMercator.forward(
         this.xyLimits.xMax,
         this.xyLimits.yMax
       )
@@ -1955,11 +1814,11 @@ export class RegionRenderer {
       // strip (y=0), which stays in-domain for any cylindrical-like projection
       // and gives the correct horizontal extent.
       if (!isFinite(dataWidthMeters) || dataWidthMeters > fullWorldMeters) {
-        const [eqMinX] = this.cachedMercatorTransformer.forward(
+        const [eqMinX] = this.projection.toMercator.forward(
           this.xyLimits.xMin,
           0
         )
-        const [eqMaxX] = this.cachedMercatorTransformer.forward(
+        const [eqMaxX] = this.projection.toMercator.forward(
           this.xyLimits.xMax,
           0
         )
@@ -2003,7 +1862,7 @@ export class RegionRenderer {
   render(renderer: ZarrRenderer, context: RenderContext): void {
     const useMapbox = !!context.mapbox
     // Use the source-projected mesh path when the CRS is resolved via proj4.
-    const useWgs84 = !!this.proj4def && !!this.cached4326Transformer
+    const useWgs84 = !!this.projection.def && !!this.projection.to4326
 
     // MapLibre globe exposes a projectionTransition value in the shader prelude.
     // Keep ECEF active while that transition is nonzero.
@@ -2215,9 +2074,11 @@ export class RegionRenderer {
     // Clean up region caches
     this.clearRegionCache(gl)
     this.activeLevel = null
-    this.cachedMercatorTransformer = null
-    this.cachedWGS84Transformer = null
-    this.cached4326Transformer = null
+    this.projection = createProjectionContext({
+      crs: 'EPSG:4326',
+      proj4def: null,
+      xyLimits: null,
+    })
     this.loadingDebouncer.hide()
   }
 
@@ -2232,18 +2093,18 @@ export class RegionRenderer {
     if (!this.xyLimits) {
       return { x0: 0, y0: 0, x1: 1, y1: 1 }
     }
-    if (this.projectionKind === 'epsg4326') {
+    if (this.projection.kind === 'epsg4326') {
       return boundsToMercatorNorm(this.xyLimits, 'EPSG:4326')
     }
-    if (this.projectionKind === 'epsg3857') {
+    if (this.projection.kind === 'epsg3857') {
       return boundsToMercatorNorm(this.xyLimits, 'EPSG:3857')
     }
-    if (!this.proj4def || !this.cachedMercatorTransformer) {
+    if (!this.projection.def || !this.projection.toMercator) {
       return { x0: 0, y0: 0, x1: 1, y1: 1 }
     }
     const result = sampleEdgesToMercatorBounds(
       this.xyLimits,
-      this.cachedMercatorTransformer,
+      this.projection.toMercator,
       20
     )
     if (!result) {
@@ -2264,18 +2125,18 @@ export class RegionRenderer {
     yMin: number
     yMax: number
   }): MercatorBounds {
-    if (this.projectionKind === 'epsg4326') {
+    if (this.projection.kind === 'epsg4326') {
       return boundsToMercatorNorm(bounds, 'EPSG:4326')
     }
-    if (this.projectionKind === 'epsg3857') {
+    if (this.projection.kind === 'epsg3857') {
       return boundsToMercatorNorm(bounds, 'EPSG:3857')
     }
-    if (!this.proj4def || !this.cachedMercatorTransformer) {
+    if (!this.projection.def || !this.projection.toMercator) {
       return { x0: 0, y0: 0, x1: 1, y1: 1 }
     }
     const result = sampleEdgesToMercatorBounds(
       bounds,
-      this.cachedMercatorTransformer,
+      this.projection.toMercator,
       5
     )
     if (!result) {
@@ -2556,7 +2417,7 @@ export class RegionRenderer {
     if (!this.mercatorBounds || !activeLevel || !sourceBounds) {
       return emptyResult()
     }
-    const projectionDef = this.proj4def
+    const projectionDef = this.projection.def
     if (!projectionDef) {
       return emptyResult()
     }
@@ -2637,7 +2498,7 @@ export class RegionRenderer {
         transforms,
         opts,
         desc.dimIndices,
-        this.cachedWGS84Transformer ?? undefined
+        this.projection.toWGS84 ?? undefined
       )
     }
 
@@ -2649,7 +2510,7 @@ export class RegionRenderer {
         level.height,
         projectionDef,
         this.latIsAscending,
-        this.cachedWGS84Transformer ?? undefined
+        this.projection.toWGS84 ?? undefined
       )
       if (!pixelBounds) return emptyResult()
       const result = await runStrip(geom, pixelBounds, options)
@@ -2660,7 +2521,7 @@ export class RegionRenderer {
       preprocessQueryGeometry(geometry)
 
     const supportsWrappedLongitude =
-      this.projectionKind === 'epsg4326' || this.projectionKind === 'epsg3857'
+      this.projection.kind === 'epsg4326' || this.projection.kind === 'epsg3857'
     const queryGeometry = supportsWrappedLongitude
       ? processedGeometry
       : geometry
@@ -2681,7 +2542,7 @@ export class RegionRenderer {
 
     // Crossing: raster extent guard (EPSG:4326 only — 3857 xyLimits are in meters)
     if (
-      this.projectionKind === 'epsg4326' &&
+      this.projection.kind === 'epsg4326' &&
       rasterExtentCrossesAntimeridian('EPSG:4326', this.xyLimits)
     ) {
       if (!this._antimeridianWarnings.has('raster-extent-crossing')) {
@@ -2701,7 +2562,7 @@ export class RegionRenderer {
       level.height,
       projectionDef,
       this.latIsAscending,
-      this.cachedWGS84Transformer ?? undefined
+      this.projection.toWGS84 ?? undefined
     )
 
     const westResult = spans.west
@@ -2721,38 +2582,6 @@ export class RegionRenderer {
     const { yDim, xDim } = findSpatialDimNames(desc.dimensions, desc.dimIndices)
     return mergeQueryResults(westResult, eastResult, this.variable, yDim, xDim)
   }
-}
-
-function normalizeBuiltinProjectionDef(
-  def: string | null | undefined
-): CRS | null {
-  if (!def) return null
-  const normalized = def.trim().toUpperCase()
-  return normalized === 'EPSG:4326' || normalized === 'EPSG:3857'
-    ? normalized
-    : null
-}
-
-function resolveProjectionKind(
-  crs: CRS,
-  proj4def: string | null
-): ProjectionKind {
-  const builtinProj4Def = normalizeBuiltinProjectionDef(proj4def)
-  if (builtinProj4Def) {
-    return builtinProj4Def === 'EPSG:3857' ? 'epsg3857' : 'epsg4326'
-  }
-  if (proj4def?.trim()) {
-    return 'custom-proj4'
-  }
-  return crs === 'EPSG:3857' ? 'epsg3857' : 'epsg4326'
-}
-
-function resolveProjectionDef(crs: CRS, proj4def: string | null): string {
-  const builtinProj4Def = normalizeBuiltinProjectionDef(proj4def)
-  if (builtinProj4Def) return builtinProj4Def
-  const trimmedProj4Def = proj4def?.trim()
-  if (trimmedProj4Def) return trimmedProj4Def
-  return crs
 }
 
 function longitudeWorldFraction(bounds: {

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -11,11 +11,7 @@
  */
 
 import * as zarr from 'zarrita'
-import {
-  WEB_MERCATOR_EXTENT,
-  MIN_SUBDIVISIONS,
-  MAX_SUBDIVISIONS,
-} from './constants'
+import { MIN_SUBDIVISIONS, MAX_SUBDIVISIONS } from './constants'
 import type {
   RenderContext,
   TileId,
@@ -33,19 +29,13 @@ import type {
   UntiledLevel,
 } from './types'
 import { ZarrStore } from './zarr-store'
-import {
-  boundsToMercatorNorm,
-  lonRangeOverlaps,
-  type MercatorBounds,
-  type XYLimits,
-} from './map-utils'
+import { type MercatorBounds, type XYLimits } from './map-utils'
 import { getBands } from './zarr-utils'
 import { interleaveBands, normalizeDataForTexture } from './webgl-utils'
 import type { ZarrRenderer, ShaderProgram } from './zarr-renderer'
 import { renderMapboxTile } from './mapbox-tile-renderer'
 import {
   createProjectionContext,
-  sampleEdgesToMercatorBounds,
   type ProjectionContext,
 } from './projection-utils'
 import type {
@@ -60,6 +50,14 @@ import {
   type DimensionValuesCache,
 } from './selector-resolution'
 import { queryData as queryDataWithContext } from './query/data-query'
+import {
+  computeMercatorBoundsFromProjection,
+  computeRegionMercatorBounds,
+  getRegionBounds,
+  getRegionSize,
+  getVisibleRegions,
+  selectLevelForZoom,
+} from './region-math'
 import { createHybridMesh } from './mesh-reprojector'
 import {
   type RequestCanceller,
@@ -306,43 +304,10 @@ export class RegionRenderer {
     )
   }
 
-  /**
-   * Detect optimal region size from array metadata.
-   * For sharded arrays: use shard chunk_shape
-   * For standard chunked arrays: use array chunks
-   */
   private getRegionSize(
     array: zarr.Array<zarr.DataType>
   ): [number, number] | null {
-    const latIdx = this.dimIndices.lat?.index
-    const lonIdx = this.dimIndices.lon?.index
-    if (latIdx === undefined || lonIdx === undefined) return null
-
-    // Check for sharding codec
-    const codecs = (array as any).codecs || []
-    for (const codec of codecs) {
-      if (
-        codec.name === 'sharding_indexed' &&
-        codec.configuration?.chunk_shape
-      ) {
-        const shardShape = codec.configuration.chunk_shape as number[]
-        return [shardShape[latIdx], shardShape[lonIdx]]
-      }
-    }
-
-    // Fall back to standard chunks
-    const chunks = array.chunks as number[] | undefined
-    if (chunks && chunks.length > Math.max(latIdx, lonIdx)) {
-      const chunkH = chunks[latIdx]
-      const chunkW = chunks[lonIdx]
-      // Only use region-based loading if chunks are smaller than the array
-      const shape = array.shape as number[]
-      if (chunkH < shape[latIdx] || chunkW < shape[lonIdx]) {
-        return [chunkH, chunkW]
-      }
-    }
-
-    return null // No chunking or single chunk
+    return getRegionSize(array, this.dimIndices)
   }
 
   /**
@@ -395,99 +360,16 @@ export class RegionRenderer {
     }
   }
 
-  /**
-   * Calculate which regions are visible in the current viewport.
-   */
   private getVisibleRegions(
     map: MapLike
   ): Array<{ regionX: number; regionY: number }> {
-    const bounds = map.getBounds?.()?.toArray?.()
-    if (!bounds || !this.xyLimits || !this.activeLevel) return []
-    if (!this.projection.def || !this.projection.toWGS84) {
-      // No proj4 transformer was set up — either because the CRS isn't
-      // one proj4js handles natively and no `proj4` prop was supplied
-      // (constructor warned), or because proj4 init threw on a malformed
-      // string. Either way, computing region indices here would be wrong;
-      // skip rather than render a misleading partial result.
-      return []
-    }
-
-    const { width, height, regionSize } = this.activeLevel
-    const [[west, south], [east, north]] = bounds
-    const [regionH, regionW] = regionSize
-
-    // For projected data, use a two-pass approach:
-    // 1. Forward-transform viewport edges to source CRS to find candidate
-    //    regions via index math (O(1) proj4 cost, may include false
-    //    positives for non-bijective projections like UTM outside their zone)
-    // 2. Inverse-transform candidate region bounds to WGS84 for precise overlap
-    const transformer = this.projection.toWGS84
-    const numRegionsX = Math.ceil(width / regionW)
-    const numRegionsY = Math.ceil(height / regionH)
-
-    const candidates = this.getCandidateRegions(
-      west,
-      south,
-      east,
-      north,
-      transformer,
-      numRegionsX,
-      numRegionsY,
-      regionW,
-      regionH,
-      width,
-      height
-    )
-
-    // Verify candidates via inverse transform to WGS84 for precise overlap.
-    // This handles non-bijective projections where forward transforms can
-    // produce false positives.
-    const regions: Array<{ regionX: number; regionY: number }> = []
-    for (const { regionX, regionY } of candidates) {
-      const regBounds = this.getRegionBounds(regionX, regionY, {
-        width,
-        height,
-        regionSize,
-      })
-      const xMid = (regBounds.xMin + regBounds.xMax) / 2
-      const yMid = (regBounds.yMin + regBounds.yMax) / 2
-
-      const samplePoints = [
-        transformer.inverse(regBounds.xMin, regBounds.yMin),
-        transformer.inverse(regBounds.xMax, regBounds.yMin),
-        transformer.inverse(regBounds.xMax, regBounds.yMax),
-        transformer.inverse(regBounds.xMin, regBounds.yMax),
-        transformer.inverse(xMid, regBounds.yMin),
-        transformer.inverse(xMid, regBounds.yMax),
-        transformer.inverse(regBounds.xMin, yMid),
-        transformer.inverse(regBounds.xMax, yMid),
-      ]
-
-      let regWest = Infinity
-      let regEast = -Infinity
-      let regSouth = Infinity
-      let regNorth = -Infinity
-      let hasValid = false
-      for (const [lon, lat] of samplePoints) {
-        if (!isFinite(lon) || !isFinite(lat)) continue
-        hasValid = true
-        if (lon < regWest) regWest = lon
-        if (lon > regEast) regEast = lon
-        if (lat < regSouth) regSouth = lat
-        if (lat > regNorth) regNorth = lat
-      }
-      if (!hasValid) continue
-
-      if (
-        lonRangeOverlaps(west, east, regWest, regEast) &&
-        regNorth >= south &&
-        regSouth <= north
-      ) {
-        regions.push({ regionX, regionY })
-      }
-    }
-
-    return regions
+    return getVisibleRegions({
+      map,
+      xyLimits: this.xyLimits,
+      levelMeta: this.activeLevel,
+      projection: this.projection,
+      latIsAscending: this.latIsAscending,
+    })
   }
 
   /**
@@ -656,185 +538,18 @@ export class RegionRenderer {
     return [...fallbackRegions, ...currentLevelRegions]
   }
 
-  /**
-   * Find candidate regions by forward-transforming viewport edges to source CRS
-   * and using grid index math to find overlapping region indices.
-   *
-   * This is a fast prefilter that may include false positives (e.g., for non-
-   * bijective projections like UTM outside their zone). Callers must verify
-   * candidates with inverse-transform overlap checks.
-   *
-   * On partial transform failures (projection boundary), uses valid points
-   * with a wider margin. Falls back to all regions only if no points are valid.
-   */
-  private getCandidateRegions(
-    west: number,
-    south: number,
-    east: number,
-    north: number,
-    transformer: { forward: (lon: number, lat: number) => [number, number] },
-    numRegionsX: number,
-    numRegionsY: number,
-    regionW: number,
-    regionH: number,
-    width: number,
-    height: number
-  ): Array<{ regionX: number; regionY: number }> {
-    if (!this.xyLimits) return []
-    const { xMin, xMax, yMin, yMax } = this.xyLimits
-
-    // Densely sample viewport edges and interior to capture projection curvature
-    // and extrema that may fall inside the viewport (e.g., pole in polar stereo).
-    const edgeSamples = 16
-    let srcXMin = Infinity
-    let srcXMax = -Infinity
-    let srcYMin = Infinity
-    let srcYMax = -Infinity
-    let validCount = 0
-    let totalCount = 0
-    for (let i = 0; i <= edgeSamples; i++) {
-      const t = i / edgeSamples
-      const lon = west + t * (east - west)
-      const lat = south + t * (north - south)
-      const points = [
-        transformer.forward(lon, south),
-        transformer.forward(lon, north),
-        transformer.forward(west, lat),
-        transformer.forward(east, lat),
-      ]
-      for (const [x, y] of points) {
-        totalCount++
-        if (!isFinite(x) || !isFinite(y)) continue
-        validCount++
-        if (x < srcXMin) srcXMin = x
-        if (x > srcXMax) srcXMax = x
-        if (y < srcYMin) srcYMin = y
-        if (y > srcYMax) srcYMax = y
-      }
-    }
-
-    // Sample interior grid to catch extrema inside viewport (e.g., pole in polar stereo)
-    const interiorSamples = 4
-    for (let iy = 1; iy <= interiorSamples; iy++) {
-      for (let ix = 1; ix <= interiorSamples; ix++) {
-        const lon = west + (ix / (interiorSamples + 1)) * (east - west)
-        const lat = south + (iy / (interiorSamples + 1)) * (north - south)
-        const [x, y] = transformer.forward(lon, lat)
-        totalCount++
-        if (!isFinite(x) || !isFinite(y)) continue
-        validCount++
-        if (x < srcXMin) srcXMin = x
-        if (x > srcXMax) srcXMax = x
-        if (y < srcYMin) srcYMin = y
-        if (y > srcYMax) srcYMax = y
-      }
-    }
-
-    // No valid points — fall back to all regions
-    if (validCount === 0) {
-      const all: Array<{ regionX: number; regionY: number }> = []
-      for (let ry = 0; ry < numRegionsY; ry++) {
-        for (let rx = 0; rx < numRegionsX; rx++) {
-          all.push({ regionX: rx, regionY: ry })
-        }
-      }
-      return all
-    }
-
-    // Widen margin when some samples failed (projection boundary)
-    const margin = validCount < totalCount ? 8 : 2
-
-    const pxXMin = ((srcXMin - xMin) / (xMax - xMin)) * width
-    const pxXMax = ((srcXMax - xMin) / (xMax - xMin)) * width
-    const pxYMin = ((srcYMin - yMin) / (yMax - yMin)) * height
-    const pxYMax = ((srcYMax - yMin) / (yMax - yMin)) * height
-    let rXMin: number, rXMax: number, rYMin: number, rYMax: number
-    if (this.latIsAscending === false) {
-      const invYMin = height - pxYMax
-      const invYMax = height - pxYMin
-      rYMin = Math.floor(invYMin / regionH) - margin
-      rYMax = Math.floor(invYMax / regionH) + margin
-    } else {
-      rYMin = Math.floor(pxYMin / regionH) - margin
-      rYMax = Math.floor(pxYMax / regionH) + margin
-    }
-    rXMin = Math.floor(pxXMin / regionW) - margin
-    rXMax = Math.floor(pxXMax / regionW) + margin
-
-    // Clamp to valid range
-    rXMin = Math.max(0, rXMin)
-    rXMax = Math.min(numRegionsX - 1, rXMax)
-    rYMin = Math.max(0, rYMin)
-    rYMax = Math.min(numRegionsY - 1, rYMax)
-
-    // When the viewport straddles the antimeridian, forward-projecting the
-    // sampled longitudes folds source X back on itself (e.g. proj4 adjust_lon),
-    // so the srcX min/max span no longer bounds the visible columns. Treat
-    // every X region as a candidate; the antimeridian-aware overlap check in
-    // getVisibleRegions then keeps only the columns that are actually visible,
-    // so this widens the search without over-fetching the result (issue #64).
-    const crossesAntimeridian = east < west || east > 180 || west < -180
-    if (crossesAntimeridian) {
-      rXMin = 0
-      rXMax = numRegionsX - 1
-    }
-
-    const candidates: Array<{ regionX: number; regionY: number }> = []
-    for (let ry = rYMin; ry <= rYMax; ry++) {
-      for (let rx = rXMin; rx <= rXMax; rx++) {
-        candidates.push({ regionX: rx, regionY: ry })
-      }
-    }
-    return candidates
-  }
-
-  /**
-   * Get geographic bounds for a region.
-   * Accounts for data orientation (latIsAscending).
-   * Requires level-specific dimensions so async work never reaches back into
-   * `activeLevel`, which may have changed since the caller captured a region.
-   */
   private getRegionBounds(
     regionX: number,
     regionY: number,
     levelMeta: LevelMeta
   ): { xMin: number; xMax: number; yMin: number; yMax: number } {
-    const { width, height, regionSize } = levelMeta
-
-    // xyLimits is assumed constant across all multiscale levels (same geographic extent).
-    // If per-level bounds are ever needed, add xyLimits to LevelMeta type.
-    if (!this.xyLimits) {
-      return { xMin: 0, xMax: 1, yMin: 0, yMax: 1 }
-    }
-
-    const [regionH, regionW] = regionSize
-    const { xMin, xMax, yMin, yMax } = this.xyLimits
-
-    // Calculate pixel bounds for this region
-    const pxXStart = regionX * regionW
-    const pxXEnd = Math.min(pxXStart + regionW, width)
-    const pxYStart = regionY * regionH
-    const pxYEnd = Math.min(pxYStart + regionH, height)
-
-    // Convert pixel bounds to geographic bounds using pixel edges.
-    const geoXMin = xMin + (pxXStart / width) * (xMax - xMin)
-    const geoXMax = xMin + (pxXEnd / width) * (xMax - xMin)
-
-    // Y mapping depends on data orientation
-    // Default (null/undefined) assumes ascending (row 0 = south = yMin)
-    let geoYMin: number
-    let geoYMax: number
-    if (this.latIsAscending === false) {
-      // Data has lat decreasing with array index: pixel 0 = north (yMax)
-      geoYMax = yMax - (pxYStart / height) * (yMax - yMin)
-      geoYMin = yMax - (pxYEnd / height) * (yMax - yMin)
-    } else {
-      // Data has lat increasing with array index: pixel 0 = south (yMin)
-      geoYMin = yMin + (pxYStart / height) * (yMax - yMin)
-      geoYMax = yMin + (pxYEnd / height) * (yMax - yMin)
-    }
-
-    return { xMin: geoXMin, xMax: geoXMax, yMin: geoYMin, yMax: geoYMax }
+    return getRegionBounds({
+      regionX,
+      regionY,
+      levelMeta,
+      xyLimits: this.xyLimits,
+      latIsAscending: this.latIsAscending,
+    })
   }
 
   /**
@@ -1637,88 +1352,13 @@ export class RegionRenderer {
   }
 
   private selectLevelForZoom(mapZoom: number): number {
-    if (!this.xyLimits || this.levels.length === 0) return 0
-
-    // Calculate map resolution: at zoom Z, full world is 256 * 2^Z pixels
-    const mapPixelsPerWorld = 256 * Math.pow(2, mapZoom)
-
-    // Calculate what fraction of the world the data covers, accounting for CRS
-    let worldFraction: number
-    if (this.projection.kind === 'epsg4326') {
-      // proj4's adjust_lon folds inputs outside [-180, 180] back into range
-      // (e.g. forward(360,·)→0, forward(190,·)→-170), which collapses or
-      // distorts the width for 0-360° stores and antimeridian-crossing
-      // extents. Use the source longitude span for level selection because
-      // render bounds may conservatively expand antimeridian-crossing regions
-      // to full-world X for tile intersection.
-      worldFraction = longitudeWorldFraction(this.xyLimits)
-    } else if (this.projection.kind === 'epsg3857') {
-      // Web Mercator: full world is ~40,075,016 meters
-      const dataWidth = this.xyLimits.xMax - this.xyLimits.xMin
-      const fullWorldMeters = 2 * WEB_MERCATOR_EXTENT
-      worldFraction = dataWidth / fullWorldMeters
-    } else if (this.projection.def && this.projection.toMercator) {
-      // Source-projected data: transform bounds corners to mercator
-      const [minMercX] = this.projection.toMercator.forward(
-        this.xyLimits.xMin,
-        this.xyLimits.yMin
-      )
-      const [maxMercX] = this.projection.toMercator.forward(
-        this.xyLimits.xMax,
-        this.xyLimits.yMax
-      )
-      let dataWidthMeters = Math.abs(maxMercX - minMercX)
-      const fullWorldMeters = 2 * WEB_MERCATOR_EXTENT
-      // worldFraction > 1 means the corner projection failed: for projections
-      // like MODIS sinusoidal the rectangular bbox corners fall outside the
-      // valid CRS domain (near-polar latitudes give out-of-domain longitudes),
-      // yielding a garbage or non-finite width. Fall back to the equatorial
-      // strip (y=0), which stays in-domain for any cylindrical-like projection
-      // and gives the correct horizontal extent.
-      if (!isFinite(dataWidthMeters) || dataWidthMeters > fullWorldMeters) {
-        const [eqMinX] = this.projection.toMercator.forward(
-          this.xyLimits.xMin,
-          0
-        )
-        const [eqMaxX] = this.projection.toMercator.forward(
-          this.xyLimits.xMax,
-          0
-        )
-        dataWidthMeters = Math.abs(eqMaxX - eqMinX)
-      }
-      worldFraction = Math.min(1, dataWidthMeters / fullWorldMeters)
-    } else {
-      const dataWidth = this.xyLimits.xMax - this.xyLimits.xMin
-      worldFraction = dataWidth / 360
-    }
-
-    // Build list of levels with their effective resolution (pixels per full world)
-    const levelResolutions: Array<{ index: number; effectivePixels: number }> =
-      []
-    for (let i = 0; i < this.levels.length; i++) {
-      const level = this.levels[i]
-      if (!level.shape) continue
-      const lonIndex = this.dimIndices.lon?.index ?? level.shape.length - 1
-      // Scale up to what resolution would be if data covered full world
-      const effectivePixels = level.shape[lonIndex] / worldFraction
-      levelResolutions.push({ index: i, effectivePixels })
-    }
-
-    // If no levels have shape data yet, fall back to the last level index
-    if (levelResolutions.length === 0) return this.levels.length - 1
-
-    // Sort by resolution ascending (lowest res first)
-    levelResolutions.sort((a, b) => a.effectivePixels - b.effectivePixels)
-
-    // Find the lowest resolution level that still provides sufficient detail
-    for (const { index, effectivePixels } of levelResolutions) {
-      if (effectivePixels >= mapPixelsPerWorld) {
-        return index
-      }
-    }
-
-    // If no level is sufficient, use the highest resolution available
-    return levelResolutions[levelResolutions.length - 1].index
+    return selectLevelForZoom({
+      mapZoom,
+      xyLimits: this.xyLimits,
+      levels: this.levels,
+      projection: this.projection,
+      lonIndex: this.dimIndices.lon?.index,
+    })
   }
 
   render(renderer: ZarrRenderer, context: RenderContext): void {
@@ -1948,64 +1588,17 @@ export class RegionRenderer {
     setLoadingCallbackUtil(this.loadingManager, callback)
   }
 
-  /**
-   * Compute mercator bounds from proj4 by sampling edge points.
-   */
   private computeMercatorBoundsFromProjection(): MercatorBounds {
-    if (!this.xyLimits) {
-      return { x0: 0, y0: 0, x1: 1, y1: 1 }
-    }
-    if (this.projection.kind === 'epsg4326') {
-      return boundsToMercatorNorm(this.xyLimits, 'EPSG:4326')
-    }
-    if (this.projection.kind === 'epsg3857') {
-      return boundsToMercatorNorm(this.xyLimits, 'EPSG:3857')
-    }
-    if (!this.projection.def || !this.projection.toMercator) {
-      return { x0: 0, y0: 0, x1: 1, y1: 1 }
-    }
-    const result = sampleEdgesToMercatorBounds(
-      this.xyLimits,
-      this.projection.toMercator,
-      20
-    )
-    if (!result) {
-      console.warn(
-        'computeMercatorBoundsFromProjection: No valid samples found'
-      )
-      return { x0: 0, y0: 0, x1: 1, y1: 1 }
-    }
-    return result
+    return computeMercatorBoundsFromProjection(this.xyLimits, this.projection)
   }
 
-  /**
-   * Compute mercator bounds for a specific region from source CRS bounds.
-   */
   private computeRegionMercatorBounds(bounds: {
     xMin: number
     xMax: number
     yMin: number
     yMax: number
   }): MercatorBounds {
-    if (this.projection.kind === 'epsg4326') {
-      return boundsToMercatorNorm(bounds, 'EPSG:4326')
-    }
-    if (this.projection.kind === 'epsg3857') {
-      return boundsToMercatorNorm(bounds, 'EPSG:3857')
-    }
-    if (!this.projection.def || !this.projection.toMercator) {
-      return { x0: 0, y0: 0, x1: 1, y1: 1 }
-    }
-    const result = sampleEdgesToMercatorBounds(
-      bounds,
-      this.projection.toMercator,
-      5
-    )
-    if (!result) {
-      console.warn('computeRegionMercatorBounds: No valid samples found')
-      return { x0: 0, y0: 0, x1: 1, y1: 1 }
-    }
-    return result
+    return computeRegionMercatorBounds(bounds, this.projection)
   }
 
   async setSelector(selector: NormalizedSelector): Promise<void> {
@@ -2100,19 +1693,4 @@ export class RegionRenderer {
       options
     )
   }
-}
-
-function longitudeWorldFraction(bounds: {
-  xMin: number
-  xMax: number
-}): number {
-  const rawSpan = bounds.xMax - bounds.xMin
-  if (!Number.isFinite(rawSpan) || rawSpan === 0) {
-    return 1
-  }
-  if (Math.abs(rawSpan) >= 360) {
-    return 1
-  }
-  const span = rawSpan > 0 ? rawSpan : rawSpan + 360
-  return Math.max(span / 360, Number.EPSILON)
 }

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -51,7 +51,12 @@ import {
   getVisibleRegions,
   selectLevelForZoom,
 } from './region-math'
-import { RegionCache, isRegionValid, makeRegionKey } from './region-cache'
+import {
+  RegionCache,
+  isRegionCpuReady,
+  isRegionGpuReady,
+  makeRegionKey,
+} from './region-cache'
 import { RegionFetcher } from './region-fetcher'
 import { LevelLoader } from './level-loader'
 import { createHybridMesh } from './mesh-reprojector'
@@ -405,13 +410,6 @@ export class RegionRenderer {
   }
 
   /**
-   * Check if a region has all required data for rendering.
-   */
-  private isRegionValid(region: RegionState): boolean {
-    return isRegionValid(region)
-  }
-
-  /**
    * Get uniforms for rendering with scale/offset disabled.
    * Untiled mode applies per-level scale/offset in JS (in fetchRegion),
    * so we tell the shader to skip its scale/offset application.
@@ -426,7 +424,9 @@ export class RegionRenderer {
 
   /**
    * Check if current level fully covers the visible viewport.
-   * Returns true if all visible regions have valid loaded data.
+   * Returns true only if every visible region is drawable right now — the
+   * decision releases the previous level's fallbacks, both from the render
+   * list and from eviction protection, so CPU-side readiness isn't enough.
    */
   private currentLevelCoversViewport(): boolean {
     // If visible regions are stale (from different level), we can't know coverage
@@ -437,7 +437,7 @@ export class RegionRenderer {
     for (const { regionX, regionY } of this.lastVisibleRegions) {
       const key = this.makeRegionKey(levelIndex, regionX, regionY)
       const region = this.regionCache.get(key)
-      if (!region || !this.isRegionValid(region)) {
+      if (!region || !isRegionGpuReady(region)) {
         return false
       }
     }
@@ -453,7 +453,7 @@ export class RegionRenderer {
     const fallbacks: RegionState[] = []
     for (const region of this.regionCache.values()) {
       if (region.levelIndex === (this.activeLevel?.index ?? -1)) continue
-      if (!this.isRegionValid(region)) continue
+      if (!isRegionCpuReady(region)) continue
       // Only include regions that are protected (were visible)
       if (!this.regionCache.isProtected(region.key)) continue
       fallbacks.push(region)
@@ -462,31 +462,30 @@ export class RegionRenderer {
   }
 
   /**
-   * Get regions to render: current level regions plus fallbacks if needed.
-   * When current level fully covers viewport, returns only current level.
-   * Otherwise, includes protected fallback regions from other levels.
+   * Get drawable regions: current level regions plus fallbacks if needed.
+   * Uploads the current level first so coverage is judged on what can actually
+   * be drawn — a level that displaces its fallbacks and then fails to upload
+   * would leave the viewport blank. Every returned region is GPU-ready.
    */
-  private getLoadedRegions(): RegionState[] {
+  private getLoadedRegions(gl: WebGL2RenderingContext): RegionState[] {
     const currentLevel = this.activeLevel?.index ?? -1
     const currentLevelRegions: RegionState[] = []
 
-    // Collect all valid regions at current level
     for (const region of this.regionCache.values()) {
-      if (!this.isRegionValid(region)) continue
-      if (region.levelIndex === currentLevel) {
-        currentLevelRegions.push(region)
-      }
+      if (region.levelIndex !== currentLevel) continue
+      if (!isRegionCpuReady(region)) continue
+      if (!ensureRegionGpuResources(gl, region)) continue
+      currentLevelRegions.push(region)
     }
 
-    // If current level fully covers viewport, no fallback needed
     if (this.currentLevelCoversViewport()) {
       return currentLevelRegions
     }
 
-    // Include protected fallback regions from other levels
-    const fallbackRegions = this.getProtectedFallbackRegions()
-
     // Render order: fallbacks first (beneath), current level on top
+    const fallbackRegions = this.getProtectedFallbackRegions().filter(
+      (region) => ensureRegionGpuResources(gl, region)
+    )
     return [...fallbackRegions, ...currentLevelRegions]
   }
 
@@ -1016,8 +1015,7 @@ export class RegionRenderer {
     setupBandTextureUniforms(gl, shaderProgram, customShaderConfig)
 
     // Render each loaded region using unified path
-    for (const region of this.getLoadedRegions()) {
-      if (!ensureRegionGpuResources(gl, region)) continue
+    for (const region of this.getLoadedRegions(gl)) {
       renderRegion(
         gl,
         shaderProgram,
@@ -1061,27 +1059,25 @@ export class RegionRenderer {
       return []
     }
 
-    return this.getLoadedRegions()
-      .filter((region) => ensureRegionGpuResources(gl, region))
-      .map((region) => ({
-        texture: region.texture!,
-        vertexBuffer: region.vertexBuffer!,
-        pixCoordBuffer: region.pixCoordBuffer!,
-        vertexArr: region.vertexArr!,
-        mercatorBounds: region.mercatorBounds!,
-        width: region.width,
-        height: region.height,
-        bandData: region.bandData,
-        bandTextures: region.bandTextures,
-        bandTexturesUploaded: region.bandTexturesUploaded,
-        bandTexturesConfigured: region.bandTexturesConfigured,
-        // Indexed mesh fields for proj4 adaptive mesh
-        indexBuffer: region.indexBuffer ?? undefined,
-        vertexCount: region.vertexCount,
-        useIndexedMesh: region.useIndexedMesh,
-        wgs84Bounds: region.wgs84Bounds ?? undefined,
-        latIsAscending: region.latIsAscending,
-      }))
+    return this.getLoadedRegions(gl).map((region) => ({
+      texture: region.texture!,
+      vertexBuffer: region.vertexBuffer!,
+      pixCoordBuffer: region.pixCoordBuffer!,
+      vertexArr: region.vertexArr!,
+      mercatorBounds: region.mercatorBounds!,
+      width: region.width,
+      height: region.height,
+      bandData: region.bandData,
+      bandTextures: region.bandTextures,
+      bandTexturesUploaded: region.bandTexturesUploaded,
+      bandTexturesConfigured: region.bandTexturesConfigured,
+      // Indexed mesh fields for proj4 adaptive mesh
+      indexBuffer: region.indexBuffer ?? undefined,
+      vertexCount: region.vertexCount,
+      useIndexedMesh: region.useIndexedMesh,
+      wgs84Bounds: region.wgs84Bounds ?? undefined,
+      latIsAscending: region.latIsAscending,
+    }))
   }
 
   dispose(gl: WebGL2RenderingContext | WebGLRenderingContext): void {

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -53,6 +53,7 @@ import {
 } from './region-math'
 import {
   RegionCache,
+  hasRegionData,
   isRegionCpuReady,
   isRegionGpuReady,
   makeRegionKey,
@@ -743,7 +744,7 @@ export class RegionRenderer {
         continue
       }
 
-      if (!cached?.data) {
+      if (!cached || !hasRegionData(cached)) {
         // No data yet - this is a new region (viewport change)
         newRegions.push({ regionX, regionY })
       } else if (cached.selectorVersion !== this.selectorVersion) {

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -22,13 +22,7 @@ import type {
   RegionRenderState,
   CustomShaderConfig,
 } from './renderer-types'
-import type {
-  QueryGeometry,
-  QueryOptions,
-  QueryResult,
-  QueryDataValues,
-  NestedValues,
-} from './query/types'
+import type { QueryGeometry, QueryOptions, QueryResult } from './query/types'
 import type {
   LoadingStateCallback,
   MapLike,
@@ -45,21 +39,12 @@ import {
   type MercatorBounds,
   type XYLimits,
 } from './map-utils'
-import { normalizeSelector, getBands } from './zarr-utils'
+import { getBands } from './zarr-utils'
 import { interleaveBands, normalizeDataForTexture } from './webgl-utils'
 import type { ZarrRenderer, ShaderProgram } from './zarr-renderer'
 import { renderMapboxTile } from './mapbox-tile-renderer'
-import { queryRegionUntiled, findSpatialDimNames } from './query/region-query'
-import {
-  computePixelBoundsFromGeometry,
-  preprocessQueryGeometry,
-  wrappedBboxToPixelSpans,
-  rasterExtentCrossesAntimeridian,
-  type PixelRect,
-} from './query/query-utils'
 import {
   createProjectionContext,
-  pixelToSourceCRS,
   sampleEdgesToMercatorBounds,
   type ProjectionContext,
 } from './projection-utils'
@@ -67,7 +52,6 @@ import type {
   LevelMeta,
   LevelRuntime,
   LevelSnapshot,
-  QueryLevelSnapshot,
   RegionState,
 } from './region-state'
 import {
@@ -75,6 +59,7 @@ import {
   buildSliceArgsForSelector,
   type DimensionValuesCache,
 } from './selector-resolution'
+import { queryData as queryDataWithContext } from './query/data-query'
 import { createHybridMesh } from './mesh-reprojector'
 import {
   type RequestCanceller,
@@ -2080,294 +2065,40 @@ export class RegionRenderer {
     emitLoadingStateUtil(this.loadingManager)
   }
 
-  /**
-   * Unified method to fetch query data for either point or region queries.
-   * Handles multi-value dimensions and channel combinations.
-   */
-  private async fetchQueryData(
-    level: QueryLevelSnapshot,
-    selector: NormalizedSelector,
-    spatialQuery: {
-      minX: number
-      maxX: number
-      minY: number
-      maxY: number
-    },
-    signal?: AbortSignal
-  ): Promise<{
-    data: Float32Array
-    width: number
-    height: number
-    channels: number
-    channelLabels: (string | number)[][]
-    multiValueDimNames: string[]
-  } | null> {
-    try {
-      const { sliceArgs: baseSliceArgs, multiValueDims } =
-        await this.buildSliceArgsForSelector(selector, {
-          includeSpatialSlices: false,
-          trackMultiValue: true,
-          spatialBounds: spatialQuery,
-          array: level.zarrArray,
-        })
-
-      const {
-        combinations: channelCombinations,
-        labelCombinations: channelLabelCombinations,
-      } = buildChannelCombinations(multiValueDims)
-      const numChannels = channelCombinations.length || 1
-      const multiValueDimNames = multiValueDims.map((d) => d.dimName)
-      const getOpts = signal ? { signal } : undefined
-
-      const fetchWidth = spatialQuery.maxX - spatialQuery.minX
-      const fetchHeight = spatialQuery.maxY - spatialQuery.minY
-
-      if (numChannels === 1) {
-        const result = (await zarr.get(
-          level.zarrArray,
-          baseSliceArgs,
-          getOpts
-        )) as { data: ArrayLike<number> }
-        return {
-          data: new Float32Array(result.data),
-          width: fetchWidth,
-          height: fetchHeight,
-          channels: 1,
-          channelLabels: channelLabelCombinations,
-          multiValueDimNames,
-        }
-      }
-
-      const packedData = new Float32Array(
-        fetchWidth * fetchHeight * numChannels
-      )
-      for (let c = 0; c < numChannels; c++) {
-        const sliceArgs = [...baseSliceArgs]
-        const combo = channelCombinations[c]
-        for (let i = 0; i < multiValueDims.length; i++) {
-          sliceArgs[multiValueDims[i].dimIndex] = combo[i]
-        }
-
-        const bandData = (await zarr.get(
-          level.zarrArray,
-          sliceArgs,
-          getOpts
-        )) as { data: ArrayLike<number> }
-        for (let pixIdx = 0; pixIdx < fetchWidth * fetchHeight; pixIdx++) {
-          packedData[pixIdx * numChannels + c] = bandData.data[pixIdx]
-        }
-      }
-
-      return {
-        data: packedData,
-        width: fetchWidth,
-        height: fetchHeight,
-        channels: numChannels,
-        channelLabels: channelLabelCombinations,
-        multiValueDimNames,
-      }
-    } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') throw err
-      console.error('Error fetching query data:', err)
-      return null
-    }
-  }
-
-  /**
-   * Query data for point or region geometries.
-   */
+  /** Query data for point or region geometries. */
   async queryData(
     geometry: QueryGeometry,
     selector?: Selector,
     options?: QueryOptions
   ): Promise<QueryResult> {
-    const desc = this.zarrStore.describe()
-    const sourceBounds: [number, number, number, number] | null = this.xyLimits
-      ? [
-          this.xyLimits.xMin,
-          this.xyLimits.yMin,
-          this.xyLimits.xMax,
-          this.xyLimits.yMax,
-        ]
-      : null
-    const { yDim: emptyYDim, xDim: emptyXDim } = findSpatialDimNames(
-      desc.dimensions,
-      desc.dimIndices
-    )
-    const emptyResult = (): QueryResult => ({
-      [this.variable]: [],
-      dimensions: [],
-      coordinates: { [emptyYDim]: [], [emptyXDim]: [] },
-    })
-
     const activeLevel = this.activeLevel
-    if (!this.mercatorBounds || !activeLevel || !sourceBounds) {
-      return emptyResult()
-    }
-    const projectionDef = this.projection.def
-    if (!projectionDef) {
-      return emptyResult()
-    }
-
-    const level: QueryLevelSnapshot = {
-      index: activeLevel.index,
-      zarrArray: activeLevel.zarrArray,
-      width: activeLevel.width,
-      height: activeLevel.height,
-    }
-
-    const normalizedSelector = selector
-      ? normalizeSelector(selector)
-      : this.selector
-
-    const currentLevel = this.levels[level.index]
-    const transforms = {
-      scaleFactor: currentLevel?.scaleFactor ?? desc.scaleFactor,
-      addOffset: currentLevel?.addOffset ?? desc.addOffset,
-      fillValue: currentLevel?.fillValue ?? desc.fill_value,
-    }
-
-    // Closure for running a single pixel-bounds strip query.
-    // Captures request-scoped locals (not instance state) to avoid races
-    // when queryData is called concurrently on the same instance.
-    const runStrip = async (
-      geom: QueryGeometry,
-      pixelBounds: PixelRect,
-      opts?: QueryOptions
-    ): Promise<QueryResult | null> => {
-      const fetched = await this.fetchQueryData(
-        level,
-        normalizedSelector,
-        pixelBounds,
-        opts?.signal
-      )
-      if (!fetched) return null
-
-      const { minX, minY, maxX, maxY } = pixelBounds
-      const [xMin0, yMin0] = pixelToSourceCRS(
-        minX,
-        minY,
-        sourceBounds,
-        level.width,
-        level.height,
-        this.latIsAscending
-      )
-      const [xMax0, yMax0] = pixelToSourceCRS(
-        maxX,
-        maxY,
-        sourceBounds,
-        level.width,
-        level.height,
-        this.latIsAscending
-      )
-      const subsetSourceBounds: Bounds = [
-        Math.min(xMin0, xMax0),
-        Math.min(yMin0, yMax0),
-        Math.max(xMin0, xMax0),
-        Math.max(yMin0, yMax0),
-      ]
-
-      return queryRegionUntiled(
-        this.variable,
-        geom,
-        normalizedSelector,
-        fetched.data,
-        fetched.width,
-        fetched.height,
-        desc.dimensions,
-        desc.coordinates,
-        subsetSourceBounds,
-        projectionDef,
-        fetched.channels,
-        fetched.channelLabels,
-        fetched.multiValueDimNames,
-        this.latIsAscending,
-        transforms,
-        opts,
-        desc.dimIndices,
-        this.projection.toWGS84 ?? undefined
-      )
-    }
-
-    const singleFetch = async (geom: QueryGeometry): Promise<QueryResult> => {
-      const pixelBounds = computePixelBoundsFromGeometry(
-        geom,
-        sourceBounds,
-        level.width,
-        level.height,
-        projectionDef,
-        this.latIsAscending,
-        this.projection.toWGS84 ?? undefined
-      )
-      if (!pixelBounds) return emptyResult()
-      const result = await runStrip(geom, pixelBounds, options)
-      return result ?? emptyResult()
-    }
-
-    const { geometry: processedGeometry, bbox: wrappedBbox } =
-      preprocessQueryGeometry(geometry)
-
-    const supportsWrappedLongitude =
-      this.projection.kind === 'epsg4326' || this.projection.kind === 'epsg3857'
-    const queryGeometry = supportsWrappedLongitude
-      ? processedGeometry
-      : geometry
-
-    if (!wrappedBbox.crossesAntimeridian) {
-      return singleFetch(queryGeometry)
-    }
-
-    if (!supportsWrappedLongitude) {
-      if (!this._antimeridianWarnings.has('proj4-crossing')) {
-        this._antimeridianWarnings.add('proj4-crossing')
-        console.warn(
-          'Antimeridian-crossing polygon queries are not supported for proj4 projections; results may be incorrect'
-        )
-      }
-      return singleFetch(queryGeometry)
-    }
-
-    // Crossing: raster extent guard (EPSG:4326 only — 3857 xyLimits are in meters)
-    if (
-      this.projection.kind === 'epsg4326' &&
-      rasterExtentCrossesAntimeridian('EPSG:4326', this.xyLimits)
-    ) {
-      if (!this._antimeridianWarnings.has('raster-extent-crossing')) {
-        this._antimeridianWarnings.add('raster-extent-crossing')
-        console.warn(
-          'Antimeridian-crossing polygon queries are not supported for rasters whose own extent crosses the antimeridian; results may be incorrect'
-        )
-      }
-      return singleFetch(geometry)
-    }
-
-    // Crossing: two-strip fetch
-    const spans = wrappedBboxToPixelSpans(
-      wrappedBbox,
-      sourceBounds,
-      level.width,
-      level.height,
-      projectionDef,
-      this.latIsAscending,
-      this.projection.toWGS84 ?? undefined
+    return queryDataWithContext(
+      {
+        zarrStore: this.zarrStore,
+        variable: this.variable,
+        selector: this.selector,
+        xyLimits: this.xyLimits,
+        mercatorBounds: this.mercatorBounds,
+        latIsAscending: this.latIsAscending,
+        levels: this.levels,
+        level: activeLevel
+          ? {
+              index: activeLevel.index,
+              zarrArray: activeLevel.zarrArray,
+              width: activeLevel.width,
+              height: activeLevel.height,
+            }
+          : null,
+        projection: this.projection,
+        antimeridianWarnings: this._antimeridianWarnings,
+        dimensionValues: this.dimensionValues,
+        isMultiscale: this.isMultiscale,
+        coordLevelIndex: activeLevel?.index ?? 0,
+      },
+      geometry,
+      selector,
+      options
     )
-
-    const westResult = spans.west
-      ? await runStrip(processedGeometry, spans.west, options)
-      : null
-    const eastResult = spans.east
-      ? await runStrip(processedGeometry, spans.east, options)
-      : null
-
-    // If either requested strip failed, return empty rather than partial data
-    if ((spans.west && !westResult) || (spans.east && !eastResult)) {
-      return emptyResult()
-    }
-    if (!westResult && !eastResult) return emptyResult()
-    if (!westResult || !eastResult) return (westResult ?? eastResult)!
-
-    const { yDim, xDim } = findSpatialDimNames(desc.dimensions, desc.dimIndices)
-    return mergeQueryResults(westResult, eastResult, this.variable, yDim, xDim)
   }
 }
 
@@ -2384,88 +2115,4 @@ function longitudeWorldFraction(bounds: {
   }
   const span = rawSpan > 0 ? rawSpan : rawSpan + 360
   return Math.max(span / 360, Number.EPSILON)
-}
-
-/**
- * Merge two QueryResult objects from west and east strips.
- *
- * Ordering: west-strip pixels first, then east-strip pixels. This does NOT
- * preserve row-major scan order. The QueryResult contract provides parallel
- * coordinate arrays so consumers index by position, not implicit grid layout.
- *
- * Spatial coordinate arrays (yDim, xDim) are concatenated.
- * Non-spatial coordinate arrays are taken from the first result unchanged.
- */
-function mergeQueryResults(
-  a: QueryResult,
-  b: QueryResult,
-  variable: string,
-  yDim: string,
-  xDim: string
-): QueryResult {
-  const spatialKeys = new Set([yDim, xDim])
-
-  // Merge coordinates: concatenate spatial, take first for non-spatial
-  const coordinates: Record<string, (number | string)[]> = {}
-  for (const key of Object.keys(a.coordinates)) {
-    if (spatialKeys.has(key)) {
-      coordinates[key] = [...a.coordinates[key], ...b.coordinates[key]]
-    } else {
-      coordinates[key] = a.coordinates[key]
-    }
-  }
-
-  // Merge variable values
-  const aVals = a[variable] as QueryDataValues
-  const bVals = b[variable] as QueryDataValues
-
-  let merged: QueryDataValues
-  if (Array.isArray(aVals) && Array.isArray(bVals)) {
-    merged = [...aVals, ...bVals]
-  } else if (!Array.isArray(aVals) && !Array.isArray(bVals)) {
-    merged = mergeNestedValues(aVals as NestedValues, bVals as NestedValues)
-  } else {
-    merged = aVals // Mismatched types: take first
-  }
-
-  return {
-    [variable]: merged,
-    dimensions: a.dimensions,
-    coordinates,
-  }
-}
-
-/**
- * Recursively merge two NestedValues objects by concatenating leaf arrays.
- */
-function mergeNestedValues(a: NestedValues, b: NestedValues): NestedValues {
-  const result: NestedValues = {}
-  for (const key of Object.keys(a)) {
-    const aVal = a[key]
-    const bVal = b[key]
-    if (Array.isArray(aVal) && Array.isArray(bVal)) {
-      result[key] = [...aVal, ...bVal]
-    } else if (
-      aVal &&
-      bVal &&
-      !Array.isArray(aVal) &&
-      !Array.isArray(bVal) &&
-      typeof aVal === 'object' &&
-      typeof bVal === 'object'
-    ) {
-      result[key] = mergeNestedValues(
-        aVal as NestedValues,
-        bVal as NestedValues
-      )
-    } else {
-      result[key] = aVal
-    }
-  }
-  // Include keys only in b
-  for (const key of Object.keys(b)) {
-    if (!(key in result)) {
-      result[key] = b[key]
-    }
-  }
-  return result
 }

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -31,21 +31,14 @@ import type {
 import { ZarrStore } from './zarr-store'
 import { type MercatorBounds, type XYLimits } from './map-utils'
 import { getBands } from './zarr-utils'
-import { interleaveBands, normalizeDataForTexture } from './webgl-utils'
 import type { ZarrRenderer, ShaderProgram } from './zarr-renderer'
 import { renderMapboxTile } from './mapbox-tile-renderer'
 import {
   createProjectionContext,
   type ProjectionContext,
 } from './projection-utils'
-import type {
-  LevelMeta,
-  LevelRuntime,
-  LevelSnapshot,
-  RegionState,
-} from './region-state'
+import type { LevelMeta, LevelRuntime, RegionState } from './region-state'
 import {
-  buildChannelCombinations,
   buildSliceArgsForSelector,
   type DimensionValuesCache,
 } from './selector-resolution'
@@ -64,6 +57,7 @@ import {
   isRegionValid,
   makeRegionKey,
 } from './region-cache'
+import { RegionFetcher } from './region-fetcher'
 import { createHybridMesh } from './mesh-reprojector'
 import {
   type RequestCanceller,
@@ -372,25 +366,6 @@ export class RegionRenderer {
    */
   private isRegionValid(region: RegionState): boolean {
     return isRegionValid(region)
-  }
-
-  /**
-   * Clear loading flags for queued-but-not-started regions in a batch.
-   * Only touches regions where requestId is null (pre-marked as loading
-   * but no fetch was started). In-flight regions (requestId set) are
-   * cleaned up by their own finally block.
-   */
-  private clearBatchLoadingFlags(
-    regions: Array<{ regionX: number; regionY: number }>,
-    levelIndex: number
-  ): void {
-    for (const { regionX, regionY } of regions) {
-      const key = this.makeRegionKey(levelIndex, regionX, regionY)
-      const region = this.regionCache.get(key)
-      if (region && region.requestId === null) {
-        region.loading = false
-      }
-    }
   }
 
   /**
@@ -767,307 +742,33 @@ export class RegionRenderer {
     this.evictOldRegions(gl)
   }
 
-  /**
-   * Fetch multiple regions with limited concurrency to avoid overwhelming the browser.
-   */
   private async fetchRegions(
     regions: Array<{ regionX: number; regionY: number }>
   ): Promise<void> {
-    // Can't fetch without a committed level.
-    if (!this.activeLevel) return
-    const level = this.activeLevel
-
-    // Capture ALL level-dependent state at start to pass to fetchRegion.
-    // This prevents races where a later `loadLevel` (zoom switch or
-    // selector rebuild) swaps `this.activeLevel` mid-batch.
-    const snapshot: LevelSnapshot = {
-      index: level.index,
-      zarrArray: level.zarrArray,
-      baseSliceArgs: [...level.baseSliceArgs],
-      width: level.width,
-      height: level.height,
-      regionSize: level.regionSize,
-      selectorVersion: this.selectorVersion,
-      bandNames: [...this.bandNames],
-      baseMultiValueDims: level.baseMultiValueDims.map((dim) => ({
-        dimIndex: dim.dimIndex,
-        dimName: dim.dimName,
-        values: [...dim.values],
-        labels: [...dim.labels],
-      })),
-    }
-
-    this.loadingDebouncer.show()
-
-    // Mark ALL regions as loading upfront to prevent duplicate fetches
-    // from subsequent update() calls before we've processed them all
-    for (const { regionX, regionY } of regions) {
-      const key = this.makeRegionKey(snapshot.index, regionX, regionY)
-      let region = this.regionCache.get(key)
-      if (!region) {
-        region = this.createRegionState(snapshot.index, regionX, regionY)
-        this.regionCache.set(key, region)
-      }
-      region.loading = true
-    }
-
-    // Pre-flight staleness check. Mid-flight changes are handled by the
-    // `cancelAllRequests` in `loadLevel`/`setSelector`, which aborts the
-    // signals that fetchRegion threads through every await.
-    if (
-      (this.activeLevel?.index ?? -1) !== snapshot.index ||
-      this.selectorVersion !== snapshot.selectorVersion
-    ) {
-      cancelAllRequests(this.requestCanceller)
-      this.clearBatchLoadingFlags(regions, snapshot.index)
-    } else {
-      // Kick off every region synchronously so their underlying chunk reads
-      // land in one microtask drain — that's what lets the range coalescer
-      // (icechunk-js + zarrita) merge them into a handful of HTTP fetches
-      // instead of one per region. Browser HTTP queueing handles back-
-      // pressure on the connection pool; throttling fetchRegion calls here
-      // just fragments the coalescer's same-tick batch window.
-      const fetches = regions.map(({ regionX, regionY }) =>
-        this.fetchRegion(regionX, regionY, snapshot)
-      )
-      await Promise.allSettled(fetches)
-    }
-
-    // Only update loading state if we're still on the same level
-    if (!hasActiveRequests(this.requestCanceller)) {
-      this.loadingDebouncer.hide()
-
-      this.invalidate()
-    }
-  }
-
-  /**
-   * Fetch data for a single region.
-   * Handles multi-band extraction when selector has multi-value dimensions.
-   * @param snapshot - Captured level state from when fetch batch started (prevents race conditions)
-   */
-  private async fetchRegion(
-    regionX: number,
-    regionY: number,
-    snapshot: LevelSnapshot
-  ): Promise<void> {
-    if ((this.activeLevel?.index ?? -1) !== snapshot.index) {
-      return
-    }
-
-    if (this.isRemoved) {
-      return
-    }
-
-    const key = this.makeRegionKey(snapshot.index, regionX, regionY)
-    const requestId = ++this.requestCanceller.currentVersion
-    const fetchSelectorVersion = snapshot.selectorVersion
-
-    const controller = new AbortController()
-    this.requestCanceller.controllers.set(requestId, controller)
-
-    let region = this.regionCache.get(key)
-    if (!region) {
-      region = this.createRegionState(snapshot.index, regionX, regionY)
-      this.regionCache.set(key, region)
-    }
-    region.loading = true
-    region.requestId = requestId
-
-    const [regionH, regionW] = snapshot.regionSize
-
-    // Calculate pixel bounds for this region
-    const yStart = regionY * regionH
-    const yEnd = Math.min(yStart + regionH, snapshot.height)
-    const xStart = regionX * regionW
-    const xEnd = Math.min(xStart + regionW, snapshot.width)
-    const actualW = xEnd - xStart
-    const actualH = yEnd - yStart
-
-    try {
-      // Build base slice args with spatial region bounds
-      const baseSliceArgs = [...snapshot.baseSliceArgs]
-      const latIdx = this.dimIndices.lat.index
-      const lonIdx = this.dimIndices.lon.index
-      baseSliceArgs[latIdx] = zarr.slice(yStart, yEnd)
-      baseSliceArgs[lonIdx] = zarr.slice(xStart, xEnd)
-
-      const desc = this.zarrStore.describe()
-      // Use per-level metadata if available (for heterogeneous pyramids)
-      const currentLevel = this.levels[snapshot.index]
-      const fillValue = currentLevel?.fillValue ?? desc.fill_value
-
-      const { combinations: channelCombinations } = buildChannelCombinations(
-        snapshot.baseMultiValueDims
-      )
-      const numChannels = channelCombinations.length || 1
-
-      // Fetch data for all channels
-      const bandArrays: Float32Array[] = []
-
-      const isStale = () =>
-        controller.signal.aborted ||
-        this.isRemoved ||
-        (this.activeLevel?.index ?? -1) !== snapshot.index
-
-      if (numChannels === 1) {
-        // Single channel - simple fetch
-        if (isStale()) return
-
-        const result = (await zarr.get(snapshot.zarrArray, baseSliceArgs, {
-          signal: controller.signal,
-        })) as { data: ArrayLike<number> }
-
-        if (isStale()) return
-
-        const rawData = new Float32Array(result.data as ArrayLike<number>)
-        bandArrays.push(rawData)
-      } else {
-        // Multi-channel - fetch all channels in parallel
-        if (isStale()) return
-
-        // Build slice args for all channels upfront
-        const allSliceArgs: (number | zarr.Slice)[][] = []
-        for (let c = 0; c < numChannels; c++) {
-          const sliceArgs = [...baseSliceArgs]
-          const combo = channelCombinations[c]
-
-          // Apply channel-specific indices to multi-value dimensions
-          for (let i = 0; i < snapshot.baseMultiValueDims.length; i++) {
-            sliceArgs[snapshot.baseMultiValueDims[i].dimIndex] = combo[i]
-          }
-          allSliceArgs.push(sliceArgs)
-        }
-
-        // Fetch all bands in parallel
-        const results = await Promise.all(
-          allSliceArgs.map((sliceArgs) =>
-            zarr.get(snapshot.zarrArray, sliceArgs, {
-              signal: controller.signal,
-            })
-          )
-        )
-
-        if (isStale()) return
-
-        // Process results in order
-        for (let c = 0; c < numChannels; c++) {
-          const result = results[c] as { data: ArrayLike<number> }
-          const bandData = new Float32Array(result.data as ArrayLike<number>)
-          bandArrays.push(bandData)
-        }
-      }
-
-      // Only render if this is newer than what's already rendered for this region
-      if (fetchSelectorVersion < region.selectorVersion) return
-
-      // Update region's selector version
-      region.selectorVersion = fetchSelectorVersion
-
-      // GPU handles reprojection. Source-projected data uses an adaptive mesh
-      // (source CRS → WGS84), then the GPU projects to Mercator or ECEF.
-      const needsProj4MercBounds =
-        this.projection.def && this.projection.toMercator
-
-      if (needsProj4MercBounds && this.xyLimits && !region.mercatorBounds) {
-        const levelMeta: LevelMeta = {
-          width: snapshot.width,
-          height: snapshot.height,
-          regionSize: snapshot.regionSize,
-        }
-        const geoBounds = this.getRegionBounds(regionX, regionY, levelMeta)
-        region.mercatorBounds = this.computeRegionMercatorBounds(geoBounds)
-      }
-
-      // Apply per-level scale/offset to convert raw values to physical units
-      // Fall back to dataset-level scale/offset for pyramids that only define them at the root
-      const scaleFactor = currentLevel?.scaleFactor ?? desc.scaleFactor
-      const addOffset = currentLevel?.addOffset ?? desc.addOffset
-
-      // Normalize bands (single pass) and collect for interleaving
-      region.bandData.clear()
-      region.bandTexturesUploaded.clear()
-      const normalizedBands: Float32Array[] = []
-
-      for (let c = 0; c < bandArrays.length; c++) {
-        const bandName = snapshot.bandNames[c] || `band_${c}`
-        let bandData = bandArrays[c]
-
-        // Apply scale/offset if needed (converts raw to physical values)
-        if (scaleFactor !== 1 || addOffset !== 0) {
-          const scaled = new Float32Array(bandData.length)
-          for (let i = 0; i < bandData.length; i++) {
-            const raw = bandData[i]
-            // Scale all values including fill - normalizeDataForTexture will filter by scaled fill
-            if (!Number.isFinite(raw)) {
-              scaled[i] = raw // Keep NaN/Inf as-is
-            } else {
-              scaled[i] = raw * scaleFactor + addOffset
-            }
-          }
-          bandData = scaled
-        }
-
-        // Compute the fill value in the same space as the data
-        const effectiveFillValue =
-          fillValue !== null && (scaleFactor !== 1 || addOffset !== 0)
-            ? fillValue * scaleFactor + addOffset
-            : fillValue
-
-        const { normalized: bandNormalized } = normalizeDataForTexture(
-          bandData,
-          effectiveFillValue,
-          this.fixedDataScale
-        )
-        region.bandData.set(bandName, bandNormalized)
-        normalizedBands.push(bandNormalized)
-      }
-
-      // Construct interleaved data from normalized bands
-      region.data = interleaveBands(normalizedBands, numChannels)
-
-      // Check if geometry needs to be (re)created before updating dimensions
-      // The adaptive mesh only depends on spatial bounds and dimensions, not the selector
-      const needsGeometry =
-        !region.vertexArr ||
-        region.width !== actualW ||
-        region.height !== actualH
-
-      region.width = actualW
-      region.height = actualH
-      region.channels = numChannels
-      region.loading = false
-
-      // Store level-specific dimensions from snapshot for geometry creation.
-      // Must use snapshot (not this.*) to avoid races with level switching.
-      // Set before createRegionGeometry is called below.
-      region.levelMeta = {
-        width: snapshot.width,
-        height: snapshot.height,
-        regionSize: [...snapshot.regionSize] as [number, number],
-      }
-
-      region.textureUploaded = false
-
-      // Create geometry only if needed (new region or dimensions changed)
-      if (needsGeometry) {
-        this.createRegionGeometry(regionX, regionY, region)
-      }
-
-      this.invalidate()
-    } catch (err) {
-      if (!(err instanceof DOMException && err.name === 'AbortError')) {
-        console.error(`[fetchRegion] Error fetching region ${key}:`, err)
-      }
-    } finally {
-      region.loading = false
-      region.requestId = null
-      this.requestCanceller.controllers.delete(requestId)
-      // Re-evaluate visible regions after abort so panned-back regions get re-fetched.
-      if (controller.signal.aborted && !this.isRemoved) {
-        this.invalidate()
-      }
-    }
+    const fetcher = new RegionFetcher({
+      zarrStore: this.zarrStore,
+      dimIndices: this.dimIndices,
+      levels: this.levels,
+      projection: this.projection,
+      xyLimits: this.xyLimits,
+      latIsAscending: this.latIsAscending,
+      fixedDataScale: this.fixedDataScale,
+      regionCache: this.regionCache,
+      requestCanceller: this.requestCanceller,
+      loadingDebouncer: this.loadingDebouncer,
+      getActiveLevel: () => this.activeLevel,
+      getSelectorVersion: () => this.selectorVersion,
+      getBandNames: () => this.bandNames,
+      isRemoved: () => this.isRemoved,
+      getRegionBounds: (regionX, regionY, levelMeta) =>
+        this.getRegionBounds(regionX, regionY, levelMeta),
+      computeRegionMercatorBounds: (bounds) =>
+        this.computeRegionMercatorBounds(bounds),
+      createRegionGeometry: (regionX, regionY, region) =>
+        this.createRegionGeometry(regionX, regionY, region),
+      invalidate: this.invalidate,
+    })
+    await fetcher.fetchRegions(regions)
   }
 
   update(map: MapLike, gl: WebGL2RenderingContext): void {

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -141,6 +141,9 @@ export class RegionRenderer {
 
   // Cached WebGL context for use in setSelector
   private cachedGl: WebGL2RenderingContext | null = null
+  // Whether the active shader samples per-band textures instead of the main
+  // texture. Owned by ZarrLayer, which decides the shader variant.
+  private rendersFromBandTextures: boolean = false
   // Track current projection for Mapbox's direct globe render path.
   private isGlobeProjection: boolean = false
   // Fixed data scale for normalization (set at initialization, passed from ZarrLayer)
@@ -805,6 +808,7 @@ export class RegionRenderer {
       getActiveLevel: () => this.activeLevel,
       getSelectorVersion: () => this.selectorVersion,
       getBandNames: () => this.bandNames,
+      usesBandTextures: () => this.rendersFromBandTextures,
       isRemoved: () => this.isRemoved,
       getRegionBounds: (regionX, regionY, levelMeta) =>
         this.getRegionBounds(regionX, regionY, levelMeta),
@@ -1096,6 +1100,20 @@ export class RegionRenderer {
 
   setLoadingCallback(callback: LoadingStateCallback | undefined): void {
     setLoadingCallbackUtil(this.loadingManager, callback)
+  }
+
+  /**
+   * Tell the renderer which texture the shader will sample. Band-sampling
+   * shaders skip the interleaved channel copy that feeds the main texture.
+   * Regions fetched under the previous setting keep their old layout until
+   * they are refetched, so bump the selector version to refresh them.
+   */
+  setRendersFromBandTextures(active: boolean): void {
+    if (this.rendersFromBandTextures === active) return
+    this.rendersFromBandTextures = active
+    this.selectorVersion++
+    this.lastViewportHash = ''
+    this.invalidate()
   }
 
   private computeMercatorBoundsFromProjection(): MercatorBounds {

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -51,12 +51,7 @@ import {
   getVisibleRegions,
   selectLevelForZoom,
 } from './region-math'
-import {
-  RegionCache,
-  createRegionState,
-  isRegionValid,
-  makeRegionKey,
-} from './region-cache'
+import { RegionCache, isRegionValid, makeRegionKey } from './region-cache'
 import { RegionFetcher } from './region-fetcher'
 import { LevelLoader } from './level-loader'
 import { createHybridMesh } from './mesh-reprojector'
@@ -68,11 +63,13 @@ import {
   createLoadingManager,
   createChunkLoadingDebouncer,
   cancelAllRequests,
-  hasActiveRequests,
   setLoadingCallback as setLoadingCallbackUtil,
   emitLoadingState as emitLoadingStateUtil,
 } from './region-utils'
-import { setupBandTextureUniforms, uploadDataTexture } from './render-helpers'
+import {
+  ensureRegionGpuResources,
+  setupBandTextureUniforms,
+} from './render-helpers'
 import { renderRegion, type RenderableRegion } from './renderable-region'
 
 export class RegionRenderer {
@@ -405,23 +402,6 @@ export class RegionRenderer {
     regionY: number
   ): string {
     return makeRegionKey(levelIndex, regionX, regionY)
-  }
-
-  /**
-   * Create a new region state entry.
-   */
-  private createRegionState(
-    levelIndex: number,
-    regionX: number,
-    regionY: number
-  ): RegionState {
-    return createRegionState(
-      levelIndex,
-      regionX,
-      regionY,
-      this.latIsAscending,
-      this.selectorVersion
-    )
   }
 
   /**
@@ -982,49 +962,6 @@ export class RegionRenderer {
    * for the ECEF vertex shader path. Render-only fields are set here instead of
    * cached on RegionState, so projection toggles have no stale state.
    */
-  private ensureRegionGpuResources(
-    gl: WebGL2RenderingContext,
-    region: RegionState
-  ): boolean {
-    if (!region.data || !region.vertexArr || !region.pixCoordArr) return false
-
-    if (!region.texture) region.texture = gl.createTexture()
-    if (!region.texture) return false
-    if (!region.textureUploaded) {
-      const result = uploadDataTexture(gl, {
-        texture: region.texture,
-        data: region.data,
-        width: region.width,
-        height: region.height,
-        channels: region.channels,
-        configured: false,
-      })
-      region.textureUploaded = result.uploaded
-    }
-
-    if (!region.vertexBuffer) {
-      region.vertexBuffer = gl.createBuffer()
-      gl.bindBuffer(gl.ARRAY_BUFFER, region.vertexBuffer)
-      gl.bufferData(gl.ARRAY_BUFFER, region.vertexArr, gl.STATIC_DRAW)
-    }
-    if (!region.pixCoordBuffer) {
-      region.pixCoordBuffer = gl.createBuffer()
-      gl.bindBuffer(gl.ARRAY_BUFFER, region.pixCoordBuffer)
-      gl.bufferData(gl.ARRAY_BUFFER, region.pixCoordArr, gl.STATIC_DRAW)
-    }
-    if (region.useIndexedMesh && region.indexArr && !region.indexBuffer) {
-      region.indexBuffer = gl.createBuffer()
-      gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, region.indexBuffer)
-      gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, region.indexArr, gl.STATIC_DRAW)
-    }
-    return !!(
-      region.textureUploaded &&
-      region.vertexBuffer &&
-      region.pixCoordBuffer &&
-      (!region.useIndexedMesh || region.indexBuffer)
-    )
-  }
-
   private regionToRenderable(
     region: RegionState,
     useDirectEcef: boolean = false
@@ -1078,7 +1015,7 @@ export class RegionRenderer {
 
     // Render each loaded region using unified path
     for (const region of this.getLoadedRegions()) {
-      if (!this.ensureRegionGpuResources(gl, region)) continue
+      if (!ensureRegionGpuResources(gl, region)) continue
       renderRegion(
         gl,
         shaderProgram,
@@ -1123,7 +1060,7 @@ export class RegionRenderer {
     }
 
     return this.getLoadedRegions()
-      .filter((region) => this.ensureRegionGpuResources(gl, region))
+      .filter((region) => ensureRegionGpuResources(gl, region))
       .map((region) => ({
         texture: region.texture!,
         vertexBuffer: region.vertexBuffer!,

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -415,8 +415,8 @@ export class RegionRenderer {
 
   /**
    * Get uniforms for rendering with scale/offset disabled.
-   * Untiled mode applies per-level scale/offset in JS (in fetchRegion),
-   * so we tell the shader to skip its scale/offset application.
+   * Per-level scale/offset is applied in JS while a region is fetched, so the
+   * shader is told to skip its own scale/offset application.
    */
   private getUniformsForRender(contextUniforms: RenderContext['uniforms']) {
     return {
@@ -449,11 +449,6 @@ export class RegionRenderer {
   }
 
   /**
-   * Get fallback regions from other levels that are protected from eviction.
-   * These were visible before or during level transitions and provide
-   * coverage while the current level loads.
-   */
-  /**
    * The band textures the active shader samples, or undefined when it reads
    * the main texture. Readiness and uploads must agree on this.
    */
@@ -461,6 +456,11 @@ export class RegionRenderer {
     return this.rendersFromBandTextures ? this.bandNames : undefined
   }
 
+  /**
+   * Get fallback regions from other levels that are protected from eviction.
+   * These were visible before or during level transitions and provide
+   * coverage while the current level loads.
+   */
   private getProtectedFallbackRegions(): RegionState[] {
     const fallbacks: RegionState[] = []
     for (const region of this.regionCache.values()) {

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -45,7 +45,7 @@ import {
   type MercatorBounds,
   type XYLimits,
 } from './map-utils'
-import { loadDimensionValues, normalizeSelector, getBands } from './zarr-utils'
+import { normalizeSelector, getBands } from './zarr-utils'
 import { interleaveBands, normalizeDataForTexture } from './webgl-utils'
 import type { ZarrRenderer, ShaderProgram } from './zarr-renderer'
 import { renderMapboxTile } from './mapbox-tile-renderer'
@@ -70,6 +70,11 @@ import type {
   QueryLevelSnapshot,
   RegionState,
 } from './region-state'
+import {
+  buildChannelCombinations,
+  buildSliceArgsForSelector,
+  type DimensionValuesCache,
+} from './selector-resolution'
 import { createHybridMesh } from './mesh-reprojector'
 import {
   type RequestCanceller,
@@ -142,9 +147,7 @@ export class RegionRenderer {
   )
 
   // Dimension values cache (supports numeric and string coordinate arrays)
-  private dimensionValues: {
-    [key: string]: Float64Array | number[] | string[]
-  } = {}
+  private dimensionValues: DimensionValuesCache = {}
 
   // Region-based loading (for multi-level datasets with chunking/sharding)
   // Single unified cache with LRU eviction - keys include level index (e.g., "2:0,0")
@@ -669,32 +672,6 @@ export class RegionRenderer {
   }
 
   /**
-   * Build all index combinations from multi-value dimensions.
-   * Returns cartesian product of all dimension value arrays.
-   */
-  private buildChannelCombinations(
-    multiValueDims: Array<{ values: number[]; labels: (number | string)[] }>
-  ): { combinations: number[][]; labelCombinations: (number | string)[][] } {
-    let combinations: number[][] = [[]]
-    let labelCombinations: (number | string)[][] = [[]]
-
-    for (const { values, labels } of multiValueDims) {
-      const nextCombos: number[][] = []
-      const nextLabels: (number | string)[][] = []
-      for (let idx = 0; idx < values.length; idx++) {
-        for (let c = 0; c < combinations.length; c++) {
-          nextCombos.push([...combinations[c], values[idx]])
-          nextLabels.push([...labelCombinations[c], labels[idx]])
-        }
-      }
-      combinations = nextCombos
-      labelCombinations = nextLabels
-    }
-
-    return { combinations, labelCombinations }
-  }
-
-  /**
    * Find candidate regions by forward-transforming viewport edges to source CRS
    * and using grid index math to find overlapping region indices.
    *
@@ -1002,28 +979,6 @@ export class RegionRenderer {
     }
   }
 
-  /**
-   * Classify a dimension by its name.
-   * Used to identify spatial (lat/lon) vs non-spatial dimensions.
-   */
-  private classifyDimension(dimKey: string): 'lon' | 'lat' | 'time' | 'other' {
-    const key = dimKey.toLowerCase()
-    if (key === 'lon' || key === 'x' || key === 'lng' || key.includes('lon')) {
-      return 'lon'
-    }
-    if (key === 'lat' || key === 'y' || key.includes('lat')) {
-      return 'lat'
-    }
-    if (key.includes('time')) {
-      return 'time'
-    }
-    return 'other'
-  }
-
-  /**
-   * Build slice arguments from a selector for all dimensions.
-   * Shared logic used by both display (buildBaseSliceArgs) and queries (fetchDataForSelector).
-   */
   private async buildSliceArgsForSelector(
     selector: NormalizedSelector,
     options: {
@@ -1055,102 +1010,23 @@ export class RegionRenderer {
       labels: (number | string)[]
     }>
   }> {
-    const { array } = options
-
-    const sliceArgs: (number | zarr.Slice)[] = new Array(
-      array.shape.length
-    ).fill(0)
-
-    const multiValueDims: Array<{
-      dimIndex: number
-      dimName: string
-      values: number[]
-      labels: (number | string)[]
-    }> = []
-
-    const dimNames = Object.keys(this.dimIndices)
-
-    for (const dimName of dimNames) {
-      const dimInfo = this.dimIndices[dimName]
-      const dimType = this.classifyDimension(dimName)
-
-      if (dimType === 'lon') {
-        if (options.spatialBounds) {
-          sliceArgs[dimInfo.index] = zarr.slice(
-            options.spatialBounds.minX,
-            options.spatialBounds.maxX
-          )
-        } else {
-          sliceArgs[dimInfo.index] = options.includeSpatialSlices
-            ? zarr.slice(0, array.shape[dimInfo.index] ?? 0)
-            : 0
-        }
-      } else if (dimType === 'lat') {
-        if (options.spatialBounds) {
-          sliceArgs[dimInfo.index] = zarr.slice(
-            options.spatialBounds.minY,
-            options.spatialBounds.maxY
-          )
-        } else {
-          sliceArgs[dimInfo.index] = options.includeSpatialSlices
-            ? zarr.slice(0, array.shape[dimInfo.index] ?? 0)
-            : 0
-        }
-      } else {
-        // Non-spatial dimension: resolve selector value
-        const selectionSpec =
-          selector[dimName] ||
-          (dimType === 'time' ? selector['time'] : undefined)
-
-        if (selectionSpec !== undefined) {
-          const selectionValue = selectionSpec.selected
-          const selectionType = selectionSpec.type
-
-          // Check for multi-value selector
-          if (
-            options.trackMultiValue &&
-            Array.isArray(selectionValue) &&
-            selectionValue.length > 1
-          ) {
-            const resolvedIndices: number[] = []
-            const labelValues: (number | string)[] = []
-            for (const val of selectionValue) {
-              const idx = await this.resolveSelectionIndex(
-                dimName,
-                dimInfo,
-                val,
-                selectionType
-              )
-              resolvedIndices.push(idx)
-              labelValues.push(val)
-            }
-            multiValueDims.push({
-              dimIndex: dimInfo.index,
-              dimName,
-              values: resolvedIndices,
-              labels: labelValues,
-            })
-            sliceArgs[dimInfo.index] = resolvedIndices[0]
-          } else {
-            // Single value (or first value if array)
-            const primaryValue = Array.isArray(selectionValue)
-              ? selectionValue[0]
-              : selectionValue
-
-            sliceArgs[dimInfo.index] = await this.resolveSelectionIndex(
-              dimName,
-              dimInfo,
-              primaryValue,
-              selectionType
-            )
-          }
-        } else {
-          sliceArgs[dimInfo.index] = 0
-        }
-      }
-    }
-
-    return { sliceArgs, multiValueDims }
+    const coordLevelIndex =
+      this.activeLevel?.index ??
+      this.loadingLevelIndex ??
+      this.desiredLevelIndex ??
+      0
+    return buildSliceArgsForSelector(
+      {
+        zarrStore: this.zarrStore,
+        dimIndices: this.dimIndices,
+        levels: this.levels,
+        isMultiscale: this.isMultiscale,
+        dimensionValues: this.dimensionValues,
+        coordLevelIndex,
+      },
+      selector,
+      options
+    )
   }
 
   /**
@@ -1418,8 +1294,9 @@ export class RegionRenderer {
       const currentLevel = this.levels[snapshot.index]
       const fillValue = currentLevel?.fillValue ?? desc.fill_value
 
-      const { combinations: channelCombinations } =
-        this.buildChannelCombinations(snapshot.baseMultiValueDims)
+      const { combinations: channelCombinations } = buildChannelCombinations(
+        snapshot.baseMultiValueDims
+      )
       const numChannels = channelCombinations.length || 1
 
       // Fetch data for all channels
@@ -2203,96 +2080,6 @@ export class RegionRenderer {
     emitLoadingStateUtil(this.loadingManager)
   }
 
-  private async resolveSelectionIndex(
-    dimName: string,
-    dimInfo: {
-      index: number
-      name: string
-      array: zarr.Array<zarr.DataType> | null
-    },
-    value: number | string | [number, number] | undefined,
-    type?: 'index' | 'value'
-  ): Promise<number> {
-    if (type === 'index') {
-      return typeof value === 'number' ? value : 0
-    }
-
-    if (typeof value !== 'number' && typeof value !== 'string') {
-      return 0
-    }
-
-    // Multiscale pyramids (tiled and untiled alike) keep their non-spatial
-    // coordinate arrays inside each level directory (e.g. "0/month"), not at
-    // the store root. ZarrStore preloads those from the level-0 directory into
-    // `coordinates`, so prefer them — opening the same arrays at the root (as
-    // the fallback below does) would 404. The fallback covers single-level
-    // datasets, whose coordinate arrays live at the root and aren't preloaded.
-    const storeCoords = this.zarrStore.coordinates[dimName] as
-      | (number | string)[]
-      | undefined
-    if (storeCoords && storeCoords.length > 0) {
-      const idx = storeCoords.indexOf(value)
-      if (idx >= 0) return idx
-      // Value not present in the preloaded coordinate array: treat a numeric
-      // selector as a direct index.
-      return typeof value === 'number' ? value : 0
-    }
-
-    if (!this.zarrStore.root) {
-      return typeof value === 'number' ? value : 0
-    }
-
-    // Multiscale pyramids keep per-dimension coordinate arrays under per-level
-    // paths (e.g. `0/band/c/0`), not at the root. Passing `null` here resolves
-    // the coordinate array from the root, which 404s for those datasets; the
-    // catch below then falls back to index 0 for every selector value. An RGB
-    // selection (red/green/blue by name) therefore collapses all three channels
-    // to band 0 and renders greyscale. Resolve the in-flight level's path
-    // instead, gated on `isMultiscale` so single-level datasets (coordinates at
-    // root) are unaffected. `loadLevel` calls `buildSliceArgsForSelector`
-    // (and so this) before committing `activeLevel`, so fall through
-    // activeLevel.index -> loadingLevelIndex -> desiredLevelIndex -> 0 to use
-    // the level the in-flight load is actually targeting.
-    let levelInfo: string | null = null
-    if (this.isMultiscale && this.levels.length > 0) {
-      const rawLevelIndex =
-        this.activeLevel?.index ??
-        this.loadingLevelIndex ??
-        this.desiredLevelIndex ??
-        0
-      const safeIdx = Math.max(
-        0,
-        Math.min(rawLevelIndex, this.levels.length - 1)
-      )
-      levelInfo = this.levels[safeIdx]?.asset ?? null
-    }
-
-    try {
-      const coords = await loadDimensionValues(
-        this.dimensionValues,
-        levelInfo,
-        dimInfo,
-        this.zarrStore.root,
-        this.zarrStore.version
-      )
-      this.dimensionValues[dimName] = coords
-
-      const coordIdx = (coords as (number | string)[]).indexOf(value)
-      if (coordIdx >= 0) return coordIdx
-      throw new Error(
-        `[ZarrLayer] Selector value '${value}' not found in coordinate array for dimension '${dimName}'. ` +
-          `Available values: [${(coords as (number | string)[])
-            .slice(0, 10)
-            .join(', ')}${coords.length > 10 ? ', ...' : ''}]. ` +
-          `Use { selected: <index>, type: 'index' } to select by array index instead.`
-      )
-    } catch (err) {
-      console.debug(`Could not resolve coordinate for '${dimName}':`, err)
-    }
-
-    return typeof value === 'number' ? value : 0
-  }
-
   /**
    * Unified method to fetch query data for either point or region queries.
    * Handles multi-value dimensions and channel combinations.
@@ -2327,7 +2114,7 @@ export class RegionRenderer {
       const {
         combinations: channelCombinations,
         labelCombinations: channelLabelCombinations,
-      } = this.buildChannelCombinations(multiValueDims)
+      } = buildChannelCombinations(multiValueDims)
       const numChannels = channelCombinations.length || 1
       const multiValueDimNames = multiValueDims.map((d) => d.dimName)
       const getOpts = signal ? { signal } : undefined

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -521,6 +521,8 @@ export class RegionRenderer {
     region.wgs84Bounds = null
     region.indexArr = null
     region.useIndexedMesh = false
+    // Whatever this produces is newer than the buffers already on the GPU.
+    region.geometryUploaded = false
 
     if (
       !this.projection.def ||
@@ -532,9 +534,9 @@ export class RegionRenderer {
 
     const geoBounds = this.getRegionBounds(regionX, regionY, region.levelMeta)
 
-    if (!region.mercatorBounds) {
-      region.mercatorBounds = this.computeRegionMercatorBounds(geoBounds)
-    }
+    // Recomputed alongside the mesh: both derive from geoBounds, so keeping a
+    // previously computed value would pair a new mesh with old shader bounds.
+    region.mercatorBounds = this.computeRegionMercatorBounds(geoBounds)
 
     // Generate a source-projected mesh via proj4. CPU transforms source CRS to
     // WGS84, then encodes region-local Mercator deltas for the shader.

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -58,6 +58,7 @@ import {
   makeRegionKey,
 } from './region-cache'
 import { RegionFetcher } from './region-fetcher'
+import { LevelLoader } from './level-loader'
 import { createHybridMesh } from './mesh-reprojector'
 import {
   type RequestCanceller,
@@ -77,21 +78,20 @@ import { renderRegion, type RenderableRegion } from './renderable-region'
 export class RegionRenderer {
   isMultiscale: boolean = false
 
-  // The single committed snapshot. All per-level state (array, dims, slice
-  // args) is swapped atomically through `loadLevel()`; nothing else mutates
-  // these fields.
-  private activeLevel: LevelRuntime | null = null
-  // Monotonic id stamped by each `loadLevel` call. Async loads check this
-  // before committing — a bump invalidates older pending work.
-  private loadToken: number = 0
-  // Target level requested by zoom/init. `update()` writes this; `loadLevel`
-  // reads it to re-target if a zoom change happened mid-load.
-  private desiredLevelIndex: number = 0
-  // Target of the currently-running `loadLevel`, or null when idle. Used
-  // by `update()` to dedupe: if we're already loading the target level,
-  // don't restart the fetch every frame (ZarrLayer.prerender calls
-  // update() once per frame, so without this we'd never commit).
-  private loadingLevelIndex: number | null = null
+  private levelLoader: LevelLoader
+
+  private get activeLevel(): LevelRuntime | null {
+    return this.levelLoader.active
+  }
+  private get desiredLevelIndex(): number {
+    return this.levelLoader.desiredIndex
+  }
+  private set desiredLevelIndex(levelIndex: number) {
+    this.levelLoader.desiredIndex = levelIndex
+  }
+  private get loadingLevelIndex(): number | null {
+    return this.levelLoader.loadingIndex
+  }
 
   // Bounds
   private mercatorBounds: MercatorBounds | null = null
@@ -157,6 +157,69 @@ export class RegionRenderer {
     this.bandNames = getBands(variable, selector)
     this.invalidate = invalidate
     this.fixedDataScale = fixedDataScale
+    this.levelLoader = new LevelLoader({
+      isMultiscale: () => this.isMultiscale,
+      getLevelCount: () => this.levels.length,
+      resolveArray: async (levelIndex, reuse) => {
+        const existing = this.activeLevel
+        const canReuseArray =
+          reuse && existing !== null && existing.index === levelIndex
+        if (canReuseArray) {
+          return {
+            zarrArray: existing.zarrArray,
+            width: existing.width,
+            height: existing.height,
+            regionSize: existing.regionSize,
+            reusedArray: true,
+          }
+        }
+        const zarrArray = this.isMultiscale
+          ? await (async () => {
+              await this.ensureLevelMetadata(levelIndex)
+              return this.zarrStore.getLevelArray(this.levels[levelIndex].asset)
+            })()
+          : await this.zarrStore.getArray()
+        const width = zarrArray.shape[this.dimIndices.lon.index]
+        const height = zarrArray.shape[this.dimIndices.lat.index]
+        return {
+          zarrArray,
+          width,
+          height,
+          regionSize: this.getRegionSize(zarrArray) ?? [height, width],
+          reusedArray: false,
+        }
+      },
+      buildSliceArgs: async (selectorSnapshot, array, coordLevelIndex) => {
+        const { sliceArgs, multiValueDims } =
+          await this.buildSliceArgsForSelector(
+            selectorSnapshot,
+            {
+              includeSpatialSlices: false,
+              trackMultiValue: true,
+              array,
+            },
+            coordLevelIndex
+          )
+        return {
+          baseSliceArgs: sliceArgs,
+          baseMultiValueDims: multiValueDims,
+        }
+      },
+      getSelector: () => this.selector,
+      isRemoved: () => this.isRemoved,
+      onCancelInflight: () => {
+        if (this.requestCanceller.controllers.size > 0) {
+          cancelAllRequests(this.requestCanceller)
+          this.loadingDebouncer.hide()
+        }
+      },
+      onNewArrayCommitted: () => this.resetVisibleRegions(),
+      invalidate: this.invalidate,
+      getAssetLabel: (levelIndex) =>
+        this.isMultiscale
+          ? this.levels[levelIndex]?.asset ?? String(levelIndex)
+          : 'single-level',
+    })
   }
 
   async initialize(): Promise<void> {
@@ -586,7 +649,8 @@ export class RegionRenderer {
        * a snapshot of the active array for query/render paths.
        */
       array: zarr.Array<zarr.DataType>
-    }
+    },
+    explicitCoordLevelIndex?: number
   ): Promise<{
     sliceArgs: (number | zarr.Slice)[]
     multiValueDims: Array<{
@@ -597,6 +661,7 @@ export class RegionRenderer {
     }>
   }> {
     const coordLevelIndex =
+      explicitCoordLevelIndex ??
       this.activeLevel?.index ??
       this.loadingLevelIndex ??
       this.desiredLevelIndex ??
@@ -811,134 +876,11 @@ export class RegionRenderer {
     this.updateVisibleRegions(map, gl)
   }
 
-  /**
-   * Unified level load: handles initial load, zoom-driven switch, and
-   * selector-driven slice-args rebuild. Builds a `LevelRuntime` off to
-   * the side and swaps it into `this.activeLevel` atomically, so readers
-   * never see a half-committed level.
-   *
-   * `reuseArray` reuses the current committed array/dims — used by
-   * `setSelector` to rebuild slice args without refetching. `loadToken`
-   * acts as a cancellation token: any load whose token is stale at
-   * commit time drops its result.
-   */
-  private async loadLevel(
+  private loadLevel(
     levelIndex: number,
-    { reuseArray = false }: { reuseArray?: boolean } = {}
+    options: { reuseArray?: boolean } = {}
   ): Promise<void> {
-    if (this.isMultiscale && this.levels.length > 0) {
-      if (levelIndex < 0 || levelIndex >= this.levels.length) return
-    } else if (levelIndex !== 0) {
-      return
-    }
-
-    // Dedupe: an in-flight load for the same target is already on it.
-    // A selector rebuild (`reuseArray`) intentionally supersedes.
-    if (this.loadingLevelIndex === levelIndex && !reuseArray) {
-      return
-    }
-
-    const token = ++this.loadToken
-    // Snapshot `this.selector` so we can detect a concurrent `setSelector`
-    // that arrived after `buildSliceArgsForSelector` resolved; committing
-    // old slice args with a new selector would leak stale data.
-    const selectorSnapshot = this.selector
-    this.loadingLevelIndex = levelIndex
-
-    // Cancel any in-flight region fetches — they were tied to the old
-    // level's array/dims (or old selector) and can't be reused.
-    if (this.requestCanceller.controllers.size > 0) {
-      cancelAllRequests(this.requestCanceller)
-      this.loadingDebouncer.hide()
-    }
-
-    try {
-      const existing = this.activeLevel
-      const canReuseArray =
-        reuseArray && existing !== null && existing.index === levelIndex
-
-      let newArray: zarr.Array<zarr.DataType>
-      let newWidth: number
-      let newHeight: number
-      let newRegionSize: [number, number]
-
-      if (canReuseArray) {
-        newArray = existing!.zarrArray
-        newWidth = existing!.width
-        newHeight = existing!.height
-        newRegionSize = existing!.regionSize
-      } else {
-        if (this.isMultiscale) {
-          await this.ensureLevelMetadata(levelIndex)
-          const level = this.levels[levelIndex]
-          newArray = await this.zarrStore.getLevelArray(level.asset)
-        } else {
-          newArray = await this.zarrStore.getArray()
-        }
-        newWidth = newArray.shape[this.dimIndices.lon.index]
-        newHeight = newArray.shape[this.dimIndices.lat.index]
-        const detected = this.getRegionSize(newArray)
-        newRegionSize = detected ?? [newHeight, newWidth]
-      }
-
-      const { sliceArgs, multiValueDims } =
-        await this.buildSliceArgsForSelector(selectorSnapshot, {
-          includeSpatialSlices: false,
-          trackMultiValue: true,
-          array: newArray,
-        })
-
-      const targetStillDesired =
-        reuseArray ||
-        !this.isMultiscale ||
-        levelIndex === this.desiredLevelIndex
-
-      // Drop on the floor if anything raced past us: a newer load (or
-      // dispose) bumped the token, the zoom target moved on, or
-      // `setSelector` replaced the selector we built slice args against.
-      if (
-        token !== this.loadToken ||
-        this.isRemoved ||
-        this.selector !== selectorSnapshot ||
-        !targetStillDesired
-      ) {
-        this.invalidate()
-        return
-      }
-
-      // Atomic commit — one reference swap replaces all per-level state.
-      this.activeLevel = {
-        index: levelIndex,
-        zarrArray: newArray,
-        width: newWidth,
-        height: newHeight,
-        regionSize: newRegionSize,
-        baseSliceArgs: sliceArgs,
-        baseMultiValueDims: multiValueDims,
-      }
-
-      // Don't clear the region cache on level changes — older-level
-      // regions serve as fallback rendering while the new level's
-      // regions load, and the LRU (`evictOldRegions`) disposes them
-      // properly once they're no longer protected by `visibleRegionKeys`.
-      // Bare `.clear()` here would leak WebGL textures/buffers.
-      if (!canReuseArray) {
-        this.resetVisibleRegions()
-      }
-
-      this.invalidate()
-    } catch (err) {
-      if (token === this.loadToken) {
-        const assetLabel = this.isMultiscale
-          ? this.levels[levelIndex]?.asset ?? String(levelIndex)
-          : 'single-level'
-        console.error(`Failed to load level ${assetLabel}:`, err)
-      }
-    } finally {
-      if (token === this.loadToken) {
-        this.loadingLevelIndex = null
-      }
-    }
+    return this.levelLoader.loadLevel(levelIndex, options)
   }
 
   private selectLevelForZoom(mapZoom: number): number {
@@ -1205,13 +1147,10 @@ export class RegionRenderer {
 
   dispose(gl: WebGL2RenderingContext | WebGLRenderingContext): void {
     this.isRemoved = true
-    // Bump so any pending `loadLevel` drops its result on commit.
-    this.loadToken++
-    this.loadingLevelIndex = null
+    this.levelLoader.dispose()
     cancelAllRequests(this.requestCanceller)
     // Clean up region caches
     this.clearRegionCache(gl)
-    this.activeLevel = null
     this.projection = createProjectionContext({
       crs: 'EPSG:4326',
       proj4def: null,

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -493,7 +493,6 @@ export class RegionRenderer {
   private createRegionGeometry(
     regionX: number,
     regionY: number,
-    gl: WebGL2RenderingContext,
     region: RegionState
   ): void {
     // Guard: can't create geometry without dimension info
@@ -589,28 +588,6 @@ export class RegionRenderer {
     region.wgs84Bounds = meshResult.wgs84Bounds
     region.useIndexedMesh = true
     region.vertexCount = region.indexArr.length
-
-    // Create/update buffers
-    if (!region.vertexBuffer) {
-      region.vertexBuffer = gl.createBuffer()
-    }
-    if (!region.pixCoordBuffer) {
-      region.pixCoordBuffer = gl.createBuffer()
-    }
-
-    gl.bindBuffer(gl.ARRAY_BUFFER, region.vertexBuffer)
-    gl.bufferData(gl.ARRAY_BUFFER, region.vertexArr, gl.STATIC_DRAW)
-    gl.bindBuffer(gl.ARRAY_BUFFER, region.pixCoordBuffer)
-    gl.bufferData(gl.ARRAY_BUFFER, region.pixCoordArr, gl.STATIC_DRAW)
-
-    // Upload index buffer for adaptive mesh
-    if (region.useIndexedMesh && region.indexArr) {
-      if (!region.indexBuffer) {
-        region.indexBuffer = gl.createBuffer()
-      }
-      gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, region.indexBuffer)
-      gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, region.indexArr, gl.STATIC_DRAW)
-    }
   }
 
   private async buildSliceArgsForSelector(
@@ -782,19 +759,19 @@ export class RegionRenderer {
     }
 
     if (newRegions.length > 0) {
-      this.fetchRegions(newRegions, gl)
+      this.fetchRegions(newRegions)
     }
     if (staleRegions.length > 0) {
-      this.fetchRegions(staleRegions, gl)
+      this.fetchRegions(staleRegions)
     }
+    this.evictOldRegions(gl)
   }
 
   /**
    * Fetch multiple regions with limited concurrency to avoid overwhelming the browser.
    */
   private async fetchRegions(
-    regions: Array<{ regionX: number; regionY: number }>,
-    gl: WebGL2RenderingContext
+    regions: Array<{ regionX: number; regionY: number }>
   ): Promise<void> {
     // Can't fetch without a committed level.
     if (!this.activeLevel) return
@@ -851,7 +828,7 @@ export class RegionRenderer {
       // pressure on the connection pool; throttling fetchRegion calls here
       // just fragments the coalescer's same-tick batch window.
       const fetches = regions.map(({ regionX, regionY }) =>
-        this.fetchRegion(regionX, regionY, gl, snapshot)
+        this.fetchRegion(regionX, regionY, snapshot)
       )
       await Promise.allSettled(fetches)
     }
@@ -860,8 +837,6 @@ export class RegionRenderer {
     if (!hasActiveRequests(this.requestCanceller)) {
       this.loadingDebouncer.hide()
 
-      // Evict old regions if cache is full (LRU via Map insertion order)
-      this.evictOldRegions(gl)
       this.invalidate()
     }
   }
@@ -874,7 +849,6 @@ export class RegionRenderer {
   private async fetchRegion(
     regionX: number,
     regionY: number,
-    gl: WebGL2RenderingContext,
     snapshot: LevelSnapshot
   ): Promise<void> {
     if ((this.activeLevel?.index ?? -1) !== snapshot.index) {
@@ -1055,7 +1029,7 @@ export class RegionRenderer {
       // Check if geometry needs to be (re)created before updating dimensions
       // The adaptive mesh only depends on spatial bounds and dimensions, not the selector
       const needsGeometry =
-        !region.vertexBuffer ||
+        !region.vertexArr ||
         region.width !== actualW ||
         region.height !== actualH
 
@@ -1073,25 +1047,11 @@ export class RegionRenderer {
         regionSize: [...snapshot.regionSize] as [number, number],
       }
 
-      // Create/update main texture for this region
-      if (!region.texture) {
-        region.texture = gl.createTexture()
-      }
-
-      // Upload texture using shared helper
-      const result = uploadDataTexture(gl, {
-        texture: region.texture!,
-        data: region.data!,
-        width: actualW,
-        height: actualH,
-        channels: numChannels,
-        configured: false,
-      })
-      region.textureUploaded = result.uploaded
+      region.textureUploaded = false
 
       // Create geometry only if needed (new region or dimensions changed)
       if (needsGeometry) {
-        this.createRegionGeometry(regionX, regionY, gl, region)
+        this.createRegionGeometry(regionX, regionY, region)
       }
 
       this.invalidate()
@@ -1379,6 +1339,49 @@ export class RegionRenderer {
    * for the ECEF vertex shader path. Render-only fields are set here instead of
    * cached on RegionState, so projection toggles have no stale state.
    */
+  private ensureRegionGpuResources(
+    gl: WebGL2RenderingContext,
+    region: RegionState
+  ): boolean {
+    if (!region.data || !region.vertexArr || !region.pixCoordArr) return false
+
+    if (!region.texture) region.texture = gl.createTexture()
+    if (!region.texture) return false
+    if (!region.textureUploaded) {
+      const result = uploadDataTexture(gl, {
+        texture: region.texture,
+        data: region.data,
+        width: region.width,
+        height: region.height,
+        channels: region.channels,
+        configured: false,
+      })
+      region.textureUploaded = result.uploaded
+    }
+
+    if (!region.vertexBuffer) {
+      region.vertexBuffer = gl.createBuffer()
+      gl.bindBuffer(gl.ARRAY_BUFFER, region.vertexBuffer)
+      gl.bufferData(gl.ARRAY_BUFFER, region.vertexArr, gl.STATIC_DRAW)
+    }
+    if (!region.pixCoordBuffer) {
+      region.pixCoordBuffer = gl.createBuffer()
+      gl.bindBuffer(gl.ARRAY_BUFFER, region.pixCoordBuffer)
+      gl.bufferData(gl.ARRAY_BUFFER, region.pixCoordArr, gl.STATIC_DRAW)
+    }
+    if (region.useIndexedMesh && region.indexArr && !region.indexBuffer) {
+      region.indexBuffer = gl.createBuffer()
+      gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, region.indexBuffer)
+      gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, region.indexArr, gl.STATIC_DRAW)
+    }
+    return !!(
+      region.textureUploaded &&
+      region.vertexBuffer &&
+      region.pixCoordBuffer &&
+      (!region.useIndexedMesh || region.indexBuffer)
+    )
+  }
+
   private regionToRenderable(
     region: RegionState,
     useDirectEcef: boolean = false
@@ -1432,6 +1435,7 @@ export class RegionRenderer {
 
     // Render each loaded region using unified path
     for (const region of this.getLoadedRegions()) {
+      if (!this.ensureRegionGpuResources(gl, region)) continue
       renderRegion(
         gl,
         shaderProgram,
@@ -1457,7 +1461,7 @@ export class RegionRenderer {
         ...context,
         uniforms: this.getUniformsForRender(context.uniforms),
       },
-      regions: this.getRegionStates(),
+      regions: this.getRegionStates(renderer.gl),
     })
   }
 
@@ -1470,30 +1474,32 @@ export class RegionRenderer {
    * Get render states for all loaded regions (for multi-region rendering).
    * Includes previous level regions as fallback during level transitions.
    */
-  private getRegionStates(): RegionRenderState[] {
+  private getRegionStates(gl: WebGL2RenderingContext): RegionRenderState[] {
     if (!(this.activeLevel?.regionSize ?? null)) {
       return []
     }
 
-    return this.getLoadedRegions().map((region) => ({
-      texture: region.texture!,
-      vertexBuffer: region.vertexBuffer!,
-      pixCoordBuffer: region.pixCoordBuffer!,
-      vertexArr: region.vertexArr!,
-      mercatorBounds: region.mercatorBounds!,
-      width: region.width,
-      height: region.height,
-      bandData: region.bandData,
-      bandTextures: region.bandTextures,
-      bandTexturesUploaded: region.bandTexturesUploaded,
-      bandTexturesConfigured: region.bandTexturesConfigured,
-      // Indexed mesh fields for proj4 adaptive mesh
-      indexBuffer: region.indexBuffer ?? undefined,
-      vertexCount: region.vertexCount,
-      useIndexedMesh: region.useIndexedMesh,
-      wgs84Bounds: region.wgs84Bounds ?? undefined,
-      latIsAscending: region.latIsAscending,
-    }))
+    return this.getLoadedRegions()
+      .filter((region) => this.ensureRegionGpuResources(gl, region))
+      .map((region) => ({
+        texture: region.texture!,
+        vertexBuffer: region.vertexBuffer!,
+        pixCoordBuffer: region.pixCoordBuffer!,
+        vertexArr: region.vertexArr!,
+        mercatorBounds: region.mercatorBounds!,
+        width: region.width,
+        height: region.height,
+        bandData: region.bandData,
+        bandTextures: region.bandTextures,
+        bandTexturesUploaded: region.bandTexturesUploaded,
+        bandTexturesConfigured: region.bandTexturesConfigured,
+        // Indexed mesh fields for proj4 adaptive mesh
+        indexBuffer: region.indexBuffer ?? undefined,
+        vertexCount: region.vertexCount,
+        useIndexedMesh: region.useIndexedMesh,
+        wgs84Bounds: region.wgs84Bounds ?? undefined,
+        latIsAscending: region.latIsAscending,
+      }))
   }
 
   dispose(gl: WebGL2RenderingContext | WebGLRenderingContext): void {

--- a/src/region-state.ts
+++ b/src/region-state.ts
@@ -20,6 +20,8 @@ export interface RegionState {
   vertexBuffer: WebGLBuffer | null
   pixCoordBuffer: WebGLBuffer | null
   indexBuffer: WebGLBuffer | null // For adaptive mesh indexed triangles
+  // False whenever the geometry arrays below are newer than the buffers above
+  geometryUploaded: boolean
   // Geometry arrays for this region's quad
   vertexArr: Float32Array | null
   pixCoordArr: Float32Array | null // Texture coordinates for sampling resampled data

--- a/src/region-state.ts
+++ b/src/region-state.ts
@@ -1,0 +1,102 @@
+import type * as zarr from 'zarrita'
+import type { MercatorBounds, Wgs84Bounds } from './map-utils'
+
+/** State for a single region (chunk/shard) in region-based loading */
+export interface RegionState {
+  key: string
+  levelIndex: number
+  regionX: number
+  regionY: number
+  // Data
+  data: Float32Array | null
+  width: number
+  height: number
+  loading: boolean
+  requestId: number | null
+  channels: number
+  // WebGL resources
+  texture: WebGLTexture | null
+  textureUploaded: boolean
+  vertexBuffer: WebGLBuffer | null
+  pixCoordBuffer: WebGLBuffer | null
+  indexBuffer: WebGLBuffer | null // For adaptive mesh indexed triangles
+  // Geometry arrays for this region's quad
+  vertexArr: Float32Array | null
+  pixCoordArr: Float32Array | null // Texture coordinates for sampling resampled data
+  indexArr: Uint32Array | null // Triangle indices for adaptive mesh
+  vertexCount: number // Number of vertices (for triangle strip) or indices (for indexed)
+  useIndexedMesh: boolean // Whether to use indexed triangles (adaptive mesh)
+  // Mercator bounds for this region (for shader uniforms)
+  mercatorBounds: MercatorBounds | null
+  // WGS84 bounds for vertex shader positioning (source-projected path, ECEF globe)
+  wgs84Bounds: Wgs84Bounds | null
+  // Data orientation: true = row 0 is south
+  latIsAscending: boolean
+  // Version tracking for selector changes
+  selectorVersion: number
+  // Multi-band support
+  bandData: Map<string, Float32Array>
+  bandTextures: Map<string, WebGLTexture>
+  bandTexturesUploaded: Set<string>
+  bandTexturesConfigured: Set<string>
+  // Level-specific dimensions for region geometry bounds.
+  // Set from LevelSnapshot during fetch to avoid races with level switching.
+  levelMeta: LevelMeta | null
+}
+
+/** Level-specific dimensions for geometry bounds calculation */
+export type LevelMeta = {
+  width: number
+  height: number
+  regionSize: [number, number]
+  // xyLimits omitted - assumed constant across levels for now.
+  // TODO: If heterogeneous pyramids with per-level bounds are needed,
+  // add xyLimits here and store per-region.
+}
+
+/** Snapshot of level state captured at fetch start to prevent race conditions */
+export interface LevelSnapshot {
+  index: number
+  zarrArray: zarr.Array<zarr.DataType>
+  baseSliceArgs: (number | zarr.Slice)[]
+  baseMultiValueDims: Array<{
+    dimIndex: number
+    dimName: string
+    values: number[]
+    labels: (number | string)[]
+  }>
+  width: number
+  height: number
+  regionSize: [number, number]
+  selectorVersion: number
+  bandNames: string[]
+}
+
+/**
+ * Fully-committed per-level state. Replaces six top-level fields that were
+ * previously mutated independently across `initializeLevel`, `switchToLevel`,
+ * `_initialize`, and `setSelector` — any of which was one `await` away from
+ * a half-commit race.
+ *
+ * `RegionRenderer.activeLevel` is either `null` (nothing loaded) or a fully-
+ * formed runtime; readers never see a partial level.
+ */
+export interface LevelRuntime {
+  index: number
+  zarrArray: zarr.Array<zarr.DataType>
+  width: number
+  height: number
+  regionSize: [number, number]
+  baseSliceArgs: (number | zarr.Slice)[]
+  baseMultiValueDims: Array<{
+    dimIndex: number
+    dimName: string
+    values: number[]
+    labels: (number | string)[]
+  }>
+}
+
+export type QueryLevelSnapshot = Pick<
+  LevelRuntime,
+  'index' | 'zarrArray' | 'width' | 'height'
+>

--- a/src/render-helpers.test.ts
+++ b/src/render-helpers.test.ts
@@ -100,6 +100,55 @@ describe('ensureRegionGpuResources', () => {
     expect(ensureRegionGpuResources(gl, region)).toBe(true)
     expect(gl.createTexture).toHaveBeenCalledTimes(1)
     expect(gl.texImage2D).toHaveBeenCalledTimes(2)
+    // Geometry is untouched by a data-only refresh.
+    expect(gl.bufferData).toHaveBeenCalledTimes(3)
+  })
+
+  it('re-uploads regenerated geometry into the existing buffers', () => {
+    const gl = fakeGl()
+    const region = fetchedRegion()
+    ensureRegionGpuResources(gl, region)
+    const buffers = [
+      region.vertexBuffer,
+      region.pixCoordBuffer,
+      region.indexBuffer,
+    ]
+
+    // A refetch at new dimensions regenerates the mesh: createRegionGeometry
+    // replaces the arrays and clears the flag. Without the re-upload the GPU
+    // would keep the old mesh and draw the new data misaligned against it.
+    const vertexArr = new Float32Array([9, 9, 9, 9, 9, 9, 9, 9])
+    const pixCoordArr = new Float32Array([8, 8, 8, 8, 8, 8, 8, 8])
+    const indexArr = new Uint32Array([2, 1, 0])
+    region.vertexArr = vertexArr
+    region.pixCoordArr = pixCoordArr
+    region.indexArr = indexArr
+    region.geometryUploaded = false
+
+    expect(ensureRegionGpuResources(gl, region)).toBe(true)
+    expect(gl.bufferData).toHaveBeenCalledTimes(6)
+    expect(gl.bufferData.mock.calls.slice(3).map((call) => call[1])).toEqual([
+      vertexArr,
+      pixCoordArr,
+      indexArr,
+    ])
+    // Reused, not reallocated.
+    expect(gl.createBuffer).toHaveBeenCalledTimes(3)
+    expect([
+      region.vertexBuffer,
+      region.pixCoordBuffer,
+      region.indexBuffer,
+    ]).toEqual(buffers)
+    expect(region.geometryUploaded).toBe(true)
+  })
+
+  it('leaves clean geometry alone across frames', () => {
+    const gl = fakeGl()
+    const region = fetchedRegion()
+    ensureRegionGpuResources(gl, region)
+    ensureRegionGpuResources(gl, region)
+    ensureRegionGpuResources(gl, region)
+    expect(gl.bufferData).toHaveBeenCalledTimes(3)
   })
 
   it('skips the index buffer for non-indexed meshes', () => {

--- a/src/render-helpers.test.ts
+++ b/src/render-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { ensureRegionGpuResources } from './render-helpers'
+import { bindBandTextures, ensureRegionGpuResources } from './render-helpers'
 import { createRegionState } from './region-cache'
 import type { RegionState } from './region-state'
 
@@ -8,12 +8,18 @@ import type { RegionState } from './region-state'
  * call ensureRegionGpuResources per frame to create and upload texture and
  * geometry buffers on the drawing context, re-uploading when the data was
  * refreshed (textureUploaded reset by fetch) and doing nothing when complete.
+ * Custom-shader bands take the parallel per-band path in bindBandTextures.
  */
+
+// Texture unit constants matter: bands bind from unit 2 up, in config order.
+const TEXTURE0 = 0x84c0
 
 function fakeGl() {
   let textureCount = 0
   let bufferCount = 0
   return {
+    TEXTURE0,
+    TEXTURE_2D: 0x0de1,
     createTexture: vi.fn(() => ({ tex: ++textureCount })),
     createBuffer: vi.fn(() => ({ buf: ++bufferCount })),
     bindTexture: vi.fn(),
@@ -27,6 +33,9 @@ function fakeGl() {
     createBuffer: ReturnType<typeof vi.fn>
     bufferData: ReturnType<typeof vi.fn>
     texImage2D: ReturnType<typeof vi.fn>
+    bindTexture: ReturnType<typeof vi.fn>
+    texParameteri: ReturnType<typeof vi.fn>
+    activeTexture: ReturnType<typeof vi.fn>
   }
 }
 
@@ -102,5 +111,119 @@ describe('ensureRegionGpuResources', () => {
     expect(ensureRegionGpuResources(gl, region)).toBe(true)
     expect(region.indexBuffer).toBeNull()
     expect(gl.createBuffer).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the index buffer for an indexed mesh whose flag is set', () => {
+    const gl = fakeGl()
+    const region = fetchedRegion()
+
+    expect(ensureRegionGpuResources(gl, region)).toBe(true)
+    expect(region.indexBuffer).not.toBeNull()
+    // A stale indexArr on a non-indexed region must not produce a buffer.
+    const flat = fetchedRegion()
+    flat.useIndexedMesh = false
+    const flatGl = fakeGl()
+    expect(ensureRegionGpuResources(flatGl, flat)).toBe(true)
+    expect(flat.indexBuffer).toBeNull()
+    expect(flatGl.createBuffer).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('bindBandTextures', () => {
+  const bandOptions = (region: RegionState, bands: string[]) => ({
+    bandData: region.bandData,
+    bandTextures: region.bandTextures,
+    bandTexturesUploaded: region.bandTexturesUploaded,
+    bandTexturesConfigured: region.bandTexturesConfigured,
+    customShaderConfig: { bands } as never,
+    width: region.width,
+    height: region.height,
+  })
+
+  function twoBandRegion(): RegionState {
+    const region = fetchedRegion()
+    region.bandData.set('red', new Float32Array([1, 2, 3, 4]))
+    region.bandData.set('green', new Float32Array([5, 6, 7, 8]))
+    return region
+  }
+
+  it('creates, configures, and uploads one texture per band', () => {
+    const gl = fakeGl()
+    const region = twoBandRegion()
+
+    expect(bindBandTextures(gl, bandOptions(region, ['red', 'green']))).toBe(
+      true
+    )
+    expect(gl.createTexture).toHaveBeenCalledTimes(2)
+    expect(gl.texImage2D).toHaveBeenCalledTimes(2)
+    expect(region.bandTextures.size).toBe(2)
+    expect([...region.bandTexturesUploaded]).toEqual(['red', 'green'])
+    expect([...region.bandTexturesConfigured]).toEqual(['red', 'green'])
+    // Bands occupy consecutive units from 2 up, in shader-config order.
+    expect(gl.activeTexture.mock.calls.map(([unit]) => unit)).toEqual([
+      TEXTURE0 + 2,
+      TEXTURE0 + 3,
+    ])
+    // Uploaded in the shader's band order, not insertion order.
+    expect(gl.texImage2D.mock.calls.map((call) => call[8])).toEqual([
+      region.bandData.get('red'),
+      region.bandData.get('green'),
+    ])
+  })
+
+  it('rebinds without re-uploading once every band is resident', () => {
+    const gl = fakeGl()
+    const region = twoBandRegion()
+    bindBandTextures(gl, bandOptions(region, ['red', 'green']))
+
+    expect(bindBandTextures(gl, bandOptions(region, ['red', 'green']))).toBe(
+      true
+    )
+    expect(gl.createTexture).toHaveBeenCalledTimes(2)
+    expect(gl.texImage2D).toHaveBeenCalledTimes(2)
+    expect(gl.texParameteri).toHaveBeenCalledTimes(2 * 4)
+    // Still bound every frame — only the upload is skipped.
+    expect(gl.bindTexture).toHaveBeenCalledTimes(4)
+  })
+
+  it('uploads only the bands that are not yet resident', () => {
+    const gl = fakeGl()
+    const region = twoBandRegion()
+    bindBandTextures(gl, bandOptions(region, ['red']))
+
+    expect(bindBandTextures(gl, bandOptions(region, ['red', 'green']))).toBe(
+      true
+    )
+    expect(gl.texImage2D).toHaveBeenCalledTimes(2)
+    expect(gl.texImage2D.mock.calls[1][8]).toBe(region.bandData.get('green'))
+  })
+
+  it('reports failure and uploads nothing when a band has no data', () => {
+    const gl = fakeGl()
+    const region = twoBandRegion()
+
+    expect(bindBandTextures(gl, bandOptions(region, ['red', 'blue']))).toBe(
+      false
+    )
+    // 'red' still binds before the missing band aborts the loop; 'blue' does
+    // not get a texture, so the caller must skip the draw entirely.
+    expect(region.bandTextures.has('blue')).toBe(false)
+    expect(region.bandTexturesUploaded.has('blue')).toBe(false)
+  })
+
+  it('routes texture creation through ensureTexture when provided', () => {
+    const gl = fakeGl()
+    const region = twoBandRegion()
+    const ensureTexture = vi.fn(() => ({ pooled: true } as WebGLTexture))
+
+    expect(
+      bindBandTextures(gl, {
+        ...bandOptions(region, ['red']),
+        ensureTexture,
+      })
+    ).toBe(true)
+    expect(ensureTexture).toHaveBeenCalledWith('red')
+    expect(gl.createTexture).not.toHaveBeenCalled()
+    expect(region.bandTextures.get('red')).toEqual({ pooled: true })
   })
 })

--- a/src/render-helpers.test.ts
+++ b/src/render-helpers.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ensureRegionGpuResources } from './render-helpers'
+import { createRegionState } from './region-cache'
+import type { RegionState } from './region-state'
+
+/**
+ * The lazy GPU upload contract: fetch leaves only CPU state; the render paths
+ * call ensureRegionGpuResources per frame to create and upload texture and
+ * geometry buffers on the drawing context, re-uploading when the data was
+ * refreshed (textureUploaded reset by fetch) and doing nothing when complete.
+ */
+
+function fakeGl() {
+  let textureCount = 0
+  let bufferCount = 0
+  return {
+    createTexture: vi.fn(() => ({ tex: ++textureCount })),
+    createBuffer: vi.fn(() => ({ buf: ++bufferCount })),
+    bindTexture: vi.fn(),
+    bindBuffer: vi.fn(),
+    bufferData: vi.fn(),
+    texImage2D: vi.fn(),
+    texParameteri: vi.fn(),
+    activeTexture: vi.fn(),
+  } as unknown as WebGL2RenderingContext & {
+    createTexture: ReturnType<typeof vi.fn>
+    createBuffer: ReturnType<typeof vi.fn>
+    bufferData: ReturnType<typeof vi.fn>
+    texImage2D: ReturnType<typeof vi.fn>
+  }
+}
+
+function fetchedRegion(): RegionState {
+  const region = createRegionState(0, 0, 0, false, 0)
+  region.data = new Float32Array([1, 2, 3, 4])
+  region.width = 2
+  region.height = 2
+  region.channels = 1
+  region.vertexArr = new Float32Array(8)
+  region.pixCoordArr = new Float32Array(8)
+  region.indexArr = new Uint32Array([0, 1, 2])
+  region.useIndexedMesh = true
+  region.vertexCount = 3
+  return region
+}
+
+describe('ensureRegionGpuResources', () => {
+  it('returns false while CPU-side state is incomplete', () => {
+    const gl = fakeGl()
+    const region = createRegionState(0, 0, 0, false, 0)
+    expect(ensureRegionGpuResources(gl, region)).toBe(false)
+    expect(gl.createTexture).not.toHaveBeenCalled()
+    expect(gl.createBuffer).not.toHaveBeenCalled()
+  })
+
+  it('creates and uploads texture and buffers on first call', () => {
+    const gl = fakeGl()
+    const region = fetchedRegion()
+
+    expect(ensureRegionGpuResources(gl, region)).toBe(true)
+    expect(region.texture).not.toBeNull()
+    expect(region.textureUploaded).toBe(true)
+    expect(region.vertexBuffer).not.toBeNull()
+    expect(region.pixCoordBuffer).not.toBeNull()
+    expect(region.indexBuffer).not.toBeNull()
+    expect(gl.createTexture).toHaveBeenCalledTimes(1)
+    expect(gl.createBuffer).toHaveBeenCalledTimes(3)
+    expect(gl.texImage2D).toHaveBeenCalledTimes(1)
+    expect(gl.bufferData).toHaveBeenCalledTimes(3)
+  })
+
+  it('is idempotent once resources exist', () => {
+    const gl = fakeGl()
+    const region = fetchedRegion()
+    ensureRegionGpuResources(gl, region)
+
+    expect(ensureRegionGpuResources(gl, region)).toBe(true)
+    expect(gl.createTexture).toHaveBeenCalledTimes(1)
+    expect(gl.createBuffer).toHaveBeenCalledTimes(3)
+    expect(gl.texImage2D).toHaveBeenCalledTimes(1)
+    expect(gl.bufferData).toHaveBeenCalledTimes(3)
+  })
+
+  it('re-uploads the texture after a data refresh without recreating it', () => {
+    const gl = fakeGl()
+    const region = fetchedRegion()
+    ensureRegionGpuResources(gl, region)
+
+    // Fetch wrote new data and reset the flag (selector change refetch).
+    region.textureUploaded = false
+    expect(ensureRegionGpuResources(gl, region)).toBe(true)
+    expect(gl.createTexture).toHaveBeenCalledTimes(1)
+    expect(gl.texImage2D).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips the index buffer for non-indexed meshes', () => {
+    const gl = fakeGl()
+    const region = fetchedRegion()
+    region.useIndexedMesh = false
+    region.indexArr = null
+
+    expect(ensureRegionGpuResources(gl, region)).toBe(true)
+    expect(region.indexBuffer).toBeNull()
+    expect(gl.createBuffer).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/render-helpers.test.ts
+++ b/src/render-helpers.test.ts
@@ -14,13 +14,13 @@ import type { RegionState } from './region-state'
 // Texture unit constants matter: bands bind from unit 2 up, in config order.
 const TEXTURE0 = 0x84c0
 
-function fakeGl() {
+function fakeGl({ failTextures = false }: { failTextures?: boolean } = {}) {
   let textureCount = 0
   let bufferCount = 0
   return {
     TEXTURE0,
     TEXTURE_2D: 0x0de1,
-    createTexture: vi.fn(() => ({ tex: ++textureCount })),
+    createTexture: vi.fn(() => (failTextures ? null : { tex: ++textureCount })),
     createBuffer: vi.fn(() => ({ buf: ++bufferCount })),
     deleteTexture: vi.fn(),
     bindTexture: vi.fn(),
@@ -177,6 +177,89 @@ describe('ensureRegionGpuResources', () => {
     expect(ensureRegionGpuResources(flatGl, flat)).toBe(true)
     expect(flat.indexBuffer).toBeNull()
     expect(flatGl.createBuffer).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('ensureRegionGpuResources with band rendering', () => {
+  function bandRegion(): RegionState {
+    const region = fetchedRegion()
+    region.bandData.set('red', new Float32Array([1, 2, 3, 4]))
+    region.bandData.set('green', new Float32Array([5, 6, 7, 8]))
+    return region
+  }
+
+  it('uploads the band textures the shader will sample', () => {
+    const gl = fakeGl()
+    const region = bandRegion()
+
+    expect(ensureRegionGpuResources(gl, region, ['red', 'green'])).toBe(true)
+    expect([...region.bandTexturesUploaded]).toEqual(['red', 'green'])
+    expect(region.bandTextures.size).toBe(2)
+    // Nothing samples the main texture in this mode.
+    expect(region.texture).toBeNull()
+    expect(region.textureUploaded).toBe(false)
+    expect(gl.createTexture).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports not-ready when a band texture cannot be allocated', () => {
+    const gl = fakeGl({ failTextures: true })
+    const region = bandRegion()
+
+    // Coverage is decided by this result, so a failed band allocation has to
+    // read as undrawable rather than as a covered level.
+    expect(ensureRegionGpuResources(gl, region, ['red', 'green'])).toBe(false)
+  })
+
+  it('reports not-ready when a required band has no data', () => {
+    const gl = fakeGl()
+    const region = bandRegion()
+    expect(ensureRegionGpuResources(gl, region, ['red', 'missing'])).toBe(false)
+  })
+
+  it('releases band textures when switching back to the main texture', () => {
+    const gl = fakeGl()
+    const region = bandRegion()
+    ensureRegionGpuResources(gl, region, ['red', 'green'])
+    const released = [...region.bandTextures.values()]
+
+    // The shader no longer samples bands. bindBandTextures is not called at
+    // all in that mode, so this is the only chance to free them.
+    expect(ensureRegionGpuResources(gl, region)).toBe(true)
+    for (const tex of released) {
+      expect(gl.deleteTexture).toHaveBeenCalledWith(tex)
+    }
+    expect(region.bandTextures.size).toBe(0)
+    expect(region.bandTexturesUploaded.size).toBe(0)
+    expect(region.texture).not.toBeNull()
+  })
+
+  it('releases the main texture when switching to band rendering', () => {
+    const gl = fakeGl()
+    const region = bandRegion()
+    ensureRegionGpuResources(gl, region)
+    const mainTexture = region.texture
+
+    expect(ensureRegionGpuResources(gl, region, ['red', 'green'])).toBe(true)
+    expect(gl.deleteTexture).toHaveBeenCalledWith(mainTexture)
+    expect(region.texture).toBeNull()
+  })
+
+  it('drops bands that leave the set on the same call', () => {
+    const gl = fakeGl()
+    const region = bandRegion()
+    ensureRegionGpuResources(gl, region, ['red', 'green'])
+    const stale = [...region.bandTextures.values()]
+
+    // Same-size swap: a count-based prune would miss this entirely.
+    region.bandData.clear()
+    region.bandData.set('nir', new Float32Array([1, 2, 3, 4]))
+    region.bandData.set('swir', new Float32Array([5, 6, 7, 8]))
+    expect(ensureRegionGpuResources(gl, region, ['nir', 'swir'])).toBe(true)
+
+    for (const tex of stale) {
+      expect(gl.deleteTexture).toHaveBeenCalledWith(tex)
+    }
+    expect([...region.bandTextures.keys()]).toEqual(['nir', 'swir'])
   })
 })
 

--- a/src/render-helpers.test.ts
+++ b/src/render-helpers.test.ts
@@ -22,6 +22,7 @@ function fakeGl() {
     TEXTURE_2D: 0x0de1,
     createTexture: vi.fn(() => ({ tex: ++textureCount })),
     createBuffer: vi.fn(() => ({ buf: ++bufferCount })),
+    deleteTexture: vi.fn(),
     bindTexture: vi.fn(),
     bindBuffer: vi.fn(),
     bufferData: vi.fn(),
@@ -31,6 +32,7 @@ function fakeGl() {
   } as unknown as WebGL2RenderingContext & {
     createTexture: ReturnType<typeof vi.fn>
     createBuffer: ReturnType<typeof vi.fn>
+    deleteTexture: ReturnType<typeof vi.fn>
     bufferData: ReturnType<typeof vi.fn>
     texImage2D: ReturnType<typeof vi.fn>
     bindTexture: ReturnType<typeof vi.fn>
@@ -258,6 +260,41 @@ describe('bindBandTextures', () => {
     // not get a texture, so the caller must skip the draw entirely.
     expect(region.bandTextures.has('blue')).toBe(false)
     expect(region.bandTexturesUploaded.has('blue')).toBe(false)
+  })
+
+  it('releases textures for bands that are no longer requested', () => {
+    const gl = fakeGl()
+    const region = twoBandRegion()
+    bindBandTextures(gl, bandOptions(region, ['red', 'green']))
+    const greenTexture = region.bandTextures.get('green')
+
+    // The selector changed: only 'red' is in the band set now.
+    region.bandData.delete('green')
+    expect(bindBandTextures(gl, bandOptions(region, ['red']))).toBe(true)
+
+    expect(gl.deleteTexture).toHaveBeenCalledWith(greenTexture)
+    expect(region.bandTextures.has('green')).toBe(false)
+    expect(region.bandTexturesUploaded.has('green')).toBe(false)
+    expect(region.bandTexturesConfigured.has('green')).toBe(false)
+    // The retained band keeps its texture and is not re-uploaded.
+    expect(region.bandTextures.has('red')).toBe(true)
+    expect(gl.texImage2D).toHaveBeenCalledTimes(2)
+  })
+
+  it('leaves caller-owned textures alone', () => {
+    const gl = fakeGl()
+    const region = twoBandRegion()
+    const ensureTexture = vi.fn(
+      (name: string) => ({ pooled: name } as unknown as WebGLTexture)
+    )
+    bindBandTextures(gl, {
+      ...bandOptions(region, ['red', 'green']),
+      ensureTexture,
+    })
+
+    bindBandTextures(gl, { ...bandOptions(region, ['red']), ensureTexture })
+    expect(gl.deleteTexture).not.toHaveBeenCalled()
+    expect(region.bandTextures.has('green')).toBe(true)
   })
 
   it('routes texture creation through ensureTexture when provided', () => {

--- a/src/render-helpers.ts
+++ b/src/render-helpers.ts
@@ -78,6 +78,21 @@ export function bindBandTextures(
     ensureTexture,
   } = options
 
+  // Band names track the selector on some datasets, so the set changes as the
+  // user scrubs. Textures for names that are no longer requested would
+  // otherwise sit on the GPU until the region is evicted. Skipped when the
+  // caller owns the textures.
+  if (!ensureTexture && bandTextures.size > customShaderConfig.bands.length) {
+    const wanted = new Set(customShaderConfig.bands)
+    for (const [name, tex] of bandTextures) {
+      if (wanted.has(name)) continue
+      gl.deleteTexture(tex)
+      bandTextures.delete(name)
+      bandTexturesUploaded.delete(name)
+      bandTexturesConfigured.delete(name)
+    }
+  }
+
   let textureUnit = 2
   for (const bandName of customShaderConfig.bands) {
     const data = bandData.get(bandName)

--- a/src/render-helpers.ts
+++ b/src/render-helpers.ts
@@ -236,25 +236,33 @@ export function ensureRegionGpuResources(
     region.textureUploaded = result.uploaded
   }
 
-  if (!region.vertexBuffer) {
-    region.vertexBuffer = gl.createBuffer()
-    gl.bindBuffer(gl.ARRAY_BUFFER, region.vertexBuffer)
-    gl.bufferData(gl.ARRAY_BUFFER, region.vertexArr, gl.STATIC_DRAW)
+  // Buffer objects are reused across re-uploads, so the dirty flag — not the
+  // presence of a buffer — decides whether the GPU has the current mesh. A
+  // region refetched at new dimensions regenerates its arrays, and without
+  // this its data would be drawn against the previous mesh.
+  if (!region.geometryUploaded) {
+    if (!region.vertexBuffer) region.vertexBuffer = gl.createBuffer()
+    if (!region.pixCoordBuffer) region.pixCoordBuffer = gl.createBuffer()
+    if (region.vertexBuffer) {
+      gl.bindBuffer(gl.ARRAY_BUFFER, region.vertexBuffer)
+      gl.bufferData(gl.ARRAY_BUFFER, region.vertexArr, gl.STATIC_DRAW)
+    }
+    if (region.pixCoordBuffer) {
+      gl.bindBuffer(gl.ARRAY_BUFFER, region.pixCoordBuffer)
+      gl.bufferData(gl.ARRAY_BUFFER, region.pixCoordArr, gl.STATIC_DRAW)
+    }
+    if (region.useIndexedMesh && region.indexArr) {
+      if (!region.indexBuffer) region.indexBuffer = gl.createBuffer()
+      if (region.indexBuffer) {
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, region.indexBuffer)
+        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, region.indexArr, gl.STATIC_DRAW)
+      }
+    }
+    region.geometryUploaded = !!(
+      region.vertexBuffer &&
+      region.pixCoordBuffer &&
+      (!region.useIndexedMesh || region.indexBuffer)
+    )
   }
-  if (!region.pixCoordBuffer) {
-    region.pixCoordBuffer = gl.createBuffer()
-    gl.bindBuffer(gl.ARRAY_BUFFER, region.pixCoordBuffer)
-    gl.bufferData(gl.ARRAY_BUFFER, region.pixCoordArr, gl.STATIC_DRAW)
-  }
-  if (region.useIndexedMesh && region.indexArr && !region.indexBuffer) {
-    region.indexBuffer = gl.createBuffer()
-    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, region.indexBuffer)
-    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, region.indexArr, gl.STATIC_DRAW)
-  }
-  return !!(
-    region.textureUploaded &&
-    region.vertexBuffer &&
-    region.pixCoordBuffer &&
-    (!region.useIndexedMesh || region.indexBuffer)
-  )
+  return region.textureUploaded && region.geometryUploaded
 }

--- a/src/render-helpers.ts
+++ b/src/render-helpers.ts
@@ -55,6 +55,9 @@ interface BindBandTexturesOptions {
   ensureTexture?: (bandName: string) => WebGLTexture | null
 }
 
+/** Shared empty list so the no-bands prune allocates nothing per frame. */
+const EMPTY_BANDS: readonly string[] = []
+
 /** The per-band GPU bookkeeping carried on a region. */
 interface BandTextureState {
   bandTextures: Map<string, WebGLTexture>
@@ -62,16 +65,30 @@ interface BandTextureState {
   bandTexturesConfigured: Set<string>
 }
 
-/** Delete every band texture whose name is not in `wanted`. */
+/**
+ * Delete every band texture whose name is not in `wanted`. Runs per region on
+ * every render call, so it exits without allocating in the common case where
+ * the resident set already matches.
+ */
 function pruneBandTextures(
   gl: WebGL2RenderingContext,
-  wanted: Set<string>,
+  wanted: readonly string[],
   state: BandTextureState
 ): void {
-  for (const [name, tex] of state.bandTextures) {
-    if (wanted.has(name)) continue
+  const { bandTextures } = state
+  if (bandTextures.size === 0) return
+  if (
+    bandTextures.size === wanted.length &&
+    wanted.every((name) => bandTextures.has(name))
+  ) {
+    return
+  }
+
+  const keep = new Set(wanted)
+  for (const [name, tex] of bandTextures) {
+    if (keep.has(name)) continue
     gl.deleteTexture(tex)
-    state.bandTextures.delete(name)
+    bandTextures.delete(name)
     state.bandTexturesUploaded.delete(name)
     state.bandTexturesConfigured.delete(name)
   }
@@ -105,7 +122,7 @@ export function bindBandTextures(
   // (red, green -> nir, swir) replaces every name without changing the size.
   // Skipped when the caller owns the textures.
   if (!ensureTexture) {
-    pruneBandTextures(gl, new Set(customShaderConfig.bands), {
+    pruneBandTextures(gl, customShaderConfig.bands, {
       bandTextures,
       bandTexturesUploaded,
       bandTexturesConfigured,
@@ -254,7 +271,7 @@ function ensureBandTextures(
   region: RegionState,
   bands: readonly string[]
 ): boolean {
-  pruneBandTextures(gl, new Set(bands), region)
+  pruneBandTextures(gl, bands, region)
 
   for (const name of bands) {
     const data = region.bandData.get(name)
@@ -321,7 +338,7 @@ export function ensureRegionGpuResources(
     }
     texturesReady = ensureBandTextures(gl, region, requiredBands)
   } else {
-    pruneBandTextures(gl, new Set(), region)
+    pruneBandTextures(gl, EMPTY_BANDS, region)
     if (!region.texture) region.texture = gl.createTexture()
     if (!region.texture) return false
     if (!region.textureUploaded) {

--- a/src/render-helpers.ts
+++ b/src/render-helpers.ts
@@ -324,7 +324,7 @@ export function ensureRegionGpuResources(
   region: RegionState,
   requiredBands?: readonly string[]
 ): boolean {
-  if (!region.data || !region.vertexArr || !region.pixCoordArr) return false
+  if (!region.vertexArr || !region.pixCoordArr) return false
 
   const bandRendering = !!requiredBands && requiredBands.length > 0
   let texturesReady: boolean
@@ -339,6 +339,9 @@ export function ensureRegionGpuResources(
     texturesReady = ensureBandTextures(gl, region, requiredBands)
   } else {
     pruneBandTextures(gl, EMPTY_BANDS, region)
+    // A region fetched for a band-sampling shader has no interleaved copy, so
+    // it stays undrawable here until the refetch that follows the switch.
+    if (!region.data) return false
     if (!region.texture) region.texture = gl.createTexture()
     if (!region.texture) return false
     if (!region.textureUploaded) {

--- a/src/render-helpers.ts
+++ b/src/render-helpers.ts
@@ -7,6 +7,7 @@
 
 import type { ShaderProgram } from './shader-program'
 import type { CustomShaderConfig } from './renderer-types'
+import type { RegionState } from './region-state'
 import { configureDataTexture, getTextureFormats } from './webgl-utils'
 
 /**
@@ -207,4 +208,53 @@ export function uploadDataTexture(
   )
 
   return { configured: true, uploaded: true }
+}
+
+/**
+ * Lazily create and upload a region's GPU resources from its CPU-side state.
+ * Fetch produces only data and geometry arrays; the render paths call this
+ * per frame so uploads happen on the context that is actually drawing.
+ * Returns false while the region isn't renderable yet.
+ */
+export function ensureRegionGpuResources(
+  gl: WebGL2RenderingContext,
+  region: RegionState
+): boolean {
+  if (!region.data || !region.vertexArr || !region.pixCoordArr) return false
+
+  if (!region.texture) region.texture = gl.createTexture()
+  if (!region.texture) return false
+  if (!region.textureUploaded) {
+    const result = uploadDataTexture(gl, {
+      texture: region.texture,
+      data: region.data,
+      width: region.width,
+      height: region.height,
+      channels: region.channels,
+      configured: false,
+    })
+    region.textureUploaded = result.uploaded
+  }
+
+  if (!region.vertexBuffer) {
+    region.vertexBuffer = gl.createBuffer()
+    gl.bindBuffer(gl.ARRAY_BUFFER, region.vertexBuffer)
+    gl.bufferData(gl.ARRAY_BUFFER, region.vertexArr, gl.STATIC_DRAW)
+  }
+  if (!region.pixCoordBuffer) {
+    region.pixCoordBuffer = gl.createBuffer()
+    gl.bindBuffer(gl.ARRAY_BUFFER, region.pixCoordBuffer)
+    gl.bufferData(gl.ARRAY_BUFFER, region.pixCoordArr, gl.STATIC_DRAW)
+  }
+  if (region.useIndexedMesh && region.indexArr && !region.indexBuffer) {
+    region.indexBuffer = gl.createBuffer()
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, region.indexBuffer)
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, region.indexArr, gl.STATIC_DRAW)
+  }
+  return !!(
+    region.textureUploaded &&
+    region.vertexBuffer &&
+    region.pixCoordBuffer &&
+    (!region.useIndexedMesh || region.indexBuffer)
+  )
 }

--- a/src/render-helpers.ts
+++ b/src/render-helpers.ts
@@ -1,8 +1,9 @@
 /**
  * @module render-helpers
  *
- * Shared rendering utilities for both tiled and untiled modes.
- * Handles band texture setup, binding, and geometry buffer binding.
+ * Rendering utilities shared by the region and Mapbox draped-tile paths.
+ * Handles band texture setup, binding, geometry buffer binding, and the lazy
+ * upload of a region's textures and geometry to the GPU.
  */
 
 import type { ShaderProgram } from './shader-program'

--- a/src/render-helpers.ts
+++ b/src/render-helpers.ts
@@ -55,6 +55,28 @@ interface BindBandTexturesOptions {
   ensureTexture?: (bandName: string) => WebGLTexture | null
 }
 
+/** The per-band GPU bookkeeping carried on a region. */
+interface BandTextureState {
+  bandTextures: Map<string, WebGLTexture>
+  bandTexturesUploaded: Set<string>
+  bandTexturesConfigured: Set<string>
+}
+
+/** Delete every band texture whose name is not in `wanted`. */
+function pruneBandTextures(
+  gl: WebGL2RenderingContext,
+  wanted: Set<string>,
+  state: BandTextureState
+): void {
+  for (const [name, tex] of state.bandTextures) {
+    if (wanted.has(name)) continue
+    gl.deleteTexture(tex)
+    state.bandTextures.delete(name)
+    state.bandTexturesUploaded.delete(name)
+    state.bandTexturesConfigured.delete(name)
+  }
+}
+
 /**
  * Bind and upload band textures for a single tile/region.
  * Returns false if any required band data is missing.
@@ -79,18 +101,15 @@ export function bindBandTextures(
   } = options
 
   // Band names track the selector on some datasets, so the set changes as the
-  // user scrubs. Textures for names that are no longer requested would
-  // otherwise sit on the GPU until the region is evicted. Skipped when the
-  // caller owns the textures.
-  if (!ensureTexture && bandTextures.size > customShaderConfig.bands.length) {
-    const wanted = new Set(customShaderConfig.bands)
-    for (const [name, tex] of bandTextures) {
-      if (wanted.has(name)) continue
-      gl.deleteTexture(tex)
-      bandTextures.delete(name)
-      bandTexturesUploaded.delete(name)
-      bandTexturesConfigured.delete(name)
-    }
+  // user scrubs. Prune by membership rather than count: a same-size swap
+  // (red, green -> nir, swir) replaces every name without changing the size.
+  // Skipped when the caller owns the textures.
+  if (!ensureTexture) {
+    pruneBandTextures(gl, new Set(customShaderConfig.bands), {
+      bandTextures,
+      bandTexturesUploaded,
+      bandTexturesConfigured,
+    })
   }
 
   let textureUnit = 2
@@ -226,29 +245,97 @@ export function uploadDataTexture(
 }
 
 /**
+ * Create and upload the band textures a custom shader samples, dropping any
+ * that are no longer requested. Returns false if a band's data is missing or
+ * a texture cannot be allocated, which makes the region undrawable.
+ */
+function ensureBandTextures(
+  gl: WebGL2RenderingContext,
+  region: RegionState,
+  bands: readonly string[]
+): boolean {
+  pruneBandTextures(gl, new Set(bands), region)
+
+  for (const name of bands) {
+    const data = region.bandData.get(name)
+    if (!data) return false
+
+    let texture = region.bandTextures.get(name)
+    if (!texture) {
+      texture = gl.createTexture()
+      if (!texture) return false
+      region.bandTextures.set(name, texture)
+    }
+    if (region.bandTexturesUploaded.has(name)) continue
+
+    gl.activeTexture(gl.TEXTURE0)
+    gl.bindTexture(gl.TEXTURE_2D, texture)
+    if (!region.bandTexturesConfigured.has(name)) {
+      configureDataTexture(gl)
+      region.bandTexturesConfigured.add(name)
+    }
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.R32F,
+      region.width,
+      region.height,
+      0,
+      gl.RED,
+      gl.FLOAT,
+      data
+    )
+    region.bandTexturesUploaded.add(name)
+  }
+  return true
+}
+
+/**
  * Lazily create and upload a region's GPU resources from its CPU-side state.
  * Fetch produces only data and geometry arrays; the render paths call this
  * per frame so uploads happen on the context that is actually drawing.
  * Returns false while the region isn't renderable yet.
+ *
+ * `requiredBands` names the textures a custom shader will sample. It has to be
+ * the same list the draw call uses: this function's return value decides
+ * whether the level is considered covered, and a level that displaces its
+ * fallbacks and then fails to bind a band leaves the viewport blank. The main
+ * texture is not created in that mode, since nothing samples it.
  */
 export function ensureRegionGpuResources(
   gl: WebGL2RenderingContext,
-  region: RegionState
+  region: RegionState,
+  requiredBands?: readonly string[]
 ): boolean {
   if (!region.data || !region.vertexArr || !region.pixCoordArr) return false
 
-  if (!region.texture) region.texture = gl.createTexture()
-  if (!region.texture) return false
-  if (!region.textureUploaded) {
-    const result = uploadDataTexture(gl, {
-      texture: region.texture,
-      data: region.data,
-      width: region.width,
-      height: region.height,
-      channels: region.channels,
-      configured: false,
-    })
-    region.textureUploaded = result.uploaded
+  const bandRendering = !!requiredBands && requiredBands.length > 0
+  let texturesReady: boolean
+
+  if (bandRendering) {
+    if (region.texture) {
+      // Switched from main-texture rendering; nothing samples it now.
+      gl.deleteTexture(region.texture)
+      region.texture = null
+      region.textureUploaded = false
+    }
+    texturesReady = ensureBandTextures(gl, region, requiredBands)
+  } else {
+    pruneBandTextures(gl, new Set(), region)
+    if (!region.texture) region.texture = gl.createTexture()
+    if (!region.texture) return false
+    if (!region.textureUploaded) {
+      const result = uploadDataTexture(gl, {
+        texture: region.texture,
+        data: region.data,
+        width: region.width,
+        height: region.height,
+        channels: region.channels,
+        configured: false,
+      })
+      region.textureUploaded = result.uploaded
+    }
+    texturesReady = region.textureUploaded
   }
 
   // Buffer objects are reused across re-uploads, so the dirty flag — not the
@@ -279,5 +366,5 @@ export function ensureRegionGpuResources(
       (!region.useIndexedMesh || region.indexBuffer)
     )
   }
-  return region.textureUploaded && region.geometryUploaded
+  return texturesReady && region.geometryUploaded
 }

--- a/src/renderable-region.ts
+++ b/src/renderable-region.ts
@@ -172,7 +172,8 @@ export function renderRegion(
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, region.indexBuffer)
   }
 
-  // Bind textures (upload happens at fetch time for both tiles and regions)
+  // Bind textures. The main texture must already be uploaded; bindBandTextures
+  // uploads any band whose contents are not resident yet.
   if (shaderProgram.useCustomShader && customShaderConfig) {
     const bandsBound = bindBandTextures(gl, {
       bandData: region.bandData,

--- a/src/renderable-region.ts
+++ b/src/renderable-region.ts
@@ -41,8 +41,8 @@ export interface RenderableRegion {
   positionSpace?: 'mercator' | 'wgs84' | 'wgs84-ecef'
   sampleMode?: 'linear' | 'mercator-invert' | 'wgs84-lookup'
 
-  // Main texture (pre-uploaded)
-  texture: WebGLTexture
+  // Main texture (pre-uploaded). Null when band textures are sampled instead.
+  texture: WebGLTexture | null
 
   // Band textures (for custom shaders)
   bandData: Map<string, Float32Array>
@@ -188,6 +188,7 @@ export function renderRegion(
       return false
     }
   } else {
+    if (!region.texture) return false
     gl.activeTexture(gl.TEXTURE0)
     gl.bindTexture(gl.TEXTURE_2D, region.texture)
     if (shaderProgram.texLoc !== null) {

--- a/src/renderer-types.ts
+++ b/src/renderer-types.ts
@@ -67,7 +67,8 @@ export interface TileId {
 }
 
 export interface RegionRenderState {
-  texture: WebGLTexture
+  /** Null when a custom shader samples band textures instead. */
+  texture: WebGLTexture | null
   vertexBuffer: WebGLBuffer
   /** Texture coordinate buffer for sampling resampled data */
   pixCoordBuffer: WebGLBuffer

--- a/src/selector-resolution.test.ts
+++ b/src/selector-resolution.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as zarr from 'zarrita'
+import {
+  buildChannelCombinations,
+  buildSliceArgsForSelector,
+  classifyDimension,
+  resolveSelectionIndex,
+  type SelectorResolutionContext,
+} from './selector-resolution'
+import { loadDimensionValues } from './zarr-utils'
+import type { ZarrStore } from './zarr-store'
+
+vi.mock('./zarr-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./zarr-utils')>()),
+  loadDimensionValues: vi.fn(),
+}))
+
+const mockedLoadDimensionValues = vi.mocked(loadDimensionValues)
+
+beforeEach(() => {
+  mockedLoadDimensionValues.mockReset()
+})
+
+function makeContext(
+  overrides: Partial<SelectorResolutionContext> = {}
+): SelectorResolutionContext {
+  return {
+    zarrStore: {
+      coordinates: {},
+      root: null,
+      version: 3,
+    } as unknown as ZarrStore,
+    dimIndices: {
+      time: { index: 0, name: 'time', array: null },
+      lat: { index: 1, name: 'lat', array: null },
+      lon: { index: 2, name: 'lon', array: null },
+    },
+    levels: [],
+    isMultiscale: false,
+    dimensionValues: {},
+    coordLevelIndex: 0,
+    ...overrides,
+  }
+}
+
+const DIM_INFO = { index: 0, name: 'time', array: null }
+
+describe('classifyDimension', () => {
+  it('recognizes spatial, time, and other dimensions', () => {
+    expect(classifyDimension('lon')).toBe('lon')
+    expect(classifyDimension('x')).toBe('lon')
+    expect(classifyDimension('longitude')).toBe('lon')
+    expect(classifyDimension('lat')).toBe('lat')
+    expect(classifyDimension('y')).toBe('lat')
+    expect(classifyDimension('Latitude')).toBe('lat')
+    expect(classifyDimension('time')).toBe('time')
+    expect(classifyDimension('valid_time')).toBe('time')
+    expect(classifyDimension('band')).toBe('other')
+  })
+})
+
+describe('resolveSelectionIndex', () => {
+  it('passes numeric values through for type "index"', async () => {
+    const context = makeContext()
+    expect(
+      await resolveSelectionIndex(context, 'time', DIM_INFO, 3, 'index')
+    ).toBe(3)
+    expect(
+      await resolveSelectionIndex(context, 'time', DIM_INFO, undefined, 'index')
+    ).toBe(0)
+  })
+
+  it('prefers the store-preloaded coordinate arrays', async () => {
+    const context = makeContext({
+      zarrStore: {
+        coordinates: { time: [2000, 2001, 2002] },
+        root: {},
+        version: 3,
+      } as unknown as ZarrStore,
+    })
+    expect(await resolveSelectionIndex(context, 'time', DIM_INFO, 2001)).toBe(1)
+    expect(mockedLoadDimensionValues).not.toHaveBeenCalled()
+  })
+
+  it('treats a numeric value missing from preloaded coords as an index', async () => {
+    const context = makeContext({
+      zarrStore: {
+        coordinates: { time: [2000, 2001] },
+        root: {},
+        version: 3,
+      } as unknown as ZarrStore,
+    })
+    expect(await resolveSelectionIndex(context, 'time', DIM_INFO, 7)).toBe(7)
+  })
+
+  it('falls back to a direct index without a store root', async () => {
+    const context = makeContext()
+    expect(await resolveSelectionIndex(context, 'time', DIM_INFO, 4)).toBe(4)
+    expect(await resolveSelectionIndex(context, 'time', DIM_INFO, 'jan')).toBe(
+      0
+    )
+  })
+
+  it('resolves against root coordinate arrays for single-level datasets', async () => {
+    mockedLoadDimensionValues.mockResolvedValue([10, 20, 30])
+    const context = makeContext({
+      zarrStore: {
+        coordinates: {},
+        root: {},
+        version: 3,
+      } as unknown as ZarrStore,
+    })
+    expect(await resolveSelectionIndex(context, 'time', DIM_INFO, 20)).toBe(1)
+    // Single-level: no level path, coords open at the root.
+    expect(mockedLoadDimensionValues.mock.calls[0][1]).toBeNull()
+    // Resolved coords are cached for subsequent lookups.
+    expect(context.dimensionValues['time']).toEqual([10, 20, 30])
+  })
+
+  it('opens coords under the coordLevelIndex level for multiscale datasets', async () => {
+    mockedLoadDimensionValues.mockResolvedValue(['red', 'green', 'blue'])
+    const context = makeContext({
+      isMultiscale: true,
+      levels: [
+        { asset: '0', scale: [1, 1], translation: [0, 0] },
+        { asset: '1', scale: [2, 2], translation: [0, 0] },
+      ],
+      coordLevelIndex: 1,
+      zarrStore: {
+        coordinates: {},
+        root: {},
+        version: 3,
+      } as unknown as ZarrStore,
+    })
+    expect(
+      await resolveSelectionIndex(context, 'band', DIM_INFO, 'green')
+    ).toBe(1)
+    expect(mockedLoadDimensionValues.mock.calls[0][1]).toBe('1')
+  })
+
+  it('clamps an out-of-range coordLevelIndex to the last level', async () => {
+    mockedLoadDimensionValues.mockResolvedValue([1, 2])
+    const context = makeContext({
+      isMultiscale: true,
+      levels: [
+        { asset: '0', scale: [1, 1], translation: [0, 0] },
+        { asset: '1', scale: [2, 2], translation: [0, 0] },
+      ],
+      coordLevelIndex: 9,
+      zarrStore: {
+        coordinates: {},
+        root: {},
+        version: 3,
+      } as unknown as ZarrStore,
+    })
+    await resolveSelectionIndex(context, 'band', DIM_INFO, 2)
+    expect(mockedLoadDimensionValues.mock.calls[0][1]).toBe('1')
+  })
+
+  it('falls back to a direct index when coordinate resolution fails', async () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    try {
+      mockedLoadDimensionValues.mockRejectedValue(new Error('404'))
+      const context = makeContext({
+        zarrStore: {
+          coordinates: {},
+          root: {},
+          version: 3,
+        } as unknown as ZarrStore,
+      })
+      expect(await resolveSelectionIndex(context, 'time', DIM_INFO, 5)).toBe(5)
+    } finally {
+      debugSpy.mockRestore()
+    }
+  })
+})
+
+describe('buildSliceArgsForSelector', () => {
+  const array = { shape: [5, 180, 360] } as unknown as zarr.Array<zarr.DataType>
+
+  it('sets spatial dims to full slices when requested', async () => {
+    const { sliceArgs } = await buildSliceArgsForSelector(
+      makeContext(),
+      {},
+      {
+        includeSpatialSlices: true,
+        trackMultiValue: false,
+        array,
+      }
+    )
+    expect(sliceArgs[0]).toBe(0) // unselected non-spatial dim
+    expect(sliceArgs[1]).not.toBe(0) // lat slice
+    expect(sliceArgs[2]).not.toBe(0) // lon slice
+  })
+
+  it('sets spatial dims to placeholder 0 when slices are excluded', async () => {
+    const { sliceArgs } = await buildSliceArgsForSelector(
+      makeContext(),
+      {},
+      {
+        includeSpatialSlices: false,
+        trackMultiValue: false,
+        array,
+      }
+    )
+    expect(sliceArgs).toEqual([0, 0, 0])
+  })
+
+  it('applies explicit spatial bounds as slices', async () => {
+    const { sliceArgs } = await buildSliceArgsForSelector(
+      makeContext(),
+      {},
+      {
+        includeSpatialSlices: false,
+        trackMultiValue: false,
+        spatialBounds: { minX: 10, maxX: 20, minY: 30, maxY: 40 },
+        array,
+      }
+    )
+    expect(sliceArgs[1]).toMatchObject({ start: 30, stop: 40 })
+    expect(sliceArgs[2]).toMatchObject({ start: 10, stop: 20 })
+  })
+
+  it('resolves single-value selectors to an index', async () => {
+    const { sliceArgs, multiValueDims } = await buildSliceArgsForSelector(
+      makeContext(),
+      { time: { selected: 3, type: 'index' } },
+      { includeSpatialSlices: false, trackMultiValue: true, array }
+    )
+    expect(sliceArgs[0]).toBe(3)
+    expect(multiValueDims).toEqual([])
+  })
+
+  it('tracks multi-value dimensions and pins the first index', async () => {
+    const { sliceArgs, multiValueDims } = await buildSliceArgsForSelector(
+      makeContext(),
+      { time: { selected: [1, 3], type: 'index' } },
+      { includeSpatialSlices: false, trackMultiValue: true, array }
+    )
+    expect(sliceArgs[0]).toBe(1)
+    expect(multiValueDims).toEqual([
+      { dimIndex: 0, dimName: 'time', values: [1, 3], labels: [1, 3] },
+    ])
+  })
+
+  it('lets a "time" selector drive any time-classified dimension', async () => {
+    const context = makeContext({
+      dimIndices: {
+        valid_time: { index: 0, name: 'valid_time', array: null },
+        lat: { index: 1, name: 'lat', array: null },
+        lon: { index: 2, name: 'lon', array: null },
+      },
+    })
+    const { sliceArgs } = await buildSliceArgsForSelector(
+      context,
+      { time: { selected: 2, type: 'index' } },
+      { includeSpatialSlices: false, trackMultiValue: false, array }
+    )
+    expect(sliceArgs[0]).toBe(2)
+  })
+})
+
+describe('buildChannelCombinations', () => {
+  it('yields a single empty combination without multi-value dims', () => {
+    expect(buildChannelCombinations([])).toEqual({
+      combinations: [[]],
+      labelCombinations: [[]],
+    })
+  })
+
+  it('expands one dimension into per-value combinations', () => {
+    const { combinations, labelCombinations } = buildChannelCombinations([
+      { values: [4, 9], labels: ['red', 'blue'] },
+    ])
+    expect(combinations).toEqual([[4], [9]])
+    expect(labelCombinations).toEqual([['red'], ['blue']])
+  })
+
+  it('builds the cartesian product across dimensions', () => {
+    const { combinations } = buildChannelCombinations([
+      { values: [1, 2], labels: [1, 2] },
+      { values: [10, 20], labels: [10, 20] },
+    ])
+    expect(combinations).toEqual([
+      [1, 10],
+      [2, 10],
+      [1, 20],
+      [2, 20],
+    ])
+  })
+})

--- a/src/selector-resolution.test.ts
+++ b/src/selector-resolution.test.ts
@@ -189,8 +189,9 @@ describe('buildSliceArgsForSelector', () => {
       }
     )
     expect(sliceArgs[0]).toBe(0) // unselected non-spatial dim
-    expect(sliceArgs[1]).not.toBe(0) // lat slice
-    expect(sliceArgs[2]).not.toBe(0) // lon slice
+    // Full extent of each spatial dim, from the array shape [5, 180, 360].
+    expect(sliceArgs[1]).toMatchObject({ start: 0, stop: 180 })
+    expect(sliceArgs[2]).toMatchObject({ start: 0, stop: 360 })
   })
 
   it('sets spatial dims to placeholder 0 when slices are excluded', async () => {

--- a/src/selector-resolution.ts
+++ b/src/selector-resolution.ts
@@ -1,0 +1,275 @@
+import * as zarr from 'zarrita'
+import type { DimIndicesProps, NormalizedSelector, UntiledLevel } from './types'
+import { loadDimensionValues } from './zarr-utils'
+import type { ZarrStore } from './zarr-store'
+
+export type DimensionValuesCache = {
+  [key: string]: Float64Array | number[] | string[]
+}
+
+export type SelectorResolutionContext = {
+  zarrStore: ZarrStore
+  dimIndices: DimIndicesProps
+  levels: UntiledLevel[]
+  isMultiscale: boolean
+  dimensionValues: DimensionValuesCache
+  coordLevelIndex: number
+}
+
+/**
+ * Classify a dimension by its name.
+ * Used to identify spatial (lat/lon) vs non-spatial dimensions.
+ */
+export function classifyDimension(
+  dimKey: string
+): 'lon' | 'lat' | 'time' | 'other' {
+  const key = dimKey.toLowerCase()
+  if (key === 'lon' || key === 'x' || key === 'lng' || key.includes('lon')) {
+    return 'lon'
+  }
+  if (key === 'lat' || key === 'y' || key.includes('lat')) {
+    return 'lat'
+  }
+  if (key.includes('time')) {
+    return 'time'
+  }
+  return 'other'
+}
+
+/**
+ * Build slice arguments from a selector for all dimensions.
+ * Shared logic used by both display (buildBaseSliceArgs) and queries (fetchDataForSelector).
+ */
+export async function buildSliceArgsForSelector(
+  context: SelectorResolutionContext,
+  selector: NormalizedSelector,
+  options: {
+    /** If true, set spatial dims to full slices; if false, set to 0 placeholder */
+    includeSpatialSlices: boolean
+    /** If true, track multi-value dimensions for channel packing */
+    trackMultiValue: boolean
+    /** Spatial bounds for fetch - bbox for region subset */
+    spatialBounds?: {
+      minX: number
+      maxX: number
+      minY: number
+      maxY: number
+    }
+    /**
+     * Array to derive shape from. Caller pins this so we don't read
+     * `this.activeLevel?.zarrArray` mid-flight (which can swap during
+     * `loadLevel` or zoom). Pass the new array during `loadLevel`, or
+     * a snapshot of the active array for query/render paths.
+     */
+    array: zarr.Array<zarr.DataType>
+  }
+): Promise<{
+  sliceArgs: (number | zarr.Slice)[]
+  multiValueDims: Array<{
+    dimIndex: number
+    dimName: string
+    values: number[]
+    labels: (number | string)[]
+  }>
+}> {
+  const { array } = options
+  const sliceArgs: (number | zarr.Slice)[] = new Array(array.shape.length).fill(
+    0
+  )
+  const multiValueDims: Array<{
+    dimIndex: number
+    dimName: string
+    values: number[]
+    labels: (number | string)[]
+  }> = []
+
+  for (const dimName of Object.keys(context.dimIndices)) {
+    const dimInfo = context.dimIndices[dimName]
+    const dimType = classifyDimension(dimName)
+
+    if (dimType === 'lon') {
+      if (options.spatialBounds) {
+        sliceArgs[dimInfo.index] = zarr.slice(
+          options.spatialBounds.minX,
+          options.spatialBounds.maxX
+        )
+      } else {
+        sliceArgs[dimInfo.index] = options.includeSpatialSlices
+          ? zarr.slice(0, array.shape[dimInfo.index] ?? 0)
+          : 0
+      }
+    } else if (dimType === 'lat') {
+      if (options.spatialBounds) {
+        sliceArgs[dimInfo.index] = zarr.slice(
+          options.spatialBounds.minY,
+          options.spatialBounds.maxY
+        )
+      } else {
+        sliceArgs[dimInfo.index] = options.includeSpatialSlices
+          ? zarr.slice(0, array.shape[dimInfo.index] ?? 0)
+          : 0
+      }
+    } else {
+      const selectionSpec =
+        selector[dimName] || (dimType === 'time' ? selector['time'] : undefined)
+
+      if (selectionSpec !== undefined) {
+        const selectionValue = selectionSpec.selected
+        const selectionType = selectionSpec.type
+
+        if (
+          options.trackMultiValue &&
+          Array.isArray(selectionValue) &&
+          selectionValue.length > 1
+        ) {
+          const resolvedIndices: number[] = []
+          const labelValues: (number | string)[] = []
+          for (const val of selectionValue) {
+            const idx = await resolveSelectionIndex(
+              context,
+              dimName,
+              dimInfo,
+              val,
+              selectionType
+            )
+            resolvedIndices.push(idx)
+            labelValues.push(val)
+          }
+          multiValueDims.push({
+            dimIndex: dimInfo.index,
+            dimName,
+            values: resolvedIndices,
+            labels: labelValues,
+          })
+          sliceArgs[dimInfo.index] = resolvedIndices[0]
+        } else {
+          const primaryValue = Array.isArray(selectionValue)
+            ? selectionValue[0]
+            : selectionValue
+          sliceArgs[dimInfo.index] = await resolveSelectionIndex(
+            context,
+            dimName,
+            dimInfo,
+            primaryValue,
+            selectionType
+          )
+        }
+      } else {
+        sliceArgs[dimInfo.index] = 0
+      }
+    }
+  }
+
+  return { sliceArgs, multiValueDims }
+}
+
+export async function resolveSelectionIndex(
+  context: SelectorResolutionContext,
+  dimName: string,
+  dimInfo: {
+    index: number
+    name: string
+    array: zarr.Array<zarr.DataType> | null
+  },
+  value: number | string | [number, number] | undefined,
+  type?: 'index' | 'value'
+): Promise<number> {
+  if (type === 'index') {
+    return typeof value === 'number' ? value : 0
+  }
+  if (typeof value !== 'number' && typeof value !== 'string') {
+    return 0
+  }
+
+  // Multiscale pyramids (tiled and untiled alike) keep their non-spatial
+  // coordinate arrays inside each level directory (e.g. "0/month"), not at
+  // the store root. ZarrStore preloads those from the level-0 directory into
+  // `coordinates`, so prefer them — opening the same arrays at the root (as
+  // the fallback below does) would 404. The fallback covers single-level
+  // datasets, whose coordinate arrays live at the root and aren't preloaded.
+  const storeCoords = context.zarrStore.coordinates[dimName] as
+    | (number | string)[]
+    | undefined
+  if (storeCoords && storeCoords.length > 0) {
+    const idx = storeCoords.indexOf(value)
+    if (idx >= 0) return idx
+    // Value not present in the preloaded coordinate array: treat a numeric
+    // selector as a direct index.
+    return typeof value === 'number' ? value : 0
+  }
+
+  if (!context.zarrStore.root) {
+    return typeof value === 'number' ? value : 0
+  }
+
+  // Multiscale pyramids keep per-dimension coordinate arrays under per-level
+  // paths (e.g. `0/band/c/0`), not at the root. Passing `null` here resolves
+  // the coordinate array from the root, which 404s for those datasets; the
+  // catch below then falls back to index 0 for every selector value. An RGB
+  // selection (red/green/blue by name) therefore collapses all three channels
+  // to band 0 and renders greyscale. Resolve the in-flight level's path
+  // instead, gated on `isMultiscale` so single-level datasets (coordinates at
+  // root) are unaffected. `loadLevel` calls `buildSliceArgsForSelector`
+  // (and so this) before committing `activeLevel`, so fall through
+  // activeLevel.index -> loadingLevelIndex -> desiredLevelIndex -> 0 to use
+  // the level the in-flight load is actually targeting.
+  let levelInfo: string | null = null
+  if (context.isMultiscale && context.levels.length > 0) {
+    const safeIdx = Math.max(
+      0,
+      Math.min(context.coordLevelIndex, context.levels.length - 1)
+    )
+    levelInfo = context.levels[safeIdx]?.asset ?? null
+  }
+
+  try {
+    const coords = await loadDimensionValues(
+      context.dimensionValues,
+      levelInfo,
+      dimInfo,
+      context.zarrStore.root,
+      context.zarrStore.version
+    )
+    context.dimensionValues[dimName] = coords
+
+    const coordIdx = (coords as (number | string)[]).indexOf(value)
+    if (coordIdx >= 0) return coordIdx
+    throw new Error(
+      `[ZarrLayer] Selector value '${value}' not found in coordinate array for dimension '${dimName}'. ` +
+        `Available values: [${(coords as (number | string)[])
+          .slice(0, 10)
+          .join(', ')}${coords.length > 10 ? ', ...' : ''}]. ` +
+        `Use { selected: <index>, type: 'index' } to select by array index instead.`
+    )
+  } catch (err) {
+    console.debug(`Could not resolve coordinate for '${dimName}':`, err)
+  }
+
+  return typeof value === 'number' ? value : 0
+}
+
+/**
+ * Build all index combinations from multi-value dimensions.
+ * Returns cartesian product of all dimension value arrays.
+ */
+export function buildChannelCombinations(
+  multiValueDims: Array<{ values: number[]; labels: (number | string)[] }>
+): { combinations: number[][]; labelCombinations: (number | string)[][] } {
+  let combinations: number[][] = [[]]
+  let labelCombinations: (number | string)[][] = [[]]
+
+  for (const { values, labels } of multiValueDims) {
+    const nextCombos: number[][] = []
+    const nextLabels: (number | string)[][] = []
+    for (let idx = 0; idx < values.length; idx++) {
+      for (let c = 0; c < combinations.length; c++) {
+        nextCombos.push([...combinations[c], values[idx]])
+        nextLabels.push([...labelCombinations[c], labels[idx]])
+      }
+    }
+    combinations = nextCombos
+    labelCombinations = nextLabels
+  }
+
+  return { combinations, labelCombinations }
+}

--- a/src/shader-program.test.ts
+++ b/src/shader-program.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect } from 'vitest'
+import {
+  applyProjectionUniforms,
+  createShaderProgram,
+  makeShaderVariantKey,
+  resolveProjectionMode,
+  type ShaderProgram,
+} from './shader-program'
+import { maplibreFragmentShaderSource } from './shaders'
+import type { ProjectionMode } from './renderer-types'
+import { createRecordingGl, FAKE_SHADER_DATA } from './__fixtures__/fake-gl'
+
+/**
+ * The map-settings decision table. Every visible difference between
+ * mapbox/maplibre, mercator/globe, and flat/polar-preserving rendering is a
+ * different ProjectionMode, and each mode has to reach the GPU as a specific
+ * vertex shader with a specific set of uploaded uniforms. Getting the table
+ * right but the shader or uniform routing wrong (or vice versa) shows up only
+ * as a wrong-looking map, so all three layers are pinned here:
+ *
+ *   1. (useMapbox, useWgs84, useDirectEcef) -> ProjectionMode
+ *   2. ProjectionMode                       -> the GLSL that gets compiled
+ *   3. ProjectionMode                       -> which uniforms get uploaded
+ */
+
+const ALL_MODES: ProjectionMode[] = [
+  'maplibre',
+  'maplibre-proj4',
+  'maplibre-ecef',
+  'mapbox',
+  'mapbox-proj4',
+  'mapbox-ecef',
+]
+
+const buildProgram = (projectionMode: ProjectionMode) => {
+  const gl = createRecordingGl()
+  const { shaderProgram } = createShaderProgram(gl, {
+    fragmentShaderSource: maplibreFragmentShaderSource,
+    shaderData: FAKE_SHADER_DATA,
+    projectionMode,
+  })
+  return { gl, shaderProgram, source: gl.sourcesFor(shaderProgram.program) }
+}
+
+describe('resolveProjectionMode', () => {
+  it('maps every (provider, source-projection, globe) combination', () => {
+    // useMapbox, useWgs84, useDirectEcef
+    expect(resolveProjectionMode(false, false, false)).toBe('maplibre')
+    expect(resolveProjectionMode(false, true, false)).toBe('maplibre-proj4')
+    expect(resolveProjectionMode(false, false, true)).toBe('maplibre-ecef')
+    expect(resolveProjectionMode(false, true, true)).toBe('maplibre-ecef')
+    expect(resolveProjectionMode(true, false, false)).toBe('mapbox')
+    expect(resolveProjectionMode(true, true, false)).toBe('mapbox-proj4')
+    expect(resolveProjectionMode(true, false, true)).toBe('mapbox-ecef')
+    expect(resolveProjectionMode(true, true, true)).toBe('mapbox-ecef')
+  })
+
+  it('defaults to the plain maplibre mode', () => {
+    expect(resolveProjectionMode()).toBe('maplibre')
+  })
+
+  it('lets the provider flag win over the input space', () => {
+    // A mapbox frame must never land on a maplibre mode: the maplibre variants
+    // call projectTile() from a prelude Mapbox does not supply.
+    expect(resolveProjectionMode(true, true, false).startsWith('mapbox')).toBe(
+      true
+    )
+    expect(resolveProjectionMode(true, false, true).startsWith('mapbox')).toBe(
+      true
+    )
+  })
+})
+
+describe('makeShaderVariantKey', () => {
+  it('gives every projection mode its own cache entry', () => {
+    const keys = ALL_MODES.map((projectionMode) =>
+      makeShaderVariantKey({ projectionMode, shaderData: FAKE_SHADER_DATA })
+    )
+    expect(new Set(keys).size).toBe(ALL_MODES.length)
+  })
+
+  it('recompiles when MapLibre swaps its prelude mid-transition', () => {
+    // MapLibre hands a different prelude (and variantName) across the
+    // globe->mercator morph; reusing the cached program would keep projecting
+    // with the old prelude's projectTile().
+    const globe = makeShaderVariantKey({
+      projectionMode: 'maplibre',
+      shaderData: { ...FAKE_SHADER_DATA, variantName: 'globe' },
+    })
+    const mercator = makeShaderVariantKey({
+      projectionMode: 'maplibre',
+      shaderData: { ...FAKE_SHADER_DATA, variantName: 'mercator' },
+    })
+    expect(globe).not.toBe(mercator)
+  })
+
+  it('keys custom band shaders separately from the base shader', () => {
+    const base = makeShaderVariantKey({ projectionMode: 'mapbox' })
+    const banded = makeShaderVariantKey({
+      projectionMode: 'mapbox',
+      customShaderConfig: { bands: ['red', 'nir'] },
+    })
+    expect(banded).not.toBe(base)
+    expect(banded).toContain('red_nir')
+  })
+})
+
+describe('projection mode -> compiled vertex shader', () => {
+  it('maplibre flat projects through the prelude’s projectTile', () => {
+    const { source } = buildProgram('maplibre')
+    expect(source.vertex).toContain('gl_Position = projectTile(merc);')
+    expect(source.vertex).toContain('#define ZARR_FAKE 1')
+  })
+
+  it('maplibre source-projected uses the eye-coords flat output', () => {
+    const { source } = buildProgram('maplibre-proj4')
+    // Region-local mercator deltas plus a precomputed anchor: the high-zoom
+    // jitter fix. Falling back to projectTile(merc) here would reintroduce it.
+    expect(source.vertex).toContain('vec2 mercDelta')
+    expect(source.vertex).toContain('gl_Position = u_anchor_clip + deltaClip;')
+  })
+
+  it('maplibre globe builds vertices on the sphere and blends to flat', () => {
+    const { source } = buildProgram('maplibre-ecef')
+    expect(source.vertex).toContain('vec3 ecef')
+    expect(source.vertex).toContain('u_projection_matrix * vec4(ecef, 1.0)')
+    // The flat fallback the globe morph blends toward.
+    expect(source.vertex).toContain('u_projection_fallback_matrix')
+    expect(source.vertex).toContain('u_projection_transition')
+  })
+
+  it('mapbox flat and globe share one shader driven by the transition', () => {
+    const { source } = buildProgram('mapbox')
+    // Mapbox drives mercator/globe from a single program: the mix() endpoint is
+    // chosen by u_globe_transition, so a mercator map is transition=1 here.
+    expect(source.vertex).toContain('u_globe_transition')
+    expect(source.vertex).toContain('mix(globeClip, mercClip')
+    expect(source.vertex).toContain('u_tile_render == 1')
+    expect(source.vertex).not.toContain('projectTile')
+  })
+
+  it('mapbox globe uses the Y-DOWN ECEF sphere with a depth bias', () => {
+    const { source } = buildProgram('mapbox-ecef')
+    expect(source.vertex).toContain('-GLOBE_RADIUS * sin(latRad)')
+    expect(source.vertex).toContain('matrix * (u_globe_to_merc * vec4(ecef')
+    // Keeps the custom layer off the globe surface it z-fights with.
+    expect(source.vertex).toContain('gl_Position.z -=')
+  })
+
+  it('only the ECEF variants carry WGS84 coords to the fragment shader', () => {
+    for (const mode of ALL_MODES) {
+      const { source } = buildProgram(mode)
+      const carriesWgs84 = source.vertex.includes(
+        'v_wgs84Pos = vec2(normLon, normLat);'
+      )
+      expect(carriesWgs84).toBe(mode.endsWith('ecef'))
+    }
+  })
+
+  it('resolves eye-coords uniforms only on the source-projected flat variants', () => {
+    // Other variants never reference them, so the compiler drops them and the
+    // per-region uploads in renderRegion become no-ops.
+    for (const mode of ALL_MODES) {
+      const { shaderProgram } = buildProgram(mode)
+      const usesEyeCoords = mode === 'maplibre-proj4' || mode === 'mapbox-proj4'
+      expect(!!shaderProgram.eyeMatrixLoc).toBe(usesEyeCoords)
+      expect(!!shaderProgram.anchorClipLoc).toBe(usesEyeCoords)
+    }
+  })
+
+  it('gives mapbox modes the globe-to-mercator matrix and maplibre modes none', () => {
+    for (const mode of ALL_MODES) {
+      const { shaderProgram } = buildProgram(mode)
+      const isMapbox = mode.startsWith('mapbox')
+      expect(!!shaderProgram.globeToMercMatrixLoc).toBe(isMapbox)
+      expect(!!shaderProgram.projMatrixLoc).toBe(!isMapbox)
+    }
+  })
+
+  it('drops the globe blend uniforms on the direct mapbox globe path', () => {
+    // mapbox-ecef only ever draws the fully-globe endpoint, so it has no
+    // mercator blend and no draped-tile branch to switch on.
+    const direct = buildProgram('mapbox-ecef').shaderProgram
+    expect(direct.globeTransitionLoc).toBeNull()
+    expect(direct.tileRenderLoc).toBeNull()
+
+    // The draped modes carry both, since one program serves the whole morph.
+    for (const mode of ['mapbox', 'mapbox-proj4'] as const) {
+      const draped = buildProgram(mode).shaderProgram
+      expect(draped.globeTransitionLoc).not.toBeNull()
+      expect(draped.tileRenderLoc).not.toBeNull()
+    }
+  })
+})
+
+describe('applyProjectionUniforms', () => {
+  const MATRIX = Array.from({ length: 16 }, (_, i) => i)
+  const EXPANDED = new Float32Array(16).fill(9)
+  const GLOBE_TO_MERC = new Float32Array(16).fill(3)
+
+  const projectionData = {
+    mainMatrix: MATRIX,
+    fallbackMatrix: new Float32Array(16).fill(2),
+    tileMercatorCoords: [0, 0, 1, 1] as [number, number, number, number],
+    clippingPlane: [0, 0, 1, 0] as [number, number, number, number],
+    projectionTransition: 0.6,
+  }
+
+  const mapbox = {
+    projection: { name: 'globe' },
+    globeToMercatorMatrix: GLOBE_TO_MERC,
+    transition: 0.25,
+    expandedFarZMercatorMatrix: EXPANDED,
+  }
+
+  const apply = (
+    mode: ProjectionMode,
+    options: {
+      withProjectionData?: boolean
+      withMapbox?: boolean
+      isGlobeTileRender?: boolean
+    } = {}
+  ) => {
+    const { gl, shaderProgram } = buildProgram(mode)
+    gl.calls.length = 0
+    applyProjectionUniforms(
+      gl,
+      shaderProgram,
+      MATRIX,
+      options.withProjectionData === false ? undefined : projectionData,
+      options.withMapbox === false ? undefined : mapbox,
+      options.isGlobeTileRender
+    )
+    return { gl, shaderProgram }
+  }
+
+  const uploadFor = (gl: ReturnType<typeof createRecordingGl>, name: string) =>
+    gl.calls.find((call) => call.args[0] === name)
+
+  it('routes maplibre modes to the projectTile uniforms', () => {
+    for (const mode of [
+      'maplibre',
+      'maplibre-proj4',
+      'maplibre-ecef',
+    ] as const) {
+      const { gl } = apply(mode)
+      expect(uploadFor(gl, 'u_projection_matrix')?.args[1]).toEqual(
+        new Float32Array(MATRIX)
+      )
+      expect(uploadFor(gl, 'u_projection_fallback_matrix')).toBeDefined()
+      expect(uploadFor(gl, 'u_projection_transition')?.args[1]).toBe(0.6)
+      // Mapbox's `matrix` does not exist in these programs; uploading it would
+      // mean the provider detection upstream went wrong.
+      expect(uploadFor(gl, 'matrix')).toBeUndefined()
+      expect(uploadFor(gl, 'u_globe_to_merc')).toBeUndefined()
+    }
+  })
+
+  it('uploads nothing for maplibre when projection data is absent', () => {
+    // Legacy MapLibre without a prelude has no projection data; a partial
+    // upload would leave stale matrices from the previous frame in place.
+    const { gl } = apply('maplibre', { withProjectionData: false })
+    expect(gl.calls).toHaveLength(0)
+  })
+
+  it('routes mapbox modes to the matrix and globe uniforms', () => {
+    for (const mode of ['mapbox', 'mapbox-proj4'] as const) {
+      const { gl } = apply(mode)
+      expect(uploadFor(gl, 'matrix')?.args[1]).toEqual(new Float32Array(MATRIX))
+      expect(uploadFor(gl, 'u_globe_to_merc')?.args[1]).toBe(GLOBE_TO_MERC)
+      expect(uploadFor(gl, 'u_globe_transition')?.args[1]).toBe(0.25)
+      expect(uploadFor(gl, 'u_projection_matrix')).toBeUndefined()
+    }
+  })
+
+  it('defaults a missing mapbox transition to mercator', () => {
+    const { gl } = apply('mapbox', { withMapbox: false })
+    expect(uploadFor(gl, 'u_globe_transition')?.args[1]).toBe(1)
+  })
+
+  it('gives the direct globe path the expanded far-plane matrix', () => {
+    // Mapbox's globe raster pass uses expandedFarZProjMatrix; the public
+    // custom-layer matrix uses the regular far plane, so the ECEF path would
+    // z-fight against the globe surface without this swap.
+    const { gl } = apply('mapbox-ecef')
+    expect(uploadFor(gl, 'matrix')?.args[1]).toBe(EXPANDED)
+  })
+
+  it('keeps the tile matrix when the direct globe path renders a tile', () => {
+    const { gl } = apply('mapbox-ecef', { isGlobeTileRender: true })
+    expect(uploadFor(gl, 'matrix')?.args[1]).toEqual(new Float32Array(MATRIX))
+  })
+
+  it('never swaps in the expanded matrix on the draped mapbox modes', () => {
+    for (const mode of ['mapbox', 'mapbox-proj4'] as const) {
+      const { gl } = apply(mode)
+      expect(uploadFor(gl, 'matrix')?.args[1]).not.toBe(EXPANDED)
+    }
+  })
+
+  it('flags tile rendering so the shader takes its flat branch', () => {
+    // renderToTile draws into a flat tile texture that Mapbox then drapes; the
+    // shader must not apply the globe projection a second time.
+    const draped = apply('mapbox', { isGlobeTileRender: true })
+    expect(uploadFor(draped.gl, 'u_tile_render')?.args[1]).toBe(1)
+
+    const direct = apply('mapbox', { isGlobeTileRender: false })
+    expect(uploadFor(direct.gl, 'u_tile_render')?.args[1]).toBe(0)
+  })
+})
+
+describe('shader program uniform surface', () => {
+  it('exposes the reprojection uniforms on every mode', () => {
+    // Polar / EPSG:4326 datasets need the fragment-side latitude lookup no
+    // matter which projection is on screen.
+    for (const mode of ALL_MODES) {
+      const { shaderProgram } = buildProgram(mode)
+      const program: ShaderProgram = shaderProgram
+      expect(program.reprojectLoc).not.toBeNull()
+      expect(program.latBoundsLoc).not.toBeNull()
+      expect(program.latIsAscendingLoc).not.toBeNull()
+    }
+  })
+})

--- a/src/shaders.test.ts
+++ b/src/shaders.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createVertexShader,
+  createFragmentShaderSource,
+  maplibreFragmentShaderSource,
+  type ShaderData,
+} from './shaders'
+import { latToMercatorNorm } from './map-utils'
+
+/** CPU-side mercator inverse (normalized Y -> latitude in degrees). */
+function mercatorNormToLat(mercY: number): number {
+  const t = Math.PI * (1 - 2 * mercY)
+  return (180 / Math.PI) * Math.atan(Math.sinh(t))
+}
+
+/**
+ * Shader behavior is verified without a GPU in two complementary layers:
+ *
+ *  1. STRUCTURE — `createVertexShader`/`createFragmentShaderSource` compose
+ *     GLSL from parts based on (inputSpace × projection) and band/customFrag
+ *     options. We assert the right transform, uniforms, and projection output
+ *     land in each variant, and that the customFrag uniform-extraction +
+ *     gl_FragColor rewrite behave.
+ *
+ *  2. MATH PARITY — the projection math the shaders run on the GPU is mirrored
+ *     here in JS (a faithful port of the exact GLSL lines) and proven equal to
+ *     the CPU implementation used for tiling and queries (map-utils). If the
+ *     CPU and GPU mercator math ever diverge, rendered rasters and queried
+ *     values would disagree; this catches that. The substring assertions pin
+ *     the GLSL formula so the JS mirror below can't silently drift from it.
+ */
+
+const FAKE_SHADER_DATA: ShaderData = {
+  vertexShaderPrelude: '// MAPLIBRE_PRELUDE projectTile()',
+  define: '#define ZARR_TEST 1',
+  variantName: 'test',
+}
+
+describe('createVertexShader — structure', () => {
+  it('emits a #version 300 es header', () => {
+    const src = createVertexShader({
+      inputSpace: 'mercator',
+      projection: 'maplibre',
+      shaderData: FAKE_SHADER_DATA,
+    })
+    expect(src.startsWith('#version 300 es')).toBe(true)
+  })
+
+  it('maplibre mercator uses projectTile and the maplibre prelude', () => {
+    const src = createVertexShader({
+      inputSpace: 'mercator',
+      projection: 'maplibre',
+      shaderData: FAKE_SHADER_DATA,
+    })
+    expect(src).toContain('gl_Position = projectTile(merc);')
+    expect(src).toContain('MAPLIBRE_PRELUDE')
+    expect(src).toContain('#define ZARR_TEST 1')
+    expect(src).toContain('uniform float scale;')
+  })
+
+  it('wgs84 input space uses eye-coords mercator deltas', () => {
+    const src = createVertexShader({
+      inputSpace: 'wgs84',
+      projection: 'mapbox',
+    })
+    // Vertices are region-local mercator deltas; the flat path projects them
+    // through the eye-coords decomposition (u_anchor_clip + deltaClip).
+    expect(src).toContain(
+      'vec2 mercDelta = vec2(vertex.x * sx, vertex.y * sy);'
+    )
+    expect(src).toContain('u_eye_matrix * vec4(mercDelta, 0.0, 0.0)')
+    expect(src).toContain('uniform mat4 matrix;') // mapbox globe uniforms
+  })
+
+  it('mapbox globe (non-direct) includes the mercator-Y->lat helper', () => {
+    const src = createVertexShader({
+      inputSpace: 'mercator',
+      projection: 'mapbox',
+    })
+    expect(src).toContain('mercatorYToLatRad')
+    expect(src).toContain('GLOBE_RADIUS')
+  })
+
+  it('wgs84-direct (maplibre) takes the ECEF path and carries wgs84 pos', () => {
+    const src = createVertexShader({
+      inputSpace: 'wgs84-direct',
+      projection: 'maplibre',
+      shaderData: FAKE_SHADER_DATA,
+    })
+    expect(src).toContain('u_projection_matrix')
+    expect(src).toContain('v_wgs84Pos = vec2(normLon, normLat);')
+  })
+
+  it('wgs84-direct (mapbox) inverts mercator deltas onto the Y-DOWN ECEF sphere', () => {
+    const src = createVertexShader({
+      inputSpace: 'wgs84-direct',
+      projection: 'mapbox',
+    })
+    expect(src).toContain('u_globe_to_merc')
+    expect(src).toContain('mercatorYToLatRad')
+    expect(src).toContain('-GLOBE_RADIUS * sin(latRad)')
+  })
+
+  it('throws when a maplibre variant is missing shaderData', () => {
+    expect(() =>
+      createVertexShader({ inputSpace: 'mercator', projection: 'maplibre' })
+    ).toThrow(/shaderData required/)
+    expect(() =>
+      createVertexShader({ inputSpace: 'wgs84-direct', projection: 'maplibre' })
+    ).toThrow(/shaderData required/)
+  })
+})
+
+describe('createFragmentShaderSource — structure', () => {
+  it('builds a single-band colormap shader', () => {
+    const src = createFragmentShaderSource({ bands: ['temp'] })
+    expect(src).toContain('uniform sampler2D temp;')
+    expect(src).toContain('texture(colormap, vec2(rescaled, 0.5))')
+    expect(src).toContain('isnan(temp_tex)')
+    expect(src).toContain('out vec4 fragColor;')
+  })
+
+  it('declares samplers for every band', () => {
+    const src = createFragmentShaderSource({ bands: ['a', 'b'] })
+    expect(src).toContain('uniform sampler2D a;')
+    expect(src).toContain('uniform sampler2D b;')
+  })
+
+  it('hoists uniforms out of customFrag and rewrites gl_FragColor', () => {
+    const src = createFragmentShaderSource({
+      bands: ['temp'],
+      customFrag:
+        'uniform float gain;\ngl_FragColor = vec4(temp * gain, 0.0, 0.0, 1.0);',
+    })
+    expect(src).toContain('uniform float gain;')
+    expect(src).toContain('fragColor = vec4(temp * gain')
+    expect(src).not.toContain('gl_FragColor')
+  })
+
+  it('declares explicitly-listed customUniforms', () => {
+    const src = createFragmentShaderSource({
+      bands: ['temp'],
+      customUniforms: ['gain'],
+      customFrag: 'gl_FragColor = vec4(temp * gain, 0.0, 0.0, 1.0);',
+    })
+    expect(src).toContain('uniform float gain;')
+    expect(src).not.toContain('gl_FragColor')
+  })
+})
+
+describe('mercator math parity (GPU shader <-> CPU map-utils)', () => {
+  // The mercator FORWARD runs on the CPU (mesh encoding via latToMercatorNorm);
+  // the shaders only INVERT (fragment texture lookup, ECEF vertex paths). If
+  // the GPU inverse and CPU forward disagree, texture lookups shift.
+
+  // Faithful JS port of the fragment shader's mercator inverse
+  // (FRAGMENT_SHADER_REPROJECT + FUNC_MERCATOR_INVERT in shaders.ts).
+  function shaderInvertLatDeg(mercYNorm: number): number {
+    const PI = Math.PI
+    const y = PI * (1 - 2 * mercYNorm)
+    const phi = 2 * Math.atan(Math.exp(y)) - PI / 2
+    return (180 / PI) * phi
+  }
+
+  it('fragment-shader inverse matches mercatorNormToLat', () => {
+    for (const mercY of [0.05, 0.25, 0.5, 0.75, 0.95]) {
+      expect(shaderInvertLatDeg(mercY)).toBeCloseTo(
+        mercatorNormToLat(mercY),
+        10
+      )
+    }
+  })
+
+  it('GPU inverse inverts the CPU forward (latToMercatorNorm)', () => {
+    for (const lat of [-80, -30, 0, 30, 80]) {
+      expect(shaderInvertLatDeg(latToMercatorNorm(lat))).toBeCloseTo(lat, 9)
+    }
+  })
+
+  it('pins the GLSL formulas the JS port mirrors', () => {
+    // If these substrings change, the JS ports above must be updated in lockstep.
+    const vtx = createVertexShader({
+      inputSpace: 'wgs84-direct',
+      projection: 'mapbox',
+    })
+    // Vertex-side inverse (FUNC_MERCATOR_Y_TO_LAT, used by the ECEF paths).
+    expect(vtx).toContain('float t = PI * (1.0 - 2.0 * y);')
+    expect(vtx).toContain('atan(sinh(t))')
+    // Fragment-side inverse (FUNC_MERCATOR_INVERT).
+    expect(maplibreFragmentShaderSource).toContain(
+      '2.0 * atan(exp(y)) - PI / 2.0'
+    )
+    expect(maplibreFragmentShaderSource).toContain(
+      'PI * (1.0 - 2.0 * v_mercatorPos.y)'
+    )
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,7 +118,7 @@ export interface ZarrLayerOptions {
   renderingMode?: '2d' | '3d'
   onLoadingStateChange?: LoadingStateCallback
   /**
-   * Proj4 definition string for reprojection (untiled mode only).
+   * Proj4 definition string for reprojection.
    * When provided, bounds are interpreted as source CRS units and data is reprojected to Web Mercator.
    * Example: "+proj=lcc +lat_1=38.5 +lat_2=38.5 +lat_0=38.5 +lon_0=-97.5 +x_0=0 +y_0=0 +R=6371229 +units=m +no_defs"
    */

--- a/src/zarr-layer.render-path.test.ts
+++ b/src/zarr-layer.render-path.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ZarrLayer } from './zarr-layer'
+import { buildMemoryZarrStore } from './__fixtures__/memory-zarr'
+import { createRecordingGl } from './__fixtures__/fake-gl'
+import type { MapLike } from './types'
+
+/**
+ * The layer-level render-path gate (configureMapboxRenderPath).
+ *
+ * Mapbox classifies a custom layer as *draped* whenever it exposes
+ * renderToTile: Mapbox renders the layer into tile textures and drapes them
+ * over the globe or over terrain. Dropping renderToTile switches the layer to
+ * the *direct* path, where it draws itself onto the sphere in ECEF and can
+ * reach the poles. The presence of `renderToTile` on the layer object is the
+ * whole contract, so it is what these tests assert.
+ *
+ * Getting the gate wrong is invisible until you look at a map: on terrain the
+ * layer detaches from the ground, mid-morph it pops, and on MapLibre — which
+ * has no draping API at all — engaging the Mapbox-only path would break the
+ * layer outright. The gate has five inputs, each covered below:
+ *
+ *   renderPoles opt-in, dataset ECEF-eligibility, terrain off, globe
+ *   projection, and Mapbox-only internals being reachable.
+ */
+
+const memoryStore = () =>
+  buildMemoryZarrStore({
+    arrays: [
+      {
+        name: 'temperature',
+        shape: [4, 8],
+        chunkShape: [2, 4],
+        dimensionNames: ['lat', 'lon'],
+        chunks: {
+          '0/0': [0, 1, 2, 3, 4, 5, 6, 7],
+          '0/1': [8, 9, 10, 11, 12, 13, 14, 15],
+          '1/0': [16, 17, 18, 19, 20, 21, 22, 23],
+          '1/1': [24, 25, 26, 27, 28, 29, 30, 31],
+        },
+      },
+    ],
+  })
+
+interface FakeMapOptions {
+  globe?: boolean
+  terrain?: boolean
+  zoom?: number
+  /** Mapbox exposes these internals; MapLibre does not. */
+  mapboxInternals?: boolean
+}
+
+function fakeMap(options: FakeMapOptions = {}) {
+  const {
+    globe = false,
+    terrain = false,
+    zoom = 0,
+    mapboxInternals = true,
+  } = options
+
+  const state = { globe, terrain, zoom }
+  const handlers = new Map<string, Array<(...args: unknown[]) => void>>()
+
+  const map = {
+    getProjection: () =>
+      // Mapbox reports `name`; a MapLibre map would report `type`.
+      mapboxInternals
+        ? { name: state.globe ? 'globe' : 'mercator' }
+        : { type: state.globe ? 'globe' : 'mercator' },
+    getTerrain: () => (state.terrain ? { source: 'dem' } : null),
+    getZoom: () => state.zoom,
+    getBounds: () => ({
+      getWest: () => -180,
+      getEast: () => 180,
+      toArray: () => [
+        [-180, -85],
+        [180, 85],
+      ],
+    }),
+    getRenderWorldCopies: () => true,
+    triggerRepaint: vi.fn(),
+    on: (event: string, handler: (...args: unknown[]) => void) => {
+      const list = handlers.get(event) ?? []
+      list.push(handler)
+      handlers.set(event, list)
+    },
+    off: vi.fn(),
+    ...(mapboxInternals
+      ? {
+          transform: {
+            expandedFarZProjMatrix: new Float64Array(16).fill(1),
+            worldSize: 512,
+          },
+        }
+      : {}),
+  }
+
+  return {
+    map: map as unknown as MapLike,
+    state,
+    /** Re-run the layer's gate the way a real map event would. */
+    emit: (event: string) => {
+      for (const handler of handlers.get(event) ?? []) handler()
+    },
+  }
+}
+
+async function addLayer(
+  mapOptions: FakeMapOptions = {},
+  layerOptions: { renderPoles?: boolean; crs?: string } = {}
+) {
+  const { renderPoles = true, crs = 'EPSG:4326' } = layerOptions
+  const { map, state, emit } = fakeMap(mapOptions)
+  const gl = createRecordingGl()
+
+  // onAdd initializes asynchronously without returning a handle, so the layer's
+  // own loading callback is what says the store, renderer, and first gate
+  // evaluation are done. Waiting on it rather than on a clock keeps the test
+  // from racing parallel workers.
+  let ready: () => void
+  const initialized = new Promise<void>((resolve) => {
+    ready = resolve
+  })
+
+  const layer = new ZarrLayer({
+    id: 'zarr',
+    store: memoryStore(),
+    variable: 'temperature',
+    colormap: [
+      [0, 0, 0],
+      [255, 255, 255],
+    ],
+    clim: [0, 31],
+    bounds: [-180, -90, 180, 90],
+    latIsAscending: false,
+    crs,
+    renderPoles,
+    onLoadingStateChange: (loadingState) => {
+      if (!loadingState.metadata) ready()
+    },
+  })
+
+  layer.onAdd(map, gl)
+  await initialized
+
+  /** True when the layer is draped (Mapbox renders it into tile textures). */
+  const isDraped = () => typeof layer.renderToTile === 'function'
+
+  return { layer, map, state, emit, isDraped }
+}
+
+describe('Mapbox draped vs direct globe path', () => {
+  it('undrapes on the globe so the layer can reach the poles', async () => {
+    const { isDraped } = await addLayer({ globe: true, zoom: 0 })
+    expect(isDraped()).toBe(false)
+  })
+
+  it('stays draped in mercator', async () => {
+    const { isDraped } = await addLayer({ globe: false })
+    expect(isDraped()).toBe(true)
+  })
+
+  it('stays draped on the globe when terrain is on', async () => {
+    // Terrain draping is the whole point of renderToTile; taking the direct
+    // path here would float the layer off the terrain surface.
+    const { isDraped } = await addLayer({ globe: true, terrain: true, zoom: 0 })
+    expect(isDraped()).toBe(true)
+  })
+
+  it('re-drapes when terrain is switched on, and undrapes when switched off', async () => {
+    const { state, emit, isDraped } = await addLayer({ globe: true, zoom: 0 })
+    expect(isDraped()).toBe(false)
+
+    state.terrain = true
+    emit('move')
+    expect(isDraped()).toBe(true)
+
+    state.terrain = false
+    emit('move')
+    expect(isDraped()).toBe(false)
+  })
+
+  it('re-drapes when the projection switches back to mercator', async () => {
+    const { state, emit, isDraped } = await addLayer({ globe: true, zoom: 0 })
+    expect(isDraped()).toBe(false)
+
+    state.globe = false
+    emit('projectionchange')
+    expect(isDraped()).toBe(true)
+  })
+
+  it('hands the globe-to-mercator morph back to Mapbox', async () => {
+    // Mapbox blends globe and mercator across zoom 5-6 using internal matrices
+    // the custom-layer callback never sees, so the direct path only holds at
+    // the fully-globe endpoint.
+    const { state, emit, isDraped } = await addLayer({ globe: true, zoom: 0 })
+    expect(isDraped()).toBe(false)
+
+    state.zoom = 5.5
+    emit('move')
+    expect(isDraped()).toBe(true)
+
+    state.zoom = 8
+    emit('move')
+    expect(isDraped()).toBe(true)
+
+    state.zoom = 4
+    emit('move')
+    expect(isDraped()).toBe(false)
+  })
+
+  it('holds the direct path right up to the start of the morph', async () => {
+    const { state, emit, isDraped } = await addLayer({ globe: true, zoom: 0 })
+
+    // smoothstep(5, 6, z) is still 0 at z=5.
+    state.zoom = 5
+    emit('move')
+    expect(isDraped()).toBe(false)
+  })
+
+  it('stays draped when the caller has not opted into pole rendering', async () => {
+    const { isDraped } = await addLayer(
+      { globe: true, zoom: 0 },
+      { renderPoles: false }
+    )
+    expect(isDraped()).toBe(true)
+  })
+
+  it('stays draped for a dataset the ECEF path cannot place', async () => {
+    // The direct path builds vertices from lon/lat, so it needs either a proj4
+    // definition or EPSG:4326 source coordinates.
+    const { isDraped } = await addLayer(
+      { globe: true, zoom: 0 },
+      { crs: 'EPSG:3857' }
+    )
+    expect(isDraped()).toBe(true)
+  })
+})
+
+describe('MapLibre never takes the Mapbox direct path', () => {
+  it('stays draped on a globe map without Mapbox internals', async () => {
+    // MapLibre has no draping API, so renderToTile is inert there — but it is
+    // also the discriminator: the probe for Mapbox-only internals is what
+    // keeps the Mapbox-specific ECEF program off a MapLibre map.
+    const { isDraped } = await addLayer({
+      globe: true,
+      zoom: 0,
+      mapboxInternals: false,
+    })
+    expect(isDraped()).toBe(true)
+  })
+
+  it('stays draped in mercator too', async () => {
+    const { isDraped } = await addLayer({
+      globe: false,
+      mapboxInternals: false,
+    })
+    expect(isDraped()).toBe(true)
+  })
+})

--- a/src/zarr-layer.test.ts
+++ b/src/zarr-layer.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ZarrLayer } from './zarr-layer'
+import type { MapLike } from './types'
+
+type Listener = (...args: unknown[]) => void
+
+const fakeMap = () => {
+  const map = {
+    on: vi.fn<(event: string, handler: Listener) => void>(),
+    off: vi.fn<(event: string, handler: Listener) => void>(),
+    triggerRepaint: vi.fn(),
+    getZoom: () => 0,
+  }
+  const handlersFor = (spy: typeof map.on, event: string) =>
+    spy.mock.calls
+      .filter(([name]) => name === event)
+      .map(([, handler]) => handler)
+  return {
+    map: map as unknown as MapLike,
+    subscribed: (event: string) => handlersFor(map.on, event),
+    unsubscribed: (event: string) => handlersFor(map.off, event),
+  }
+}
+
+// resolveGl only probes for these two members before accepting the context.
+// Anything past that fails, which drives the layer down its init-error path.
+const fakeGl = () =>
+  ({
+    getUniformLocation: () => null,
+    drawBuffers: () => {},
+  } as unknown as WebGL2RenderingContext)
+
+const makeLayer = () =>
+  new ZarrLayer({
+    id: 'zarr-layer',
+    source: 'https://example.invalid/missing.zarr',
+    variable: 'foo',
+    colormap: [
+      [0, 0, 0],
+      [255, 255, 255],
+    ],
+    clim: [0, 1],
+  })
+
+/**
+ * `map.remove()` reaches `Style._remove()`, which tears the style down without
+ * calling `onRemove` on custom layers. The layer subscribes to the map's own
+ * `remove` event so it releases its store either way.
+ */
+describe('ZarrLayer map lifecycle', () => {
+  it('subscribes to the map remove event when added', () => {
+    const { map, subscribed } = fakeMap()
+
+    makeLayer().onAdd(map, fakeGl())
+
+    expect(subscribed('remove')).toHaveLength(1)
+  })
+
+  it('subscribes before initialization so a failed init still has a hook', () => {
+    const { map, subscribed, unsubscribed } = fakeMap()
+
+    // This gl stub cannot satisfy colormap upload, so init throws and the
+    // layer disposes itself during onAdd.
+    makeLayer().onAdd(map, fakeGl())
+
+    expect(subscribed('remove')).toHaveLength(1)
+    expect(unsubscribed('remove')).toEqual(subscribed('remove'))
+  })
+
+  it('unsubscribes on removal so the map stops retaining it', () => {
+    const { map, subscribed, unsubscribed } = fakeMap()
+    const layer = makeLayer()
+
+    layer.onAdd(map, fakeGl())
+    layer.onRemove(map, fakeGl())
+
+    expect(unsubscribed('remove')).toEqual(subscribed('remove'))
+  })
+})

--- a/src/zarr-layer.ts
+++ b/src/zarr-layer.ts
@@ -135,6 +135,7 @@ export class ZarrLayer {
   private tileNeedsRender: boolean = true
 
   private projectionChangeHandler: (() => void) | null = null
+  private mapRemoveHandler: (() => void) | null = null
   private resolveGl(
     map: MapLike,
     gl: WebGL2RenderingContext | WebGLRenderingContext | null
@@ -519,6 +520,15 @@ export class ZarrLayer {
     this.map = map
     const resolvedGl = this.resolveGl(map, gl)
     this.gl = resolvedGl
+
+    // `map.remove()` tears down the style without calling `onRemove`, so the
+    // layer releases its store and GPU resources off the map's own event.
+    // Registered before initialization so a failed init still leaves a hook.
+    this.mapRemoveHandler = () => this._disposeResources(resolvedGl)
+    if (typeof map.on === 'function') {
+      map.on('remove', this.mapRemoveHandler)
+    }
+
     this.invalidate = () => {
       this.tileNeedsRender = true
       if (map.triggerRepaint) map.triggerRepaint()
@@ -864,6 +874,7 @@ export class ZarrLayer {
   private _disposeResources(
     gl: WebGL2RenderingContext | WebGLRenderingContext
   ): void {
+    if (this.isRemoved) return
     this.isRemoved = true
 
     this.renderer?.dispose()
@@ -879,15 +890,18 @@ export class ZarrLayer {
       this.zarrStore = null
     }
 
-    if (
-      this.map &&
-      this.projectionChangeHandler &&
-      typeof this.map.off === 'function'
-    ) {
-      this.map.off('projectionchange', this.projectionChangeHandler)
-      this.map.off('style.load', this.projectionChangeHandler)
-      this.map.off('move', this.projectionChangeHandler)
+    if (this.map && typeof this.map.off === 'function') {
+      if (this.projectionChangeHandler) {
+        this.map.off('projectionchange', this.projectionChangeHandler)
+        this.map.off('style.load', this.projectionChangeHandler)
+        this.map.off('move', this.projectionChangeHandler)
+      }
+      if (this.mapRemoveHandler) {
+        this.map.off('remove', this.mapRemoveHandler)
+      }
     }
+    this.projectionChangeHandler = null
+    this.mapRemoveHandler = null
   }
 
   onRemove(_map: MapLike, gl: WebGL2RenderingContext | WebGLRenderingContext) {

--- a/src/zarr-layer.ts
+++ b/src/zarr-layer.ts
@@ -349,14 +349,7 @@ export class ZarrLayer {
     this.customFrag = customFrag
     this.customUniforms = uniforms || {}
 
-    this.bandNames = getBands(variable, this.normalizedSelector)
-    if (this.bandNames.length > 1 || customFrag) {
-      this.customShaderConfig = {
-        bands: this.bandNames,
-        customFrag: customFrag,
-        customUniforms: this.customUniforms,
-      }
-    }
+    this.refreshCustomShaderConfig()
 
     if (fillValue !== undefined) this._fillValue = fillValue
     this.onLoadingStateChange = onLoadingStateChange
@@ -364,6 +357,25 @@ export class ZarrLayer {
     this.transformRequest = transformRequest
     this.customStore = store
     this.renderPoles = renderPoles
+  }
+
+  /**
+   * Recompute the band list and the shader variant it implies. More than one
+   * band, or any custom fragment, means the shader samples per-band textures
+   * rather than the main one, which the renderer needs to know so it can skip
+   * building data only the main texture would consume.
+   */
+  private refreshCustomShaderConfig(): void {
+    this.bandNames = getBands(this.variable, this.normalizedSelector)
+    this.customShaderConfig =
+      this.bandNames.length > 1 || this.customFrag
+        ? {
+            bands: this.bandNames,
+            customFrag: this.customFrag,
+            customUniforms: this.customUniforms,
+          }
+        : null
+    this.regionRenderer?.setRendersFromBandTextures(!!this.customShaderConfig)
   }
 
   private emitLoadingState(): void {
@@ -485,16 +497,7 @@ export class ZarrLayer {
     this.selector = selector
     this.normalizedSelector = normalized
 
-    this.bandNames = getBands(this.variable, this.normalizedSelector)
-    if (this.bandNames.length > 1 || this.customFrag) {
-      this.customShaderConfig = {
-        bands: this.bandNames,
-        customFrag: this.customFrag,
-        customUniforms: this.customUniforms,
-      }
-    } else {
-      this.customShaderConfig = null
-    }
+    this.refreshCustomShaderConfig()
 
     if (this.regionRenderer) {
       await this.regionRenderer.setSelector(this.normalizedSelector)
@@ -593,6 +596,9 @@ export class ZarrLayer {
     // Lock immediately after the renderer captures the value, before async initialize()
     this.dataScaleLocked = true
 
+    // The shader variant was resolved during initialize(), before this
+    // renderer existed, so hand it over before the first fetch.
+    this.regionRenderer.setRendersFromBandTextures(!!this.customShaderConfig)
     this.regionRenderer.setLoadingCallback(this.handleChunkLoadingChange)
     await this.regionRenderer.initialize()
 
@@ -637,16 +643,7 @@ export class ZarrLayer {
       this.normalizedSelector = normalizeSelector(this.selector)
       await this.loadInitialDimensionValues()
 
-      this.bandNames = getBands(this.variable, this.normalizedSelector)
-      if (this.bandNames.length > 1 || this.customFrag) {
-        this.customShaderConfig = {
-          bands: this.bandNames,
-          customFrag: this.customFrag,
-          customUniforms: this.customUniforms,
-        }
-      } else {
-        this.customShaderConfig = null
-      }
+      this.refreshCustomShaderConfig()
     } catch (err) {
       // Clean up partially-initialized store before re-throwing
       if (this.zarrStore) {

--- a/src/zarr-store.test.ts
+++ b/src/zarr-store.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from 'vitest'
+import { ZarrStore } from './zarr-store'
+import {
+  buildMemoryZarrStore,
+  ramp,
+  type MemoryStore,
+} from './__fixtures__/memory-zarr'
+
+/**
+ * Integration test for the metadata → description pipeline. A hand-authored,
+ * in-memory Zarr v3 store (no network/fs/GL) is driven through the real
+ * `ZarrStore._initialize()` path, asserting that `describe()` reflects the
+ * fixture's structure and that bounds / orientation are correctly DETECTED
+ * from the coordinate arrays (not supplied explicitly).
+ */
+
+// 4-lat × 8-lon grid; coordinates are pixel centers on a 45° grid, lat ordered
+// north-first (descending). Half-pixel expansion + global snap should yield an
+// exactly-global extent, and the descending lat should be detected.
+const LAT_CENTERS = [67.5, 22.5, -22.5, -67.5]
+const LON_CENTERS = [-157.5, -112.5, -67.5, -22.5, 22.5, 67.5, 112.5, 157.5]
+
+function makeStore(): MemoryStore {
+  return buildMemoryZarrStore({
+    arrays: [
+      {
+        name: 'temperature',
+        shape: [2, 4, 8],
+        chunkShape: [2, 4, 8],
+        dtype: 'float32',
+        fillValue: -9999,
+        dimensionNames: ['time', 'lat', 'lon'],
+        attributes: { scale_factor: 0.1, add_offset: 5 },
+        chunks: { '0/0/0': ramp(2 * 4 * 8) },
+      },
+      {
+        name: 'lat',
+        shape: [4],
+        chunkShape: [4],
+        dimensionNames: ['lat'],
+        chunks: { '0': LAT_CENTERS },
+      },
+      {
+        name: 'lon',
+        shape: [8],
+        chunkShape: [8],
+        dimensionNames: ['lon'],
+        chunks: { '0': LON_CENTERS },
+      },
+    ],
+  })
+}
+
+describe('ZarrStore (in-memory v3 fixture)', () => {
+  it('reads array metadata into the store description', async () => {
+    const store = new ZarrStore({
+      customStore: makeStore(),
+      variable: 'temperature',
+      version: 3,
+    })
+    await store.initialized
+    const d = store.describe()
+
+    expect(d.dimensions).toEqual(['time', 'lat', 'lon'])
+    expect(d.shape).toEqual([2, 4, 8])
+    expect(d.chunks).toEqual([2, 4, 8])
+    expect(d.dtype).toBe('float32')
+    expect(d.fill_value).toBe(-9999)
+    expect(d.scaleFactor).toBe(0.1)
+    expect(d.addOffset).toBe(5)
+    expect(d.multiscaleType).toBe('none')
+  })
+
+  it('identifies spatial dimension indices', async () => {
+    const store = new ZarrStore({
+      customStore: makeStore(),
+      variable: 'temperature',
+      version: 3,
+    })
+    await store.initialized
+    const { dimIndices } = store.describe()
+
+    expect(dimIndices.lat?.index).toBe(1)
+    expect(dimIndices.lon?.index).toBe(2)
+    expect(dimIndices.time?.index).toBe(0)
+  })
+
+  it('detects bounds and orientation from coordinate arrays', async () => {
+    const store = new ZarrStore({
+      customStore: makeStore(),
+      variable: 'temperature',
+      version: 3,
+    })
+    await store.initialized
+    const d = store.describe()
+
+    // Half-pixel expansion (45° spacing → ±22.5°) + global snap → exactly global.
+    expect(d.xyLimits).toEqual({ xMin: -180, xMax: 180, yMin: -90, yMax: 90 })
+    // lat is north-first (67.5 → -67.5), so row 0 is north.
+    expect(d.latIsAscending).toBe(false)
+    // Degree-range bounds → EPSG:4326 inferred.
+    expect(d.crs).toBe('EPSG:4326')
+  })
+
+  it('opens the variable array and decodes a chunk', async () => {
+    const store = new ZarrStore({
+      customStore: makeStore(),
+      variable: 'temperature',
+      version: 3,
+    })
+    await store.initialized
+
+    const array = await store.getArray()
+    const chunk = await array.getChunk([0, 0, 0])
+    expect(Array.from(chunk.data as ArrayLike<number>)).toEqual(ramp(2 * 4 * 8))
+  })
+
+  it('infers EPSG:3857 from metric coordinates', async () => {
+    const metric = buildMemoryZarrStore({
+      arrays: [
+        {
+          name: 'temperature',
+          shape: [4, 8],
+          chunkShape: [4, 8],
+          dimensionNames: ['lat', 'lon'],
+        },
+        {
+          name: 'lat',
+          shape: [4],
+          chunkShape: [4],
+          dimensionNames: ['lat'],
+          chunks: { '0': [6e6, 2e6, -2e6, -6e6] },
+        },
+        {
+          name: 'lon',
+          shape: [8],
+          chunkShape: [8],
+          dimensionNames: ['lon'],
+          chunks: { '0': [-1.4e7, -1e7, -6e6, -2e6, 2e6, 6e6, 1e7, 1.4e7] },
+        },
+      ],
+    })
+    const store = new ZarrStore({
+      customStore: metric,
+      variable: 'temperature',
+      version: 3,
+    })
+    await store.initialized
+    expect(store.describe().crs).toBe('EPSG:3857')
+  })
+})
+
+/**
+ * The multiscale classifier (`_getPyramidMetadata`/`_parseUntiledMultiscale`)
+ * sniffs three metadata layouts and picks the render mode + CRS. A wrong guess
+ * fails silently (wrong mode/CRS, never throws), so these pin each layout's
+ * classification. Untiled cases pass explicit bounds + orientation so the path
+ * skips coordinate-array reads and isolates the classification logic.
+ */
+
+/** Build a pyramid store: root `multiscales` attr + one variable array per level. */
+function pyramidStore(multiscales: unknown, levels: string[]): MemoryStore {
+  return buildMemoryZarrStore({
+    attributes: { multiscales },
+    arrays: levels.map((lvl) => ({
+      name: `${lvl}/temperature`,
+      shape: [256, 256],
+      chunkShape: [256, 256],
+      dimensionNames: ['lat', 'lon'],
+    })),
+  })
+}
+
+describe('ZarrStore multiscale classification', () => {
+  it('classifies an OME-NGFF pyramid with pixels_per_tile as tiled', async () => {
+    const store = new ZarrStore({
+      customStore: pyramidStore(
+        [
+          {
+            datasets: [
+              { path: '0', pixels_per_tile: 256, crs: 'EPSG:4326' },
+              { path: '1', pixels_per_tile: 256, crs: 'EPSG:4326' },
+            ],
+          },
+        ],
+        ['0', '1']
+      ),
+      variable: 'temperature',
+      version: 3,
+    })
+    await store.initialized
+    const d = store.describe()
+
+    expect(d.multiscaleType).toBe('tiled')
+    expect(d.levels).toEqual(['0', '1'])
+    expect(d.crs).toBe('EPSG:4326')
+    // Tiled pyramids default to a global extent, north-first.
+    expect(d.xyLimits).toEqual({ xMin: -180, xMax: 180, yMin: -90, yMax: 90 })
+    expect(d.latIsAscending).toBe(false)
+  })
+
+  it('classifies an OME-NGFF pyramid without pixels_per_tile as untiled', async () => {
+    const store = new ZarrStore({
+      customStore: pyramidStore(
+        [{ datasets: [{ path: '0' }, { path: '1' }] }],
+        ['0', '1']
+      ),
+      variable: 'temperature',
+      version: 3,
+      bounds: [-180, -90, 180, 90],
+      latIsAscending: false,
+    })
+    await store.initialized
+    const d = store.describe()
+
+    expect(d.multiscaleType).toBe('untiled')
+    expect(d.levels).toEqual(['0', '1'])
+    expect(d.untiledLevels.map((l) => l.asset)).toEqual(['0', '1'])
+    // Intentionally NOT pinned here:
+    //  - crs: an untiled pyramid with absent CRS currently resolves to EPSG:3857
+    //    (the classifier defaults there and bounds inference never demotes to
+    //    EPSG:4326). That looks incidental rather than intentional, so we don't
+    //    cement it — see the CRS-resolution test for the tiled default.
+  })
+
+  it('classifies a zarr-conventions layout pyramid as untiled with transforms', async () => {
+    const store = new ZarrStore({
+      customStore: pyramidStore(
+        {
+          layout: [
+            { asset: '0', transform: { scale: [1, 1], translation: [0, 0] } },
+            { asset: '1', transform: { scale: [2, 2], translation: [0, 0] } },
+          ],
+          crs: 'EPSG:4326',
+        },
+        ['0', '1']
+      ),
+      variable: 'temperature',
+      version: 3,
+      bounds: [-180, -90, 180, 90],
+      latIsAscending: false,
+    })
+    await store.initialized
+    const d = store.describe()
+
+    expect(d.multiscaleType).toBe('untiled')
+    expect(d.levels).toEqual(['0', '1'])
+    expect(d.crs).toBe('EPSG:4326')
+    expect(d.untiledLevels).toEqual([
+      { asset: '0', scale: [1, 1], translation: [0, 0] },
+      { asset: '1', scale: [2, 2], translation: [0, 0] },
+    ])
+  })
+
+  it('resolves the CRS of a tiled OME-NGFF pyramid from the dataset crs field', async () => {
+    // All datasets here are tiled (pixels_per_tile present). A tiled (slippy-map)
+    // pyramid with absent CRS conventionally defaults to Web Mercator, so pinning
+    // the tiled default is intentional — unlike the untiled-absent case above.
+    const crsFor = async (crs?: string) => {
+      const dataset = {
+        path: '0',
+        pixels_per_tile: 256,
+        ...(crs ? { crs } : {}),
+      }
+      const store = new ZarrStore({
+        customStore: pyramidStore([{ datasets: [dataset] }], ['0']),
+        variable: 'temperature',
+        version: 3,
+      })
+      await store.initialized
+      return store.describe().crs
+    }
+    expect(await crsFor(undefined)).toBe('EPSG:3857')
+    expect(await crsFor('EPSG:4326')).toBe('EPSG:4326')
+    expect(await crsFor('EPSG:3857')).toBe('EPSG:3857')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,5 +7,9 @@ export default defineConfig({
     // (see src/shaders.test.ts).
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    // The renderer wiring tests decode real chunks through zarrita and proj4,
+    // which takes a few hundred ms each and inflates several-fold when the
+    // whole suite transforms and runs across parallel workers.
+    testTimeout: 15000,
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // Pure-logic unit tests run in Node; no DOM/WebGL is required because
+    // shader behavior is verified by math parity rather than a live GL context
+    // (see src/shaders.test.ts).
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
This is a big refactor targeting testability. it breaks a lot of things out of monolith files, adds vitest, and creates tests for lots of functionality. coverage additions will be ongoing for a while. It also improves a few fragile areas around cache size growth, async state, and resource cleanup. 