### PR TITLE
Better geozarr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,37 @@ See the [demo](https://zarr-layer.demo.carbonplan.org/) for a quick tour of capa
 
 Supports v2 and v3 zarr stores via [zarrita](https://github.com/manzt/zarrita.js). Arbitrary CRS support via [proj4](https://github.com/proj4js/proj4js) reprojection.
 
+### Self-describing stores
+
+A store that carries the zarr [`proj`](https://github.com/zarr-conventions/geo-proj) and [`spatial`](https://github.com/zarr-conventions/spatial) conventions needs no configuration: the layer reads its CRS, extent, orientation and axis names straight out of the metadata, with no coordinate-array reads at all.
+
+| Attribute                     | What it settles                                                                                                                                                         |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `proj:code`                   | The CRS by identifier. `EPSG:4326`, `EPSG:3857` and `OGC:CRS84` render natively; anything proj4 has a built-in definition for (all UTM zones, among others) reprojects. |
+| `proj:wkt2` / `proj:projjson` | The CRS in full, for codes proj4 doesn't ship. No lookup table needed.                                                                                                  |
+| `spatial:transform`           | The extent and which edge row 0 sits on.                                                                                                                                |
+| `spatial:bbox`                | The extent, when the transform is absent or rotated.                                                                                                                    |
+| `spatial:registration`        | Whether the declared coordinates fall on cell edges (`pixel`, the default) or cell centers (`node`).                                                                    |
+| `spatial:dimensions`          | Which array dimensions are y and x, for axes not named something recognizable.                                                                                          |
+| `spatial:shape`               | Each pyramid level's size, on `multiscales.layout` entries, sparing an array open per level.                                                                            |
+
+Declared attributes are authoritative. If a store publishes them, they are used as-is rather than checked against its coordinate arrays, so a store whose attributes disagree with its own data will render wrong rather than be quietly corrected.
+
+Constructor options always win over what the store declares: `crs`, `proj4`, `bounds`, `latIsAscending` and `spatialDimensions` each override the corresponding attribute.
+
+For a store declaring a `proj:code` proj4 doesn't know and no `proj:wkt2` or `proj:projjson`, the layer warns and leaves the CRS unresolved. Register the definition before creating the layer:
+
+```ts
+import proj4 from 'proj4'
+
+proj4.defs(
+  'EPSG:5070',
+  '+proj=aea +lat_1=29.5 +lat_2=45.5 +lat_0=23 +lon_0=-96 +datum=NAD83 +units=m'
+)
+```
+
+Where these attributes are absent the layer falls back to what it always did: reading the coordinate arrays for extent and orientation, matching dimension names against a list of common aliases, and inferring the CRS from the magnitude of the bounds. A CF `grid_mapping` variable is read for `crs_wkt` when no `proj:` attribute is present.
+
 ### Multiscales
 
 High resolution datasets require multiscales. Chunks are loaded based on viewport intersection, and the level is chosen to match the screen resolution. Supports the zarr [multiscales convention](https://github.com/zarr-conventions/multiscales) and legacy [ndpyramid](https://github.com/carbonplan/ndpyramid) outputs, and tries to interpret other multiscale formats. See [topozarr](https://github.com/norlandrhagen/topozarr) for a look at how to create these datasets.
@@ -223,6 +254,8 @@ new ZarrLayer({
 ## custom projections
 
 For datasets in non-standard projections (e.g., Lambert Conformal Conic, UTM), provide a `proj4` definition string. Specifying `bounds` in source CRS units is recommended for performance (otherwise derived from coordinate arrays). If you set `crs` to a non-`EPSG:4326`/`EPSG:3857` value without `proj4`, the renderer will warn and fall back to inferred CRS.
+
+None of this is needed for a store carrying the `proj` and `spatial` conventions — see [self-describing stores](#self-describing-stores).
 
 ```ts
 new ZarrLayer({

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ Supports v2 and v3 zarr stores via [zarrita](https://github.com/manzt/zarrita.js
 
 A store that carries the zarr [`proj`](https://github.com/zarr-conventions/geo-proj) and [`spatial`](https://github.com/zarr-conventions/spatial) conventions needs no configuration: the layer reads its CRS, extent, orientation and axis names straight out of the metadata, with no coordinate-array reads at all.
 
-| Attribute                     | What it settles                                                                                                                                                         |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `proj:code`                   | The CRS by identifier. `EPSG:4326`, `EPSG:3857` and `OGC:CRS84` render natively; anything proj4 has a built-in definition for (all UTM zones, among others) reprojects. |
-| `proj:wkt2` / `proj:projjson` | The CRS in full, for codes proj4 doesn't ship. No lookup table needed.                                                                                                  |
-| `spatial:transform`           | The extent and which edge row 0 sits on.                                                                                                                                |
-| `spatial:bbox`                | The extent, when the transform is absent or rotated.                                                                                                                    |
-| `spatial:registration`        | Whether the declared coordinates fall on cell edges (`pixel`, the default) or cell centers (`node`).                                                                    |
-| `spatial:dimensions`          | Which array dimensions are y and x, for axes not named something recognizable.                                                                                          |
-| `spatial:shape`               | Each pyramid level's size, on `multiscales.layout` entries, sparing an array open per level.                                                                            |
+| Attribute                     | What it settles                                                                                                                              |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `proj:code`                   | The CRS by identifier: `EPSG:4326`, `EPSG:3857`, `OGC:CRS84`, or anything proj4 has a built-in definition for (all UTM zones, among others). |
+| `proj:wkt2` / `proj:projjson` | The CRS in full, for codes proj4 doesn't ship. No lookup table needed.                                                                       |
+| `spatial:transform`           | The extent and which edge row 0 sits on.                                                                                                     |
+| `spatial:bbox`                | The extent, when the transform is absent or rotated.                                                                                         |
+| `spatial:registration`        | Whether the declared coordinates fall on cell edges (`pixel`, the default) or cell centers (`node`).                                         |
+| `spatial:dimensions`          | Which array dimensions are y and x, for axes not named something recognizable.                                                               |
+| `spatial:shape`               | Each pyramid level's size, on `multiscales.layout` entries, sparing an array open per level.                                                 |
 
 Declared attributes are authoritative. If a store publishes them, they are used as-is rather than checked against its coordinate arrays, so a store whose attributes disagree with its own data will render wrong rather than be quietly corrected.
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ new ZarrLayer({
 
 ## custom projections
 
-For datasets in non-standard projections (e.g., Lambert Conformal Conic, UTM), provide a `proj4` definition string. Specifying `bounds` in source CRS units is recommended for performance (otherwise derived from coordinate arrays). If you set `crs` to a non-`EPSG:4326`/`EPSG:3857` value without `proj4`, the renderer will warn and fall back to inferred CRS.
+For datasets in non-standard projections (e.g., Lambert Conformal Conic, UTM), set `crs` to the code. Any code proj4 ships a definition for (all UTM zones, among others) or that you have registered with `proj4.defs` resolves with no further configuration; for anything else, provide a `proj4` definition string alongside it, or the renderer will warn and fall back to inferred CRS. Specifying `bounds` in source CRS units is recommended for performance (otherwise derived from coordinate arrays).
 
 None of this is needed for a store carrying the `proj` and `spatial` conventions — see [self-describing stores](#self-describing-stores).
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ new ZarrLayer({
 
 ## custom projections
 
-For datasets in non-standard projections (e.g., Lambert Conformal Conic, UTM), set `crs` to the code. Any code proj4 ships a definition for (all UTM zones, among others) or that you have registered with `proj4.defs` resolves with no further configuration; for anything else, provide a `proj4` definition string alongside it, or the renderer will warn and fall back to inferred CRS. Specifying `bounds` in source CRS units is recommended for performance (otherwise derived from coordinate arrays).
+For datasets in projections beyond the two native CRSs (e.g., Lambert Conformal Conic, UTM), set `crs` to the code. Any code proj4 ships a definition for (all UTM zones, among others) or that you have registered with `proj4.defs` resolves with no further configuration; for anything else, provide a `proj4` definition string alongside it, or the renderer will warn and fall back to inferred CRS. Specifying `bounds` in source CRS units is recommended for performance (otherwise derived from coordinate arrays).
 
 None of this is needed for a store carrying the `proj` and `spatial` conventions — see [self-describing stores](#self-describing-stores).
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ map.on('load', () => {
 | maxzoom | number | `Infinity` | Maximum zoom level for rendering |
 | fillValue | number | auto | No-data value (from metadata if not set) |
 | spatialDimensions | object | auto | Custom `{ lat, lon }` dim names |
-| crs | string | auto | CRS identifier for built-in projections (`EPSG:4326` or `EPSG:3857`). For other CRS, use `proj4`. |
+| crs | string | auto | CRS identifier. `EPSG:4326`/`EPSG:3857` render natively; any other code proj4 has a definition for (all UTM zones, among others) or that was registered with `proj4.defs` reprojects without a `proj4` string. |
 | proj4 | string | - | Proj4 definition string for CRS reprojection (`bounds` recommended, else derived from coordinates) |
 | bounds | array | auto | `[xMin, yMin, xMax, yMax]` in source CRS units (degrees for EPSG:4326, meters for EPSG:3857). These are interpreted as edge bounds (not center-to-center) |
 | latIsAscending | boolean | auto | Latitude orientation |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A store that carries the zarr [`proj`](https://github.com/zarr-conventions/geo-p
 | `proj:code`                   | The CRS by identifier: `EPSG:4326`, `EPSG:3857`, `OGC:CRS84`, or anything proj4 has a built-in definition for (all UTM zones, among others). |
 | `proj:wkt2` / `proj:projjson` | The CRS in full, for codes proj4 doesn't ship. No lookup table needed.                                                                       |
 | `spatial:transform`           | The extent and which edge row 0 sits on.                                                                                                     |
-| `spatial:bbox`                | The extent, when the transform is absent or rotated.                                                                                         |
+| `spatial:bbox`                | The extent, winning over the transform's when both are declared.                                                                             |
 | `spatial:registration`        | Whether the declared coordinates fall on cell edges (`pixel`, the default) or cell centers (`node`).                                         |
 | `spatial:dimensions`          | Which array dimensions are y and x, for axes not named something recognizable.                                                               |
 | `spatial:shape`               | Each pyramid level's size, on `multiscales.layout` entries, sparing an array open per level.                                                 |

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ map.on('load', () => {
 | maxzoom | number | `Infinity` | Maximum zoom level for rendering |
 | fillValue | number | auto | No-data value (from metadata if not set) |
 | spatialDimensions | object | auto | Custom `{ lat, lon }` dim names |
-| crs | string | auto | CRS identifier. `EPSG:4326`/`EPSG:3857` render natively; any other code proj4 has a definition for (all UTM zones, among others) or that was registered with `proj4.defs` reprojects without a `proj4` string. |
+| crs | string | auto | CRS identifier. Not needed for `EPSG:4326`/`EPSG:3857` data (detected automatically). Any code proj4 has a definition for (all UTM zones, among others) or that was registered with `proj4.defs` works without a `proj4` string. |
 | proj4 | string | - | Proj4 definition string for CRS reprojection (`bounds` recommended, else derived from coordinates) |
 | bounds | array | auto | `[xMin, yMin, xMax, yMax]` in source CRS units (degrees for EPSG:4326, meters for EPSG:3857). These are interpreted as edge bounds (not center-to-center) |
 | latIsAscending | boolean | auto | Latitude orientation |
@@ -253,7 +253,7 @@ new ZarrLayer({
 
 ## custom projections
 
-For datasets in projections beyond the two native CRSs (e.g., Lambert Conformal Conic, UTM), set `crs` to the code. Any code proj4 ships a definition for (all UTM zones, among others) or that you have registered with `proj4.defs` resolves with no further configuration; for anything else, provide a `proj4` definition string alongside it, or the renderer will warn and fall back to inferred CRS. Specifying `bounds` in source CRS units is recommended for performance (otherwise derived from coordinate arrays).
+Datasets in EPSG:4326 or EPSG:3857 need no CRS configuration. For anything else (e.g., Lambert Conformal Conic, UTM), set `crs` to the code. Any code proj4 ships a definition for (all UTM zones, among others) or that you have registered with `proj4.defs` resolves with no further configuration; for anything else, provide a `proj4` definition string alongside it, or the renderer will warn and fall back to inferred CRS. Specifying `bounds` in source CRS units is recommended for performance (otherwise derived from coordinate arrays).
 
 None of this is needed for a store carrying the `proj` and `spatial` conventions — see [self-describing stores](#self-describing-stores).
 

--- a/src/geozarr.test.ts
+++ b/src/geozarr.test.ts
@@ -307,20 +307,16 @@ describe('boundsFromSpatialAttrs', () => {
     ).toBeNull()
   })
 
-  it('still uses a bbox declared alongside a rotated transform', () => {
-    const rotated = boundsFromSpatialAttrs(
-      attrs({ bbox: [0, 0, 90, 45], transform: [10, 1, 5e5, 1, -10, 5e6] }),
-      GRID
-    )
-
-    expect(rotated).toEqual({
-      xMin: 0,
-      yMin: 0,
-      xMax: 90,
-      yMax: 45,
-      // The rotation makes the row direction unusable even for orientation.
-      latIsAscending: null,
-    })
+  it('rejects a rotated grid even when a bbox encloses it', () => {
+    // The bbox bounds the rotated footprint, but the renderer maps rows and
+    // columns linearly across it, which would draw the raster unrotated and
+    // stretched to the corners.
+    expect(
+      boundsFromSpatialAttrs(
+        attrs({ bbox: [0, 0, 90, 45], transform: [10, 1, 5e5, 1, -10, 5e6] }),
+        GRID
+      )
+    ).toBeNull()
   })
 
   it('rejects a transform type it cannot map to a grid', () => {

--- a/src/geozarr.test.ts
+++ b/src/geozarr.test.ts
@@ -76,6 +76,50 @@ describe('parseGeoZarrAttrs', () => {
     expect(attrs.registration).toBe('node')
   })
 
+  it('lets the nearest source in the chain win', () => {
+    const attrs = parseGeoZarrAttrs(
+      { 'proj:code': 'EPSG:4326', 'spatial:registration': 'node' },
+      { 'proj:code': 'EPSG:3857' },
+      { 'spatial:transform': TRANSFORM }
+    )
+
+    // The level group beats the root; the array declares no proj: at all.
+    expect(attrs.crs?.code).toBe('EPSG:3857')
+    // Untouched all the way down, so the root's value still applies.
+    expect(attrs.registration).toBe('node')
+    expect(attrs.transform).toEqual(TRANSFORM)
+  })
+
+  it('takes a proj: declaration whole from the nearest source', () => {
+    const attrs = parseGeoZarrAttrs(
+      { 'proj:code': 'EPSG:4326', 'proj:wkt2': 'GEOGCRS["WGS 84"]' },
+      { 'proj:code': 'EPSG:32631' }
+    )
+
+    // Blending the level's code with the root's wkt2 would compose two
+    // different coordinate systems.
+    expect(attrs.crs).toEqual({
+      code: 'EPSG:32631',
+      wkt2: undefined,
+      projjson: undefined,
+    })
+  })
+
+  it('overrides spatial: one property at a time', () => {
+    const attrs = parseGeoZarrAttrs(
+      {
+        'spatial:bbox': [0, 0, 90, 45],
+        'spatial:dimensions': ['y', 'x'],
+        'spatial:registration': 'node',
+      },
+      { 'spatial:bbox': [10, 10, 20, 20] }
+    )
+
+    expect(attrs.bbox).toEqual([10, 10, 20, 20])
+    expect(attrs.dimensions).toEqual(['y', 'x'])
+    expect(attrs.registration).toBe('node')
+  })
+
   it('carries a code-only CRS through without a wkt2 or projjson', () => {
     const attrs = parseGeoZarrAttrs({ 'proj:code': 'EPSG:5070' }, undefined)
 

--- a/src/geozarr.test.ts
+++ b/src/geozarr.test.ts
@@ -139,6 +139,15 @@ describe('parseGeoZarrAttrs', () => {
     expect(attrs.transform).toEqual(rotated)
   })
 
+  it('preserves a quarter-turn transform, whose resolutions are both zero', () => {
+    const quarterTurn = [0, 10, 500000, 10, 0, 5000000]
+    const attrs = parseGeoZarrAttrs(undefined, {
+      'spatial:transform': quarterTurn,
+    })
+
+    expect(attrs.transform).toEqual(quarterTurn)
+  })
+
   it('reports a non-affine transform type verbatim', () => {
     const attrs = parseGeoZarrAttrs(undefined, {
       'spatial:transform_type': 'rpc',
@@ -358,6 +367,15 @@ describe('boundsFromSpatialAttrs', () => {
     expect(
       boundsFromSpatialAttrs(
         attrs({ bbox: [0, 0, 90, 45], transform: [10, 1, 5e5, 1, -10, 5e6] }),
+        GRID
+      )
+    ).toBeNull()
+  })
+
+  it('rejects a quarter-turn rotated grid the same way', () => {
+    expect(
+      boundsFromSpatialAttrs(
+        attrs({ bbox: [0, 0, 90, 45], transform: [0, 10, 5e5, 10, 0, 5e6] }),
         GRID
       )
     ).toBeNull()

--- a/src/geozarr.test.ts
+++ b/src/geozarr.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  parseGeoZarrAttrs,
+  parseLayoutItemSpatial,
+  type GeoZarrAttrs,
+} from './geozarr'
+
+/**
+ * Unit tests for the zarr-conventions attribute readers. Everything here is
+ * pure: attribute objects in, parsed values out, with malformed input expected
+ * to warn and drop rather than throw.
+ */
+
+const silenceWarnings = () =>
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// A north-up 10 m grid at the origin of a UTM-style projected CRS.
+const TRANSFORM = [10, 0, 500000, 0, -10, 5000000]
+
+describe('parseGeoZarrAttrs', () => {
+  it('defaults registration and transform type when nothing is declared', () => {
+    const attrs = parseGeoZarrAttrs(undefined, undefined)
+
+    expect(attrs.registration).toBe('pixel')
+    expect(attrs.transformType).toBe('affine')
+    expect(attrs.crs).toBeUndefined()
+    expect(attrs.bbox).toBeUndefined()
+    expect(attrs.transform).toBeUndefined()
+    expect(attrs.shape).toBeUndefined()
+    expect(attrs.dimensions).toBeUndefined()
+  })
+
+  it('reads every proj: and spatial: field', () => {
+    const projjson = {
+      type: 'ProjectedCRS',
+      id: { authority: 'EPSG', code: 32631 },
+    }
+    const attrs = parseGeoZarrAttrs(undefined, {
+      'proj:code': 'EPSG:32631',
+      'proj:wkt2': 'PROJCRS["WGS 84 / UTM zone 31N"]',
+      'proj:projjson': projjson,
+      'spatial:bbox': [500000, 4990000, 600000, 5000000],
+      'spatial:transform': TRANSFORM,
+      'spatial:shape': [1000, 10000],
+      'spatial:dimensions': ['y', 'x'],
+      'spatial:registration': 'node',
+      'spatial:transform_type': 'affine',
+    })
+
+    expect(attrs.crs).toEqual({
+      code: 'EPSG:32631',
+      wkt2: 'PROJCRS["WGS 84 / UTM zone 31N"]',
+      projjson,
+    })
+    expect(attrs.bbox).toEqual([500000, 4990000, 600000, 5000000])
+    expect(attrs.transform).toEqual(TRANSFORM)
+    expect(attrs.shape).toEqual([1000, 10000])
+    expect(attrs.dimensions).toEqual(['y', 'x'])
+    expect(attrs.registration).toBe('node')
+    expect(attrs.transformType).toBe('affine')
+  })
+
+  it('lets array attributes override the group they inherit from', () => {
+    const attrs = parseGeoZarrAttrs(
+      { 'proj:code': 'EPSG:4326', 'spatial:registration': 'node' },
+      { 'proj:code': 'EPSG:3857' }
+    )
+
+    expect(attrs.crs?.code).toBe('EPSG:3857')
+    // Untouched by the array, so the group's value still applies.
+    expect(attrs.registration).toBe('node')
+  })
+
+  it('carries a code-only CRS through without a wkt2 or projjson', () => {
+    const attrs = parseGeoZarrAttrs({ 'proj:code': 'EPSG:5070' }, undefined)
+
+    expect(attrs.crs).toEqual({
+      code: 'EPSG:5070',
+      wkt2: undefined,
+      projjson: undefined,
+    })
+  })
+
+  it('preserves a rotated transform for the caller to reject', () => {
+    const rotated = [10, 1, 500000, 1, -10, 5000000]
+    const attrs = parseGeoZarrAttrs(undefined, {
+      'spatial:transform': rotated,
+    })
+
+    expect(attrs.transform).toEqual(rotated)
+  })
+
+  it('reports a non-affine transform type verbatim', () => {
+    const attrs = parseGeoZarrAttrs(undefined, {
+      'spatial:transform_type': 'rpc',
+    })
+
+    expect(attrs.transformType).toBe('rpc')
+  })
+
+  const dropped: [string, unknown, (a: GeoZarrAttrs) => unknown][] = [
+    ['spatial:bbox', [1, 2, 3], (a) => a.bbox],
+    ['spatial:bbox', [1, 2, 'three', 4], (a) => a.bbox],
+    ['spatial:bbox', [10, 0, 0, 10], (a) => a.bbox],
+    ['spatial:transform', [1, 2, 3], (a) => a.transform],
+    ['spatial:transform', [0, 0, 500000, 0, -10, 5000000], (a) => a.transform],
+    ['spatial:shape', [10.5, 10], (a) => a.shape],
+    ['spatial:shape', [0, 10], (a) => a.shape],
+    ['spatial:shape', [10], (a) => a.shape],
+    ['spatial:dimensions', ['y'], (a) => a.dimensions],
+    ['spatial:dimensions', ['y', ''], (a) => a.dimensions],
+    ['proj:code', 42, (a) => a.crs],
+    ['proj:wkt2', '', (a) => a.crs],
+    ['proj:projjson', ['not', 'an', 'object'], (a) => a.crs],
+  ]
+
+  it.each(dropped)(
+    'drops a malformed %s with a warning',
+    (key, value, read) => {
+      const warn = silenceWarnings()
+
+      expect(
+        read(parseGeoZarrAttrs(undefined, { [key]: value }))
+      ).toBeUndefined()
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(key))
+    }
+  )
+
+  it('falls back to pixel registration when the value is unrecognized', () => {
+    const warn = silenceWarnings()
+    const attrs = parseGeoZarrAttrs(undefined, {
+      'spatial:registration': 'centre',
+    })
+
+    expect(attrs.registration).toBe('pixel')
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('spatial:registration')
+    )
+  })
+})
+
+describe('parseLayoutItemSpatial', () => {
+  it('reads the per-level fields sitting alongside asset', () => {
+    expect(
+      parseLayoutItemSpatial({
+        asset: 'r10m',
+        transform: { scale: [1, 1], translation: [0, 0] },
+        'spatial:transform': TRANSFORM,
+        'spatial:shape': [10000, 10000],
+      })
+    ).toEqual({ transform: TRANSFORM, shape: [10000, 10000] })
+  })
+
+  it('returns nothing for an entry carrying only relative transforms', () => {
+    expect(
+      parseLayoutItemSpatial({
+        asset: '0',
+        transform: { scale: [2, 2], translation: [0, 0] },
+      })
+    ).toEqual({ transform: undefined, shape: undefined })
+  })
+
+  it.each([[null], [undefined], ['0'], [[1, 2]]])(
+    'returns nothing for a non-object entry (%s)',
+    (item) => {
+      expect(parseLayoutItemSpatial(item)).toEqual({
+        transform: undefined,
+        shape: undefined,
+      })
+    }
+  )
+})

--- a/src/geozarr.test.ts
+++ b/src/geozarr.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
   parseGeoZarrAttrs,
   parseLayoutItemSpatial,
+  boundsFromSpatialAttrs,
   type GeoZarrAttrs,
 } from './geozarr'
 
@@ -173,4 +174,174 @@ describe('parseLayoutItemSpatial', () => {
       })
     }
   )
+})
+
+/**
+ * A 100-column by 50-row grid on a 10 m north-up transform, the shape
+ * `spatial:transform` is written for. Its edges are x 500000..501000 and
+ * y 4999500..5000000.
+ */
+const GRID = { nCols: 100, nRows: 50 }
+
+const attrs = (over: Partial<GeoZarrAttrs> = {}): GeoZarrAttrs => ({
+  registration: 'pixel',
+  transformType: 'affine',
+  ...over,
+})
+
+describe('boundsFromSpatialAttrs', () => {
+  it('walks a north-up transform out to the grid edges', () => {
+    expect(
+      boundsFromSpatialAttrs(
+        attrs({ transform: [10, 0, 5e5, 0, -10, 5e6] }),
+        GRID
+      )
+    ).toEqual({
+      xMin: 5e5,
+      xMax: 501000,
+      yMin: 4999500,
+      yMax: 5e6,
+      latIsAscending: false,
+    })
+  })
+
+  it('reads row direction off the sign of the y resolution', () => {
+    const south = boundsFromSpatialAttrs(
+      attrs({ transform: [10, 0, 5e5, 0, 10, 4999500] }),
+      GRID
+    )
+
+    expect(south).toEqual({
+      xMin: 5e5,
+      xMax: 501000,
+      yMin: 4999500,
+      yMax: 5e6,
+      latIsAscending: true,
+    })
+  })
+
+  it('pushes a node-registered transform out by half a cell', () => {
+    // The transform lands on the first cell center, so every edge moves out 5 m.
+    expect(
+      boundsFromSpatialAttrs(
+        attrs({ registration: 'node', transform: [10, 0, 5e5, 0, -10, 5e6] }),
+        GRID
+      )
+    ).toEqual({
+      xMin: 499995,
+      xMax: 500995,
+      yMin: 4999505,
+      yMax: 5000005,
+      latIsAscending: false,
+    })
+  })
+
+  it('takes a pixel-registered bbox as the edges outright', () => {
+    expect(
+      boundsFromSpatialAttrs(attrs({ bbox: [-180, -90, 180, 90] }), GRID)
+    ).toEqual({
+      xMin: -180,
+      yMin: -90,
+      xMax: 180,
+      yMax: 90,
+      latIsAscending: null,
+    })
+  })
+
+  it('expands a node-registered bbox using the span between border centers', () => {
+    // 10 columns of centers span 9 cells, so half a cell is 90/9/2 = 5.
+    expect(
+      boundsFromSpatialAttrs(
+        attrs({ registration: 'node', bbox: [0, 0, 90, 45] }),
+        { nCols: 10, nRows: 5 }
+      )
+    ).toEqual({
+      xMin: -5,
+      xMax: 95,
+      yMin: -5.625,
+      yMax: 50.625,
+      latIsAscending: null,
+    })
+  })
+
+  it('prefers the transform resolution over the bbox span for a node expansion', () => {
+    const both = boundsFromSpatialAttrs(
+      attrs({
+        registration: 'node',
+        bbox: [0, 0, 90, 45],
+        transform: [10, 0, 0, 0, -10, 45],
+      }),
+      { nCols: 10, nRows: 5 }
+    )
+
+    expect(both).toEqual({
+      xMin: -5,
+      xMax: 95,
+      yMin: -5,
+      yMax: 50,
+      latIsAscending: false,
+    })
+  })
+
+  it('lets the bbox set the extent while the transform sets the row direction', () => {
+    expect(
+      boundsFromSpatialAttrs(
+        attrs({ bbox: [0, 0, 90, 45], transform: [10, 0, 5e5, 0, -10, 5e6] }),
+        GRID
+      )
+    ).toEqual({
+      xMin: 0,
+      yMin: 0,
+      xMax: 90,
+      yMax: 45,
+      latIsAscending: false,
+    })
+  })
+
+  it('rejects a rotated transform, whose corners are not its extent', () => {
+    expect(
+      boundsFromSpatialAttrs(
+        attrs({ transform: [10, 1, 5e5, 1, -10, 5e6] }),
+        GRID
+      )
+    ).toBeNull()
+  })
+
+  it('still uses a bbox declared alongside a rotated transform', () => {
+    const rotated = boundsFromSpatialAttrs(
+      attrs({ bbox: [0, 0, 90, 45], transform: [10, 1, 5e5, 1, -10, 5e6] }),
+      GRID
+    )
+
+    expect(rotated).toEqual({
+      xMin: 0,
+      yMin: 0,
+      xMax: 90,
+      yMax: 45,
+      // The rotation makes the row direction unusable even for orientation.
+      latIsAscending: null,
+    })
+  })
+
+  it('rejects a transform type it cannot map to a grid', () => {
+    expect(
+      boundsFromSpatialAttrs(
+        attrs({ transformType: 'rpc', bbox: [0, 0, 90, 45] }),
+        GRID
+      )
+    ).toBeNull()
+  })
+
+  it('rejects a node-registered bbox on a grid too small to size a cell from', () => {
+    expect(
+      boundsFromSpatialAttrs(
+        attrs({ registration: 'node', bbox: [0, 0, 90, 45] }),
+        { nCols: 1, nRows: 1 }
+      )
+    ).toBeNull()
+  })
+
+  it('returns nothing when the store declares no extent at all', () => {
+    expect(boundsFromSpatialAttrs(attrs(), GRID)).toBeNull()
+  })
 })

--- a/src/geozarr.ts
+++ b/src/geozarr.ts
@@ -226,11 +226,18 @@ export function boundsFromSpatialAttrs(
 ): SpatialExtent | null {
   if (attrs.transformType !== 'affine') return null
 
-  // A rotated grid's corners are not its min/max, so the transform tells us
-  // nothing usable about an axis-aligned extent.
-  const rotated =
-    !!attrs.transform && (attrs.transform[1] !== 0 || attrs.transform[3] !== 0)
-  const transform = rotated ? undefined : attrs.transform
+  // Rotated grids have no axis-aligned placement at all. The renderer maps rows
+  // and columns linearly across the extent with no rotation term, so a bbox --
+  // which merely encloses the rotated footprint -- would render the raster
+  // unrotated and stretched to fill it. Decline rather than misplace it.
+  if (
+    attrs.transform &&
+    (attrs.transform[1] !== 0 || attrs.transform[3] !== 0)
+  ) {
+    return null
+  }
+
+  const transform = attrs.transform
   const latIsAscending = transform ? transform[4] > 0 : null
 
   if (attrs.bbox) {

--- a/src/geozarr.ts
+++ b/src/geozarr.ts
@@ -122,10 +122,11 @@ function asTransform(value: unknown): AffineTransform | undefined {
   const nums = asNumbers(value, 'spatial:transform', 6)
   if (!nums) return undefined
   const [a, b, c, d, e, f] = nums
-  if (a === 0 || e === 0) {
-    warn(
-      `Ignoring 'spatial:transform': resolution coefficients must be non-zero.`
-    )
+  // An axis with zero resolution and zero rotation maps every index to one
+  // coordinate. A zero resolution alone is a quarter-turn rotation, kept
+  // intact so the rotation handling sees it.
+  if ((a === 0 && b === 0) || (d === 0 && e === 0)) {
+    warn(`Ignoring 'spatial:transform': it collapses an axis.`)
     return undefined
   }
   return [a, b, c, d, e, f]

--- a/src/geozarr.ts
+++ b/src/geozarr.ts
@@ -1,0 +1,215 @@
+/**
+ * @module geozarr
+ *
+ * Readers for the zarr-conventions geospatial attribute sets: `proj:` names the
+ * CRS, `spatial:` places the grid within it.
+ *
+ * Pure and I/O-free — every function takes already-fetched attribute objects.
+ * Malformed values are warned about and dropped rather than thrown; this runs
+ * during layer init, where one bad attribute must not take the layer down.
+ *
+ * @see https://github.com/zarr-conventions/geo-proj
+ * @see https://github.com/zarr-conventions/spatial
+ * @see https://github.com/zarr-conventions/multiscales
+ */
+
+import type { Bounds } from './types'
+
+type Attrs = Record<string, unknown> | undefined
+
+/** `spatial:transform` coefficients [a, b, c, d, e, f]. */
+export type AffineTransform = [number, number, number, number, number, number]
+
+export type Registration = 'pixel' | 'node'
+
+export interface GeoZarrCrs {
+  /** `proj:code`, e.g. "EPSG:4326". */
+  code?: string
+  /** `proj:wkt2`, a WKT2 (ISO 19162) string. */
+  wkt2?: string
+  /** `proj:projjson`, a PROJJSON object. */
+  projjson?: Record<string, unknown>
+}
+
+export interface GeoZarrAttrs {
+  /** Present when at least one of the three `proj:` forms was found. */
+  crs?: GeoZarrCrs
+  /** `spatial:bbox` as [xMin, yMin, xMax, yMax]. */
+  bbox?: Bounds
+  /**
+   * `spatial:transform`, mapping index to coordinate as
+   * `x = a*col + b*row + c` and `y = d*col + e*row + f`. `a` and `e` are the
+   * axis resolutions (`e` negative for north-up), `b` and `d` the rotations,
+   * `c` and `f` the westernmost/northernmost coordinate.
+   */
+  transform?: AffineTransform
+  /** `spatial:shape` as [height, width]. */
+  shape?: [number, number]
+  /** `spatial:dimensions`, ordered by axis role as [yName, xName]. */
+  dimensions?: [string, string]
+  registration: Registration
+  transformType: string
+}
+
+/** The `spatial:` fields a multiscales layout entry may carry per level. */
+export type LayoutItemSpatial = Pick<GeoZarrAttrs, 'transform' | 'shape'>
+
+const warn = (message: string): void => {
+  console.warn(`[zarr-layer] ${message}`)
+}
+
+/**
+ * Array attributes override the group's, following `proj:`'s inheritance model:
+ * a group's attributes apply to its direct child arrays unless the array
+ * declares its own.
+ */
+const pick = (group: Attrs, array: Attrs, key: string): unknown =>
+  array?.[key] !== undefined ? array[key] : group?.[key]
+
+function asString(value: unknown, key: string): string | undefined {
+  if (value === undefined || value === null) return undefined
+  if (typeof value === 'string' && value.trim()) return value.trim()
+  warn(`Ignoring '${key}': expected a non-empty string.`)
+  return undefined
+}
+
+function asObject(
+  value: unknown,
+  key: string
+): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) return undefined
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  warn(`Ignoring '${key}': expected an object.`)
+  return undefined
+}
+
+function asNumbers(
+  value: unknown,
+  key: string,
+  length: number
+): number[] | undefined {
+  if (value === undefined || value === null) return undefined
+  if (
+    !Array.isArray(value) ||
+    value.length !== length ||
+    !value.every((v) => typeof v === 'number' && Number.isFinite(v))
+  ) {
+    warn(`Ignoring '${key}': expected an array of ${length} finite numbers.`)
+    return undefined
+  }
+  return value as number[]
+}
+
+function asBbox(value: unknown): Bounds | undefined {
+  const nums = asNumbers(value, 'spatial:bbox', 4)
+  if (!nums) return undefined
+  const [xMin, yMin, xMax, yMax] = nums
+  if (xMax <= xMin || yMax <= yMin) {
+    warn(`Ignoring 'spatial:bbox': expected [xMin, yMin, xMax, yMax].`)
+    return undefined
+  }
+  return [xMin, yMin, xMax, yMax]
+}
+
+function asTransform(value: unknown): AffineTransform | undefined {
+  const nums = asNumbers(value, 'spatial:transform', 6)
+  if (!nums) return undefined
+  const [a, b, c, d, e, f] = nums
+  if (a === 0 || e === 0) {
+    warn(
+      `Ignoring 'spatial:transform': resolution coefficients must be non-zero.`
+    )
+    return undefined
+  }
+  return [a, b, c, d, e, f]
+}
+
+function asShape(value: unknown): [number, number] | undefined {
+  const nums = asNumbers(value, 'spatial:shape', 2)
+  if (!nums) return undefined
+  if (!nums.every((n) => Number.isInteger(n) && n > 0)) {
+    warn(`Ignoring 'spatial:shape': expected two positive integers.`)
+    return undefined
+  }
+  return [nums[0], nums[1]]
+}
+
+function asDimensions(value: unknown): [string, string] | undefined {
+  if (value === undefined || value === null) return undefined
+  if (
+    !Array.isArray(value) ||
+    value.length !== 2 ||
+    !value.every((v) => typeof v === 'string' && v.trim())
+  ) {
+    warn(
+      `Ignoring 'spatial:dimensions': expected two dimension names ordered [y, x].`
+    )
+    return undefined
+  }
+  return [value[0].trim(), value[1].trim()]
+}
+
+function asRegistration(value: unknown): Registration {
+  if (value === undefined || value === null) return 'pixel'
+  if (value === 'pixel' || value === 'node') return value
+  warn(
+    `Ignoring 'spatial:registration' value ${JSON.stringify(value)}: ` +
+      `expected 'pixel' or 'node'. Using 'pixel'.`
+  )
+  return 'pixel'
+}
+
+function parseCrs(group: Attrs, array: Attrs): GeoZarrCrs | undefined {
+  const code = asString(pick(group, array, 'proj:code'), 'proj:code')
+  const wkt2 = asString(pick(group, array, 'proj:wkt2'), 'proj:wkt2')
+  const projjson = asObject(
+    pick(group, array, 'proj:projjson'),
+    'proj:projjson'
+  )
+  if (!code && !wkt2 && !projjson) return undefined
+  return { code, wkt2, projjson }
+}
+
+/**
+ * Read the `proj:` and `spatial:` attributes a store declares for one array.
+ *
+ * `registration` and `transformType` always come back populated, defaulting to
+ * the spec's `'pixel'` and `'affine'`. Everything else is absent when the store
+ * doesn't declare it or declares it malformed.
+ */
+export function parseGeoZarrAttrs(
+  groupAttrs: Attrs,
+  arrayAttrs: Attrs
+): GeoZarrAttrs {
+  const spatial = (key: string) => pick(groupAttrs, arrayAttrs, key)
+  return {
+    crs: parseCrs(groupAttrs, arrayAttrs),
+    bbox: asBbox(spatial('spatial:bbox')),
+    transform: asTransform(spatial('spatial:transform')),
+    shape: asShape(spatial('spatial:shape')),
+    dimensions: asDimensions(spatial('spatial:dimensions')),
+    registration: asRegistration(spatial('spatial:registration')),
+    transformType:
+      asString(spatial('spatial:transform_type'), 'spatial:transform_type') ??
+      'affine',
+  }
+}
+
+/**
+ * Read the per-level `spatial:` attributes from one `multiscales.layout` entry.
+ *
+ * These sit alongside `asset` on the entry itself, not inside its `transform`
+ * object, which holds only the relative scale/translation between levels.
+ */
+export function parseLayoutItemSpatial(item: unknown): LayoutItemSpatial {
+  const attrs =
+    item && typeof item === 'object' && !Array.isArray(item)
+      ? (item as Record<string, unknown>)
+      : undefined
+  return {
+    transform: asTransform(attrs?.['spatial:transform']),
+    shape: asShape(attrs?.['spatial:shape']),
+  }
+}

--- a/src/geozarr.ts
+++ b/src/geozarr.ts
@@ -197,6 +197,90 @@ export function parseGeoZarrAttrs(
   }
 }
 
+export interface SpatialExtent {
+  xMin: number
+  xMax: number
+  yMin: number
+  yMax: number
+  /** `null` when nothing declared settles which edge row 0 sits on. */
+  latIsAscending: boolean | null
+}
+
+/**
+ * Derive the grid's outer edges from what the `spatial:` convention declares.
+ *
+ * The result is edge-to-edge, matching what the renderer means by bounds, which
+ * is why `spatial:registration` is load-bearing: under `'pixel'` the declared
+ * coordinates already sit on cell boundaries, under `'node'` they sit on cell
+ * centers and everything moves out by half a cell.
+ *
+ * `spatial:bbox` wins the extent when both are declared, since it states the
+ * extent directly; `spatial:transform` still supplies the cell size and the row
+ * direction. Returns `null` when nothing declared pins the extent down: a
+ * rotated transform with no bbox, or a node-registered bbox on a grid too small
+ * to recover a cell size from.
+ */
+export function boundsFromSpatialAttrs(
+  attrs: GeoZarrAttrs,
+  grid: { nCols: number; nRows: number }
+): SpatialExtent | null {
+  if (attrs.transformType !== 'affine') return null
+
+  // A rotated grid's corners are not its min/max, so the transform tells us
+  // nothing usable about an axis-aligned extent.
+  const rotated =
+    !!attrs.transform && (attrs.transform[1] !== 0 || attrs.transform[3] !== 0)
+  const transform = rotated ? undefined : attrs.transform
+  const latIsAscending = transform ? transform[4] > 0 : null
+
+  if (attrs.bbox) {
+    const [xMin, yMin, xMax, yMax] = attrs.bbox
+    if (attrs.registration === 'pixel') {
+      return { xMin, yMin, xMax, yMax, latIsAscending }
+    }
+
+    // Node registration puts the bbox on the centers of the border cells, so
+    // half a cell is missing from each side. The transform gives the cell size
+    // outright; otherwise the bbox spans nCols - 1 whole cells.
+    const halfCell = (
+      resolution: number | undefined,
+      span: number,
+      count: number
+    ): number | null => {
+      if (resolution !== undefined) return Math.abs(resolution) / 2
+      return count > 1 ? span / (count - 1) / 2 : null
+    }
+    const halfX = halfCell(transform?.[0], xMax - xMin, grid.nCols)
+    const halfY = halfCell(transform?.[4], yMax - yMin, grid.nRows)
+    if (halfX === null || halfY === null) return null
+
+    return {
+      xMin: xMin - halfX,
+      xMax: xMax + halfX,
+      yMin: yMin - halfY,
+      yMax: yMax + halfY,
+      latIsAscending,
+    }
+  }
+
+  if (!transform) return null
+
+  const [a, , c, , e, f] = transform
+  // Under node registration the transform lands on the first cell's center.
+  const originX = attrs.registration === 'node' ? c - a / 2 : c
+  const originY = attrs.registration === 'node' ? f - e / 2 : f
+  const endX = originX + a * grid.nCols
+  const endY = originY + e * grid.nRows
+
+  return {
+    xMin: Math.min(originX, endX),
+    xMax: Math.max(originX, endX),
+    yMin: Math.min(originY, endY),
+    yMax: Math.max(originY, endY),
+    latIsAscending,
+  }
+}
+
 /**
  * Read the per-level `spatial:` attributes from one `multiscales.layout` entry.
  *

--- a/src/geozarr.ts
+++ b/src/geozarr.ts
@@ -59,12 +59,17 @@ const warn = (message: string): void => {
 }
 
 /**
- * Array attributes override the group's, following `proj:`'s inheritance model:
- * a group's attributes apply to its direct child arrays unless the array
- * declares its own.
+ * The nearest source declaring `key` wins, sources being ordered outermost
+ * first. `spatial:` is overridden a property at a time, so a level that
+ * restates only its own transform keeps the rest of what it inherits.
  */
-const pick = (group: Attrs, array: Attrs, key: string): unknown =>
-  array?.[key] !== undefined ? array[key] : group?.[key]
+const pick = (sources: Attrs[], key: string): unknown => {
+  for (let i = sources.length - 1; i >= 0; i--) {
+    const value = sources[i]?.[key]
+    if (value !== undefined) return value
+  }
+  return undefined
+}
 
 function asString(value: unknown, key: string): string | undefined {
   if (value === undefined || value === null) return undefined
@@ -161,31 +166,44 @@ function asRegistration(value: unknown): Registration {
   return 'pixel'
 }
 
-function parseCrs(group: Attrs, array: Attrs): GeoZarrCrs | undefined {
-  const code = asString(pick(group, array, 'proj:code'), 'proj:code')
-  const wkt2 = asString(pick(group, array, 'proj:wkt2'), 'proj:wkt2')
-  const projjson = asObject(
-    pick(group, array, 'proj:projjson'),
-    'proj:projjson'
-  )
-  if (!code && !wkt2 && !projjson) return undefined
-  return { code, wkt2, projjson }
+const PROJ_KEYS = ['proj:code', 'proj:wkt2', 'proj:projjson'] as const
+
+/**
+ * Unlike `spatial:`, a `proj:` declaration is taken whole from the nearest
+ * source that makes one. The three forms describe a single CRS, so blending a
+ * level's `proj:code` with an ancestor's `proj:wkt2` could silently compose two
+ * different coordinate systems.
+ */
+function parseCrs(sources: Attrs[]): GeoZarrCrs | undefined {
+  for (let i = sources.length - 1; i >= 0; i--) {
+    const source = sources[i]
+    if (!source || !PROJ_KEYS.some((k) => source[k] !== undefined)) continue
+    const code = asString(source['proj:code'], 'proj:code')
+    const wkt2 = asString(source['proj:wkt2'], 'proj:wkt2')
+    const projjson = asObject(source['proj:projjson'], 'proj:projjson')
+    if (!code && !wkt2 && !projjson) return undefined
+    return { code, wkt2, projjson }
+  }
+  return undefined
 }
 
 /**
- * Read the `proj:` and `spatial:` attributes a store declares for one array.
+ * Read the `proj:` and `spatial:` attributes that apply to one array.
+ *
+ * Sources are given outermost first -- typically the store root, then the
+ * level's own group, then the array -- and the nearest declaration wins. The
+ * `proj:` convention inherits to a group's direct child arrays only, so a
+ * pyramid may legitimately restate it on each level group rather than at the
+ * root; passing the whole chain covers either placement.
  *
  * `registration` and `transformType` always come back populated, defaulting to
- * the spec's `'pixel'` and `'affine'`. Everything else is absent when the store
- * doesn't declare it or declares it malformed.
+ * the spec's `'pixel'` and `'affine'`. Everything else is absent when nothing
+ * declares it or what is declared is malformed.
  */
-export function parseGeoZarrAttrs(
-  groupAttrs: Attrs,
-  arrayAttrs: Attrs
-): GeoZarrAttrs {
-  const spatial = (key: string) => pick(groupAttrs, arrayAttrs, key)
+export function parseGeoZarrAttrs(...sources: Attrs[]): GeoZarrAttrs {
+  const spatial = (key: string) => pick(sources, key)
   return {
-    crs: parseCrs(groupAttrs, arrayAttrs),
+    crs: parseCrs(sources),
     bbox: asBbox(spatial('spatial:bbox')),
     transform: asTransform(spatial('spatial:transform')),
     shape: asShape(spatial('spatial:shape')),

--- a/src/level-loader.ts
+++ b/src/level-loader.ts
@@ -4,7 +4,7 @@ import type { NormalizedSelector } from './types'
 
 type ResolvedLevel = Pick<
   LevelRuntime,
-  'zarrArray' | 'width' | 'height' | 'regionSize'
+  'zarrArray' | 'width' | 'height' | 'regionSize' | 'xyLimits'
 > & { reusedArray: boolean }
 
 export type LevelLoaderContext = {
@@ -119,6 +119,7 @@ export class LevelLoader {
         width: resolved.width,
         height: resolved.height,
         regionSize: resolved.regionSize,
+        xyLimits: resolved.xyLimits,
         baseSliceArgs,
         baseMultiValueDims,
       }

--- a/src/map-utils.test.ts
+++ b/src/map-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { latToMercatorNorm, boundsToMercatorNorm } from './map-utils'
+import {
+  latToMercatorNorm,
+  boundsToMercatorNorm,
+  normalizeLongitudeExtent,
+} from './map-utils'
 import { MERCATOR_LAT_LIMIT } from './constants'
 
 describe('latToMercatorNorm', () => {
@@ -55,5 +59,56 @@ describe('boundsToMercatorNorm', () => {
     expect(b.x1).toBeCloseTo(0.75, 12)
     expect(b.y1).toBeCloseTo(0.5, 12) // yMin=0 -> equator
     expect(b.y0).toBeLessThan(0.5) // yMax=45 -> north of equator
+  })
+})
+
+describe('normalizeLongitudeExtent', () => {
+  it('leaves an extent already in -180-180 alone', () => {
+    expect(normalizeLongitudeExtent(-120, -60, 1)).toEqual({
+      xMin: -120,
+      xMax: -60,
+    })
+  })
+
+  it('folds a 0-360 extent', () => {
+    expect(normalizeLongitudeExtent(200, 300, 1)).toEqual({
+      xMin: -160,
+      xMax: -60,
+    })
+  })
+
+  it('leaves a global 0-360 extent unfolded', () => {
+    // The fold needs both edges past 180 to tell 0-360 degrees from projected
+    // meters, and a global grid's western edge sits at 0. Such a store still
+    // needs an explicit `bounds` to render across the antimeridian.
+    expect(normalizeLongitudeExtent(0, 360, 45)).toEqual({ xMin: 0, xMax: 360 })
+  })
+
+  it('snaps a global extent that misses the antimeridian by a hair', () => {
+    const { xMin, xMax } = normalizeLongitudeExtent(-179.9999, 180.0001, 0.25)
+    expect(xMin).toBe(-180)
+    expect(xMax).toBe(180)
+  })
+
+  it('leaves an extent one cell short of global unsnapped', () => {
+    // 359.75 deg of span is a real gap, not float drift.
+    expect(normalizeLongitudeExtent(-180, 179.75, 0.25)).toEqual({
+      xMin: -180,
+      xMax: 179.75,
+    })
+  })
+
+  it('leaves a regional extent near 180 unsnapped', () => {
+    expect(normalizeLongitudeExtent(170, 179.9, 0.25)).toEqual({
+      xMin: 170,
+      xMax: 179.9,
+    })
+  })
+
+  it('leaves an extent alone when the cell width is unknown', () => {
+    expect(normalizeLongitudeExtent(-179.9999, 180.0001, NaN)).toEqual({
+      xMin: -179.9999,
+      xMax: 180.0001,
+    })
   })
 })

--- a/src/map-utils.ts
+++ b/src/map-utils.ts
@@ -107,6 +107,43 @@ export interface XYLimits {
   yMax: number
 }
 
+/**
+ * Put a longitude extent into the -180–180 representation the renderer works
+ * in. Only meaningful for a geographic CRS; callers hold that check.
+ *
+ * Two corrections, neither of them a judgment about the source. A 0–360 extent
+ * is folded, since that convention is just as correct and xarray writes it. A
+ * global extent landing within a cell of ±180 is snapped onto it, which is what
+ * keeps a seam from opening at the antimeridian when the grid doesn't divide
+ * evenly.
+ *
+ * @param cellWidth - Longitude span of one cell, the tolerance for both checks.
+ */
+export function normalizeLongitudeExtent(
+  xMin: number,
+  xMax: number,
+  cellWidth: number
+): { xMin: number; xMax: number } {
+  let lo = xMin
+  let hi = xMax
+
+  // Both edges past 180 but still within the degree range is 0–360 data
+  // rather than projected meters.
+  if (lo > 180 && hi > 180 && hi <= 360) {
+    lo -= 360
+    hi -= 360
+  }
+
+  // A truly global grid spans exactly N * cellWidth = 360°; one a cell short
+  // spans 360 - cellWidth and fails the check.
+  if (Number.isFinite(cellWidth) && Math.abs(hi - lo - 360) < cellWidth / 2) {
+    if (Math.abs(lo + 180) < cellWidth) lo = -180
+    if (Math.abs(hi - 180) < cellWidth) hi = 180
+  }
+
+  return { xMin: lo, xMax: hi }
+}
+
 export function boundsToMercatorNorm(
   xyLimits: { xMin: number; xMax: number; yMin: number; yMax: number },
   crs: 'EPSG:4326' | 'EPSG:3857' | null

--- a/src/query/data-query.test.ts
+++ b/src/query/data-query.test.ts
@@ -238,6 +238,48 @@ describe('queryData with a per-level extent', () => {
     const viaLevel = await queryData(eastern, point(90, 0), { time: 10 })
     expect(viaLevel.temp).toEqual([20])
   })
+
+  it('guards antimeridian crossings against the level extent, not the dataset one', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const { context } = await makeQueryHarness()
+      // The dataset extent stays within range; only the level's own extent
+      // crosses. The two-strip path is unsupported for such a raster, so the
+      // guard must consult the extent the pixel-span mapping would use.
+      const wrapped: QueryContext = {
+        ...context,
+        level: {
+          ...context.level!,
+          xyLimits: { xMin: 0, xMax: 360, yMin: -90, yMax: 90 },
+        },
+      }
+      const result = await queryData(
+        wrapped,
+        {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [130, 50],
+              [230, 50],
+              [230, 80],
+              [130, 80],
+              [130, 50],
+            ],
+          ],
+        },
+        { time: 10 }
+      )
+
+      expect(wrapped.antimeridianWarnings.has('raster-extent-crossing')).toBe(
+        true
+      )
+      // Single-fetched against the 0-360 extent: centers 157.5 and 202.5 are
+      // pixels 3 and 4 of the top row.
+      expect(result.temp).toEqual([3, 4])
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
 })
 
 describe('mergeQueryResults', () => {

--- a/src/query/data-query.test.ts
+++ b/src/query/data-query.test.ts
@@ -218,6 +218,28 @@ describe('queryData', () => {
  * coordinates taken from the first strip.
  */
 
+describe('queryData with a per-level extent', () => {
+  it('maps through the level extent rather than the dataset one', async () => {
+    const { context } = await makeQueryHarness()
+    // Read against the dataset extent, 90E sits three quarters across: pixel
+    // (6, 2), value 2*8 + 6.
+    const viaDataset = await queryData(context, point(90, 0), { time: 10 })
+    expect(viaDataset.temp).toEqual([22])
+
+    // Told the level covers only the eastern hemisphere, the same point is its
+    // midpoint: pixel (4, 2), value 2*8 + 4.
+    const eastern: QueryContext = {
+      ...context,
+      level: {
+        ...context.level!,
+        xyLimits: { xMin: 0, xMax: 180, yMin: -90, yMax: 90 },
+      },
+    }
+    const viaLevel = await queryData(eastern, point(90, 0), { time: 10 })
+    expect(viaLevel.temp).toEqual([20])
+  })
+})
+
 describe('mergeQueryResults', () => {
   it('concatenates values and spatial coordinates', () => {
     const west: QueryResult = {

--- a/src/query/data-query.ts
+++ b/src/query/data-query.ts
@@ -158,13 +158,11 @@ export async function queryData(
   options?: QueryOptions
 ): Promise<QueryResult> {
   const desc = context.zarrStore.describe()
-  const sourceBounds: Bounds | null = context.xyLimits
-    ? [
-        context.xyLimits.xMin,
-        context.xyLimits.yMin,
-        context.xyLimits.xMax,
-        context.xyLimits.yMax,
-      ]
+  // Queries index into the active level, so they must map through whatever
+  // extent that level is drawn against.
+  const queryLimits = context.level?.xyLimits ?? context.xyLimits
+  const sourceBounds: Bounds | null = queryLimits
+    ? [queryLimits.xMin, queryLimits.yMin, queryLimits.xMax, queryLimits.yMax]
     : null
   const { yDim: emptyYDim, xDim: emptyXDim } = findSpatialDimNames(
     desc.dimensions,

--- a/src/query/data-query.ts
+++ b/src/query/data-query.ts
@@ -288,10 +288,11 @@ export async function queryData(
     return singleFetch(queryGeometry)
   }
 
-  // Crossing: raster extent guard (EPSG:4326 only — 3857 xyLimits are in meters)
+  // Crossing: raster extent guard (EPSG:4326 only — 3857 xyLimits are in
+  // meters). Checked against the same extent the pixel-span mapping uses.
   if (
     context.projection.kind === 'epsg4326' &&
-    rasterExtentCrossesAntimeridian('EPSG:4326', context.xyLimits)
+    rasterExtentCrossesAntimeridian('EPSG:4326', queryLimits)
   ) {
     if (!context.antimeridianWarnings.has('raster-extent-crossing')) {
       context.antimeridianWarnings.add('raster-extent-crossing')

--- a/src/region-fetcher.ts
+++ b/src/region-fetcher.ts
@@ -105,6 +105,7 @@ export class RegionFetcher {
       width: level.width,
       height: level.height,
       regionSize: level.regionSize,
+      xyLimits: level.xyLimits,
       selectorVersion: this.context.getSelectorVersion(),
       bandNames: [...this.context.getBandNames()],
       baseMultiValueDims: level.baseMultiValueDims.map((dim) => ({
@@ -308,6 +309,7 @@ export class RegionFetcher {
           width: snapshot.width,
           height: snapshot.height,
           regionSize: snapshot.regionSize,
+          xyLimits: snapshot.xyLimits,
         }
         const geoBounds = this.context.getRegionBounds(
           regionX,
@@ -392,6 +394,7 @@ export class RegionFetcher {
         width: snapshot.width,
         height: snapshot.height,
         regionSize: [...snapshot.regionSize] as [number, number],
+        xyLimits: snapshot.xyLimits,
       }
 
       region.textureUploaded = false

--- a/src/region-math.test.ts
+++ b/src/region-math.test.ts
@@ -359,8 +359,6 @@ describe('getVisibleRegions', () => {
 describe('selectLevelForZoom', () => {
   const level = (asset: string, lonSize: number): UntiledLevel => ({
     asset,
-    scale: [1, 1],
-    translation: [0, 0],
     shape: [lonSize / 2, lonSize],
   })
   const projection4326 = createProjectionContext({

--- a/src/region-math.test.ts
+++ b/src/region-math.test.ts
@@ -481,3 +481,55 @@ describe('computeRegionMercatorBounds', () => {
     )
   })
 })
+
+describe('getRegionBounds with per-level extents', () => {
+  const DATASET = { xMin: 0, xMax: 100, yMin: 0, yMax: 100 }
+
+  it('places a region against the dataset extent by default', () => {
+    expect(
+      getRegionBounds({
+        regionX: 0,
+        regionY: 0,
+        levelMeta: { width: 10, height: 10, regionSize: [10, 10] },
+        xyLimits: DATASET,
+        latIsAscending: true,
+      })
+    ).toEqual({ xMin: 0, xMax: 100, yMin: 0, yMax: 100 })
+  })
+
+  it("prefers the level's own extent when it declares one", () => {
+    // A floor-divided level covering 90 of the dataset's 100 units must not be
+    // stretched over the full extent.
+    expect(
+      getRegionBounds({
+        regionX: 0,
+        regionY: 0,
+        levelMeta: {
+          width: 10,
+          height: 10,
+          regionSize: [10, 10],
+          xyLimits: { xMin: 0, xMax: 90, yMin: 0, yMax: 90 },
+        },
+        xyLimits: DATASET,
+        latIsAscending: true,
+      })
+    ).toEqual({ xMin: 0, xMax: 90, yMin: 0, yMax: 90 })
+  })
+
+  it('scales sub-regions within the level extent', () => {
+    expect(
+      getRegionBounds({
+        regionX: 1,
+        regionY: 0,
+        levelMeta: {
+          width: 10,
+          height: 10,
+          regionSize: [10, 5],
+          xyLimits: { xMin: 0, xMax: 90, yMin: 0, yMax: 90 },
+        },
+        xyLimits: DATASET,
+        latIsAscending: true,
+      })
+    ).toEqual({ xMin: 45, xMax: 90, yMin: 0, yMax: 90 })
+  })
+})

--- a/src/region-math.test.ts
+++ b/src/region-math.test.ts
@@ -482,6 +482,45 @@ describe('computeRegionMercatorBounds', () => {
   })
 })
 
+describe('getVisibleRegions with per-level extents', () => {
+  it('generates candidates against the extent it verifies with', () => {
+    // The level covers the eastern hemisphere across 20 region columns, and
+    // the viewport sits over its western end. Index math run against the
+    // dataset extent points at columns 10-14; the margin widens that to 8-16,
+    // so the leading columns are never even considered and the west edge of
+    // the level goes missing.
+    const levelLimits = { xMin: 0, xMax: 180, yMin: -90, yMax: 90 }
+    const regions = getVisibleRegions({
+      map: {
+        getBounds: () => ({
+          getWest: () => 1,
+          getEast: () => 89,
+          toArray: () => [
+            [1, -89],
+            [89, 89],
+          ],
+        }),
+        getZoom: () => 2,
+      } as never,
+      xyLimits: { xMin: -180, xMax: 180, yMin: -90, yMax: 90 },
+      levelMeta: {
+        width: 100,
+        height: 100,
+        regionSize: [5, 5],
+        xyLimits: levelLimits,
+      },
+      projection: createProjectionContext({
+        crs: 'EPSG:4326',
+        proj4def: null,
+        xyLimits: levelLimits,
+      }),
+      latIsAscending: false,
+    })
+
+    expect(regions.some((r) => r.regionX === 0)).toBe(true)
+  })
+})
+
 describe('getRegionBounds with per-level extents', () => {
   const DATASET = { xMin: 0, xMax: 100, yMin: 0, yMax: 100 }
 

--- a/src/region-math.ts
+++ b/src/region-math.ts
@@ -264,11 +264,12 @@ export function getRegionBounds({
   latIsAscending: boolean
 }): SourceBounds {
   const { width, height, regionSize } = levelMeta
-  // xyLimits is assumed constant across all multiscale levels (same geographic extent).
-  // If per-level bounds are ever needed, add xyLimits to LevelMeta type.
-  if (!xyLimits) return { xMin: 0, xMax: 1, yMin: 0, yMax: 1 }
+  // A level that declares its own extent is placed against that; the dataset
+  // extent describes the base level and would stretch any level covering less.
+  const limits = levelMeta.xyLimits ?? xyLimits
+  if (!limits) return { xMin: 0, xMax: 1, yMin: 0, yMax: 1 }
   const [regionH, regionW] = regionSize
-  const { xMin, xMax, yMin, yMax } = xyLimits
+  const { xMin, xMax, yMin, yMax } = limits
   const pxXStart = regionX * regionW
   const pxXEnd = Math.min(pxXStart + regionW, width)
   const pxYStart = regionY * regionH

--- a/src/region-math.ts
+++ b/src/region-math.ts
@@ -68,6 +68,9 @@ export function getVisibleRegions({
   const { width, height, regionSize } = levelMeta
   const [[west, south], [east, north]] = bounds
   const [regionH, regionW] = regionSize
+  // Candidate index math and the verification below must agree on the extent,
+  // or a level placed against its own bounds can generate no candidates at all.
+  const limits = levelMeta.xyLimits ?? xyLimits
   // For projected data, use a two-pass approach:
   // 1. Forward-transform viewport edges to source CRS to find candidate
   //    regions via index math (O(1) proj4 cost, may include false
@@ -86,7 +89,7 @@ export function getVisibleRegions({
     regionH,
     width,
     height,
-    xyLimits,
+    xyLimits: limits,
     latIsAscending,
   })
 

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -176,6 +176,7 @@ export class RegionRenderer {
             width: existing.width,
             height: existing.height,
             regionSize: existing.regionSize,
+            xyLimits: existing.xyLimits,
             reusedArray: true,
           }
         }
@@ -192,6 +193,9 @@ export class RegionRenderer {
           width,
           height,
           regionSize: this.getRegionSize(zarrArray) ?? [height, width],
+          xyLimits: this.isMultiscale
+            ? this.levels[levelIndex]?.xyLimits
+            : undefined,
           reusedArray: false,
         }
       },

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -1222,6 +1222,7 @@ export class RegionRenderer {
               zarrArray: activeLevel.zarrArray,
               width: activeLevel.width,
               height: activeLevel.height,
+              xyLimits: activeLevel.xyLimits,
             }
           : null,
         projection: this.projection,

--- a/src/region-state.ts
+++ b/src/region-state.ts
@@ -101,5 +101,5 @@ export interface LevelRuntime {
 
 export type QueryLevelSnapshot = Pick<
   LevelRuntime,
-  'index' | 'zarrArray' | 'width' | 'height'
+  'index' | 'zarrArray' | 'width' | 'height' | 'xyLimits'
 >

--- a/src/region-state.ts
+++ b/src/region-state.ts
@@ -1,5 +1,5 @@
 import type * as zarr from 'zarrita'
-import type { MercatorBounds, Wgs84Bounds } from './map-utils'
+import type { MercatorBounds, Wgs84Bounds, XYLimits } from './map-utils'
 
 /** State for a single region (chunk/shard) in region-based loading */
 export interface RegionState {
@@ -51,9 +51,8 @@ export type LevelMeta = {
   width: number
   height: number
   regionSize: [number, number]
-  // xyLimits omitted - assumed constant across levels for now.
-  // TODO: If heterogeneous pyramids with per-level bounds are needed,
-  // add xyLimits here and store per-region.
+  /** This level's own extent, when it declares one. Falls back to the dataset's. */
+  xyLimits?: XYLimits
 }
 
 /** Snapshot of level state captured at fetch start to prevent race conditions */
@@ -70,6 +69,7 @@ export interface LevelSnapshot {
   width: number
   height: number
   regionSize: [number, number]
+  xyLimits?: XYLimits
   selectorVersion: number
   bandNames: string[]
 }
@@ -89,6 +89,7 @@ export interface LevelRuntime {
   width: number
   height: number
   regionSize: [number, number]
+  xyLimits?: XYLimits
   baseSliceArgs: (number | zarr.Slice)[]
   baseMultiValueDims: Array<{
     dimIndex: number

--- a/src/selector-resolution.test.ts
+++ b/src/selector-resolution.test.ts
@@ -121,10 +121,7 @@ describe('resolveSelectionIndex', () => {
     mockedLoadDimensionValues.mockResolvedValue(['red', 'green', 'blue'])
     const context = makeContext({
       isMultiscale: true,
-      levels: [
-        { asset: '0', scale: [1, 1], translation: [0, 0] },
-        { asset: '1', scale: [2, 2], translation: [0, 0] },
-      ],
+      levels: [{ asset: '0' }, { asset: '1' }],
       coordLevelIndex: 1,
       zarrStore: {
         coordinates: {},
@@ -142,10 +139,7 @@ describe('resolveSelectionIndex', () => {
     mockedLoadDimensionValues.mockResolvedValue([1, 2])
     const context = makeContext({
       isMultiscale: true,
-      levels: [
-        { asset: '0', scale: [1, 1], translation: [0, 0] },
-        { asset: '1', scale: [2, 2], translation: [0, 0] },
-      ],
+      levels: [{ asset: '0' }, { asset: '1' }],
       coordLevelIndex: 9,
       zarrStore: {
         coordinates: {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import * as zarr from 'zarrita'
+import type { XYLimits } from './map-utils'
 
 /** Bounds tuple: [xMin, yMin, xMax, yMax] */
 export type Bounds = [number, number, number, number]
@@ -152,6 +153,13 @@ export type CRS = 'EPSG:4326' | 'EPSG:3857'
 // Untiled multiscale types (zarr-conventions/multiscales format)
 export interface UntiledLevel {
   asset: string
+  /**
+   * Extent of this level alone, from its own `spatial:transform`. Levels of a
+   * pyramid usually share the dataset extent, but a floor-divided level covers
+   * a partial trailing cell less, and the convention permits larger
+   * differences. Absent when the store declares no per-level transform.
+   */
+  xyLimits?: XYLimits
   shape?: number[]
   chunks?: number[]
   scaleFactor?: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,8 +152,6 @@ export type CRS = 'EPSG:4326' | 'EPSG:3857'
 // Untiled multiscale types (zarr-conventions/multiscales format)
 export interface UntiledLevel {
   asset: string
-  scale: [number, number]
-  translation: [number, number]
   shape?: number[]
   chunks?: number[]
   scaleFactor?: number

--- a/src/zarr-store.geozarr.test.ts
+++ b/src/zarr-store.geozarr.test.ts
@@ -301,3 +301,195 @@ describe('an unresolvable proj:code', () => {
     expect(d.crs).toBe('EPSG:3857')
   })
 })
+
+/**
+ * A 4-row by 8-column global grid on a 45 deg cell. Coordinates are cell
+ * centers ordered north-first, so the coordinate-array path yields an exactly
+ * global extent with row 0 at the north. The equivalent declaration is
+ * `spatial:transform` [45, 0, -180, 0, -45, 90] under pixel registration.
+ */
+const LAT_CENTERS = [67.5, 22.5, -22.5, -67.5]
+const LON_CENTERS = [-157.5, -112.5, -67.5, -22.5, 22.5, 67.5, 112.5, 157.5]
+const GLOBAL_TRANSFORM = [45, 0, -180, 0, -45, 90]
+const GLOBAL_LIMITS = { xMin: -180, xMax: 180, yMin: -90, yMax: 90 }
+
+function spatialStore(arrayAttrs: Record<string, unknown>): MemoryStore {
+  return buildMemoryZarrStore({
+    arrays: [
+      {
+        name: 'temperature',
+        shape: [4, 8],
+        chunkShape: [4, 8],
+        dimensionNames: ['lat', 'lon'],
+        attributes: arrayAttrs,
+      },
+      {
+        name: 'lat',
+        shape: [4],
+        chunkShape: [4],
+        dimensionNames: ['lat'],
+        chunks: { '0': LAT_CENTERS },
+      },
+      {
+        name: 'lon',
+        shape: [8],
+        chunkShape: [8],
+        dimensionNames: ['lon'],
+        chunks: { '0': LON_CENTERS },
+      },
+    ],
+  })
+}
+
+/** Wraps a store so every key it is asked for can be inspected afterwards. */
+function recordReads(inner: MemoryStore) {
+  const keys: string[] = []
+  return {
+    keys,
+    store: {
+      get: async (key: string) => {
+        keys.push(key)
+        return inner.get(key)
+      },
+    },
+  }
+}
+
+async function describeSpatialStore(
+  arrayAttrs: Record<string, unknown>,
+  options: { bounds?: [number, number, number, number] } = {}
+) {
+  const { keys, store: recorded } = recordReads(spatialStore(arrayAttrs))
+  const store = new ZarrStore({
+    customStore: recorded,
+    variable: 'temperature',
+    version: 3,
+    ...options,
+  })
+  await store.initialized
+  return { d: store.describe(), keys }
+}
+
+describe('bounds from the spatial: convention', () => {
+  it('derives the extent and row direction from a transform', async () => {
+    const { d } = await describeSpatialStore({
+      'spatial:transform': GLOBAL_TRANSFORM,
+    })
+
+    expect(d.xyLimits).toEqual(GLOBAL_LIMITS)
+    expect(d.latIsAscending).toBe(false)
+  })
+
+  it('never touches the coordinate arrays when a transform settles both', async () => {
+    const { keys } = await describeSpatialStore({
+      'spatial:transform': GLOBAL_TRANSFORM,
+    })
+
+    expect(
+      keys.filter((k) => k.startsWith('/lat') || k.startsWith('/lon'))
+    ).toEqual([])
+  })
+
+  it('lands exactly where the coordinate arrays would have', async () => {
+    // Half a cell of disagreement here would shift the raster silently.
+    const declared = await describeSpatialStore({
+      'spatial:transform': GLOBAL_TRANSFORM,
+    })
+    const read = await describeSpatialStore({})
+
+    expect(declared.d.xyLimits).toEqual(read.d.xyLimits)
+    expect(declared.d.latIsAscending).toBe(read.d.latIsAscending)
+  })
+
+  it('reads a bbox as the extent but still checks orientation', async () => {
+    const { d, keys } = await describeSpatialStore({
+      'spatial:bbox': [-180, -90, 180, 90],
+    })
+
+    expect(d.xyLimits).toEqual(GLOBAL_LIMITS)
+    // A bbox says nothing about which edge row 0 sits on, so the coordinate
+    // read still has to happen. Setting `latIsAscending` skips it.
+    expect(keys.some((k) => k.startsWith('/lat'))).toBe(true)
+  })
+
+  it('folds a 0-360 bbox into the range the renderer works in', async () => {
+    const { d } = await describeSpatialStore({
+      'spatial:bbox': [200, -90, 340, 90],
+      'spatial:transform': GLOBAL_TRANSFORM,
+    })
+
+    expect(d.xyLimits?.xMin).toBe(-160)
+    expect(d.xyLimits?.xMax).toBe(-20)
+  })
+
+  it('snaps a global bbox that misses the antimeridian by a hair', async () => {
+    const { d } = await describeSpatialStore({
+      'spatial:bbox': [-179.9999, -90, 180.0001, 90],
+      'spatial:transform': GLOBAL_TRANSFORM,
+    })
+
+    expect(d.xyLimits?.xMin).toBe(-180)
+    expect(d.xyLimits?.xMax).toBe(180)
+  })
+
+  it('shifts a node-registered grid out by half a cell', async () => {
+    // A 1 deg regional grid, well clear of the global snap below.
+    const { d } = await describeSpatialStore({
+      'spatial:transform': [1, 0, -100, 0, -1, 40],
+      'spatial:registration': 'node',
+    })
+
+    expect(d.xyLimits).toEqual({
+      xMin: -100.5,
+      xMax: -92.5,
+      yMin: 36.5,
+      yMax: 40.5,
+    })
+  })
+
+  it('snaps a node-registered global grid onto the antimeridian', async () => {
+    // Node registration puts this grid's edges at -202.5..157.5, a full 360 deg
+    // of coverage offset by half a cell. The global snap pulls it onto +/-180
+    // rather than leaving a seam. Its tolerance is a whole cell, so the half
+    // cell here is well inside it.
+    const { d } = await describeSpatialStore({
+      'spatial:transform': GLOBAL_TRANSFORM,
+      'spatial:registration': 'node',
+    })
+
+    expect(d.xyLimits?.xMin).toBe(-180)
+    expect(d.xyLimits?.xMax).toBe(180)
+  })
+
+  it('lets the bounds option win over a declared bbox', async () => {
+    const { d } = await describeSpatialStore(
+      { 'spatial:bbox': [-180, -90, 180, 90] },
+      { bounds: [-10, -10, 10, 10] }
+    )
+
+    expect(d.xyLimits).toEqual({ xMin: -10, xMax: 10, yMin: -10, yMax: 10 })
+  })
+
+  it('falls back to the coordinate arrays for a transform type it cannot map', async () => {
+    const warn = silenceWarnings()
+    const { d, keys } = await describeSpatialStore({
+      'spatial:transform': GLOBAL_TRANSFORM,
+      'spatial:transform_type': 'rpc',
+    })
+
+    expect(d.xyLimits).toEqual(GLOBAL_LIMITS)
+    expect(keys.some((k) => k.startsWith('/lat'))).toBe(true)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('rpc'))
+  })
+
+  it('falls back to the coordinate arrays for a rotated transform', async () => {
+    const warn = silenceWarnings()
+    const { d, keys } = await describeSpatialStore({
+      'spatial:transform': [45, 1, -180, 1, -45, 90],
+    })
+
+    expect(d.xyLimits).toEqual(GLOBAL_LIMITS)
+    expect(keys.some((k) => k.startsWith('/lat'))).toBe(true)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('rotated'))
+  })
+})

--- a/src/zarr-store.geozarr.test.ts
+++ b/src/zarr-store.geozarr.test.ts
@@ -281,6 +281,46 @@ describe('CRS resolution precedence', () => {
   })
 })
 
+describe('the crs option without a proj4 string', () => {
+  it('resolves through proj4 built-ins', async () => {
+    const d = await describeGeoStore({}, { crs: 'EPSG:32631' })
+
+    expect(d.proj4).toBe('EPSG:32631')
+  })
+
+  it('normalizes a lowercase code before looking it up', async () => {
+    const d = await describeGeoStore({}, { crs: 'epsg:32631' })
+
+    expect(d.proj4).toBe('EPSG:32631')
+  })
+
+  it('wins over the store attributes', async () => {
+    const d = await describeGeoStore(
+      { arrayAttrs: { 'proj:wkt2': ALBERS_WKT2 } },
+      { crs: 'EPSG:32631' }
+    )
+
+    expect(d.proj4).toBe('EPSG:32631')
+  })
+
+  it('resolves a definition the consumer registered', async () => {
+    proj4.defs('TEST:ALBERS', ALBERS_PROJ4)
+    const d = await describeGeoStore({}, { crs: 'TEST:ALBERS' })
+
+    expect(d.proj4).toBe('TEST:ALBERS')
+  })
+
+  it('warns naming the proj4.defs remedy for a code proj4 does not know', async () => {
+    const warn = silenceWarnings()
+    const d = await describeGeoStore({}, { crs: 'EPSG:5070' })
+
+    expect(d.proj4).toBeNull()
+    const message = warn.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(message).toContain('EPSG:5070')
+    expect(message).toContain('proj4.defs')
+  })
+})
+
 describe('an unresolvable proj:code', () => {
   it('warns naming the code and the proj4.defs remedy', async () => {
     const warn = silenceWarnings()

--- a/src/zarr-store.geozarr.test.ts
+++ b/src/zarr-store.geozarr.test.ts
@@ -965,6 +965,66 @@ describe('per-level extents from the layout entries', () => {
     })
   })
 
+  it('declines a level whose row direction contradicts the dataset', async () => {
+    // The renderer draws every level in the dataset's row direction. A level
+    // declaring the opposite cannot be honored, so its extent is dropped with
+    // a warning rather than placed as if its rows ran the other way.
+    const warn = silenceWarnings()
+    const { d } = await describeLevels(
+      [
+        {
+          asset: '0',
+          'spatial:transform': GLOBAL_TRANSFORM,
+          'spatial:shape': [4, 8],
+        },
+        {
+          asset: '1',
+          'spatial:transform': [90, 0, -180, 0, 90, -90],
+          'spatial:shape': [2, 4],
+        },
+      ],
+      { bounds: null }
+    )
+
+    expect(d.untiledLevels[0].xyLimits).toEqual(GLOBAL_LIMITS)
+    expect(d.untiledLevels[1].xyLimits).toBeUndefined()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('row direction'))
+  })
+
+  it('keeps extents of a consistent store under a latIsAscending override', async () => {
+    // The harness overrides latIsAscending to false against south-up
+    // transforms. The override changes how rows are drawn, not what the
+    // store's transforms declare about placement, so extents survive.
+    const warn = silenceWarnings()
+    const { d } = await describeLevels(
+      [
+        {
+          asset: '0',
+          'spatial:transform': [45, 0, -180, 0, 45, -90],
+          'spatial:shape': [4, 8],
+        },
+        {
+          asset: '1',
+          'spatial:transform': [90, 0, -180, 0, 90, -90],
+          'spatial:shape': [2, 3],
+        },
+      ],
+      { bounds: null }
+    )
+
+    expect(d.latIsAscending).toBe(false)
+    expect(d.untiledLevels[0].xyLimits).toEqual(GLOBAL_LIMITS)
+    expect(d.untiledLevels[1].xyLimits).toEqual({
+      xMin: -180,
+      xMax: 90,
+      yMin: -90,
+      yMax: 90,
+    })
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('row direction')
+    )
+  })
+
   it('leaves a level with no declared transform without one', async () => {
     const { d } = await describeLevels(
       [

--- a/src/zarr-store.geozarr.test.ts
+++ b/src/zarr-store.geozarr.test.ts
@@ -664,3 +664,98 @@ describe('level shapes from spatial:shape', () => {
     expect(d.untiledLevels[1].shape).toBeUndefined()
   })
 })
+
+describe('georeferencing declared on the layout entries', () => {
+  /**
+   * A pyramid whose absolute placement lives only on its `multiscales.layout`
+   * entries, which is where the multiscales convention puts it. Nothing on the
+   * group or the array says where the grid sits.
+   */
+  const layoutGeoStore = (layout: unknown[]) =>
+    buildMemoryZarrStore({
+      attributes: { multiscales: { layout } },
+      arrays: [0, 1].map((i) => ({
+        name: `${i}/temperature`,
+        shape: [4 >> i, 8 >> i],
+        chunkShape: [4 >> i, 8 >> i],
+        dimensionNames: ['lat', 'lon'],
+      })),
+    })
+
+  const describeLayoutGeo = async (layout: unknown[]) => {
+    const { keys, store: recorded } = recordReads(layoutGeoStore(layout))
+    const store = new ZarrStore({
+      customStore: recorded,
+      variable: 'temperature',
+      version: 3,
+    })
+    await store.initialized
+    return { d: store.describe(), keys }
+  }
+
+  it('places the grid from the base level transform', async () => {
+    const { d } = await describeLayoutGeo([
+      {
+        asset: '0',
+        'spatial:transform': GLOBAL_TRANSFORM,
+        'spatial:shape': [4, 8],
+      },
+      {
+        asset: '1',
+        'spatial:transform': [90, 0, -180, 0, -90, 90],
+        'spatial:shape': [2, 4],
+      },
+    ])
+
+    expect(d.xyLimits).toEqual(GLOBAL_LIMITS)
+    expect(d.latIsAscending).toBe(false)
+  })
+
+  it('needs no coordinate arrays to do it', async () => {
+    const { keys } = await describeLayoutGeo([
+      {
+        asset: '0',
+        'spatial:transform': GLOBAL_TRANSFORM,
+        'spatial:shape': [4, 8],
+      },
+      { asset: '1', 'spatial:shape': [2, 4] },
+    ])
+
+    expect(keys.filter((k) => k.includes('lat') || k.includes('lon'))).toEqual(
+      []
+    )
+  })
+
+  it('lets a group-level declaration win over the layout entry', async () => {
+    const store = new ZarrStore({
+      customStore: buildMemoryZarrStore({
+        attributes: {
+          multiscales: {
+            layout: [
+              { asset: '0', 'spatial:transform': GLOBAL_TRANSFORM },
+              { asset: '1' },
+            ],
+          },
+          'spatial:bbox': [-10, -10, 10, 10],
+        },
+        arrays: [0, 1].map((i) => ({
+          name: `${i}/temperature`,
+          shape: [4 >> i, 8 >> i],
+          chunkShape: [4 >> i, 8 >> i],
+          dimensionNames: ['lat', 'lon'],
+        })),
+      }),
+      variable: 'temperature',
+      version: 3,
+      latIsAscending: false,
+    })
+    await store.initialized
+
+    expect(store.describe().xyLimits).toEqual({
+      xMin: -10,
+      xMax: 10,
+      yMin: -10,
+      yMax: 10,
+    })
+  })
+})

--- a/src/zarr-store.geozarr.test.ts
+++ b/src/zarr-store.geozarr.test.ts
@@ -177,6 +177,16 @@ describe('CRS from the proj: convention', () => {
     expect(d.proj4).toBe('EPSG:32631')
   })
 
+  it('normalizes a lowercase proj:code before looking it up', async () => {
+    // proj4's registry is keyed on the uppercase form, and the built-in codes
+    // already accept either case.
+    const d = await describeGeoStore({
+      arrayAttrs: { 'proj:code': 'epsg:32631' },
+    })
+
+    expect(d.proj4).toBe('EPSG:32631')
+  })
+
   it('registers proj:wkt2 and reprojects through it', async () => {
     const d = await describeGeoStore({
       arrayAttrs: { 'proj:wkt2': ALBERS_WKT2 },
@@ -575,6 +585,16 @@ describe('axis identification from spatial:dimensions', () => {
       expect(d.dimIndices[untouched]?.name).toBe(stillDeclared)
     }
   )
+
+  it('lets an override repair an axis the store declared wrongly', async () => {
+    const d = await describeNamedAxes(
+      { 'spatial:dimensions': ['bogus', 'easting'] },
+      { lat: 'northing' }
+    )
+
+    expect(d.dimIndices.lat?.name).toBe('northing')
+    expect(d.dimIndices.lon?.name).toBe('easting')
+  })
 
   it('rejects a declaration naming dimensions the array does not have', async () => {
     await expect(

--- a/src/zarr-store.geozarr.test.ts
+++ b/src/zarr-store.geozarr.test.ts
@@ -493,3 +493,92 @@ describe('bounds from the spatial: convention', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('rotated'))
   })
 })
+
+/**
+ * A grid whose axes are named something the alias list has never heard of, so
+ * only `spatial:dimensions` can identify them.
+ */
+function namedAxesStore(arrayAttrs: Record<string, unknown>): MemoryStore {
+  return buildMemoryZarrStore({
+    arrays: [
+      {
+        name: 'temperature',
+        shape: [2, 4, 8],
+        chunkShape: [2, 4, 8],
+        dimensionNames: ['band', 'northing', 'easting'],
+        attributes: arrayAttrs,
+      },
+    ],
+  })
+}
+
+async function describeNamedAxes(
+  arrayAttrs: Record<string, unknown>,
+  spatialDimensions?: { lat?: string; lon?: string }
+) {
+  const store = new ZarrStore({
+    customStore: namedAxesStore(arrayAttrs),
+    variable: 'temperature',
+    version: 3,
+    bounds: [-100, 30, -92, 40],
+    latIsAscending: false,
+    spatialDimensions,
+  })
+  await store.initialized
+  return store.describe()
+}
+
+describe('axis identification from spatial:dimensions', () => {
+  it('identifies axes the alias list cannot', async () => {
+    const d = await describeNamedAxes({
+      'spatial:dimensions': ['northing', 'easting'],
+    })
+
+    expect(d.dimIndices.lat?.name).toBe('northing')
+    expect(d.dimIndices.lat?.index).toBe(1)
+    expect(d.dimIndices.lon?.name).toBe('easting')
+    expect(d.dimIndices.lon?.index).toBe(2)
+  })
+
+  it('leaves the alias heuristic in charge when nothing is declared', async () => {
+    const d = await describeNamedAxes({})
+
+    expect(d.dimIndices.lat).toBeUndefined()
+    expect(d.dimIndices.lon).toBeUndefined()
+  })
+
+  it('reads the declared order as [y, x]', async () => {
+    // Declared the other way round, the axes swap with it.
+    const d = await describeNamedAxes({
+      'spatial:dimensions': ['easting', 'northing'],
+    })
+
+    expect(d.dimIndices.lat?.name).toBe('easting')
+    expect(d.dimIndices.lon?.name).toBe('northing')
+  })
+
+  // Pointing an axis at the band dimension is nonsense geographically; it is
+  // picked precisely because the store would never resolve that axis there.
+  it.each([
+    ['lat' as const, 'lon' as const, 'easting'],
+    ['lon' as const, 'lat' as const, 'northing'],
+  ])(
+    'lets the spatialDimensions option win for %s alone',
+    async (overridden, untouched, stillDeclared) => {
+      const d = await describeNamedAxes(
+        { 'spatial:dimensions': ['northing', 'easting'] },
+        { [overridden]: 'band' }
+      )
+
+      expect(d.dimIndices[overridden]?.name).toBe('band')
+      // The axis the caller left alone still comes from the store.
+      expect(d.dimIndices[untouched]?.name).toBe(stillDeclared)
+    }
+  )
+
+  it('rejects a declaration naming dimensions the array does not have', async () => {
+    await expect(
+      describeNamedAxes({ 'spatial:dimensions': ['y', 'x'] })
+    ).rejects.toThrow(/spatial:dimensions names \[y, x\]/)
+  })
+})

--- a/src/zarr-store.geozarr.test.ts
+++ b/src/zarr-store.geozarr.test.ts
@@ -671,9 +671,12 @@ describe('georeferencing declared on the layout entries', () => {
    * entries, which is where the multiscales convention puts it. Nothing on the
    * group or the array says where the grid sits.
    */
-  const layoutGeoStore = (layout: unknown[]) =>
+  const layoutGeoStore = (
+    layout: unknown[],
+    groupAttrs: Record<string, unknown> = {}
+  ) =>
     buildMemoryZarrStore({
-      attributes: { multiscales: { layout } },
+      attributes: { multiscales: { layout }, ...groupAttrs },
       arrays: [0, 1].map((i) => ({
         name: `${i}/temperature`,
         shape: [4 >> i, 8 >> i],
@@ -682,8 +685,13 @@ describe('georeferencing declared on the layout entries', () => {
       })),
     })
 
-  const describeLayoutGeo = async (layout: unknown[]) => {
-    const { keys, store: recorded } = recordReads(layoutGeoStore(layout))
+  const describeLayoutGeo = async (
+    layout: unknown[],
+    groupAttrs: Record<string, unknown> = {}
+  ) => {
+    const { keys, store: recorded } = recordReads(
+      layoutGeoStore(layout, groupAttrs)
+    )
     const store = new ZarrStore({
       customStore: recorded,
       variable: 'temperature',
@@ -721,6 +729,21 @@ describe('georeferencing declared on the layout entries', () => {
       { asset: '1', 'spatial:shape': [2, 4] },
     ])
 
+    expect(keys.filter((k) => k.includes('lat') || k.includes('lon'))).toEqual(
+      []
+    )
+  })
+
+  it('takes the extent from a group bbox and the row direction from the entry', async () => {
+    // How EOPF Sentinel-2 declares itself: a bbox on the group, the transform
+    // only on the layout entries. Neither settles the grid alone.
+    const { d, keys } = await describeLayoutGeo(
+      [{ asset: '0', 'spatial:transform': GLOBAL_TRANSFORM }, { asset: '1' }],
+      { 'spatial:bbox': [-180, -90, 180, 90] }
+    )
+
+    expect(d.xyLimits).toEqual(GLOBAL_LIMITS)
+    expect(d.latIsAscending).toBe(false)
     expect(keys.filter((k) => k.includes('lat') || k.includes('lon'))).toEqual(
       []
     )

--- a/src/zarr-store.geozarr.test.ts
+++ b/src/zarr-store.geozarr.test.ts
@@ -608,9 +608,12 @@ describe('axis identification from spatial:dimensions', () => {
  * be the declared [height, width] pair — the non-spatial dimension has to
  * survive and the spatial ones have to land in the array's own axis order.
  */
-function levelShapeStore(layout: unknown[]): MemoryStore {
+function levelShapeStore(
+  layout: unknown[],
+  rootAttrs: Record<string, unknown> = {}
+): MemoryStore {
   return buildMemoryZarrStore({
-    attributes: { multiscales: { layout, crs: 'EPSG:4326' } },
+    attributes: { multiscales: { layout, crs: 'EPSG:4326' }, ...rootAttrs },
     arrays: [0, 1].map((i) => ({
       name: `${i}/temperature`,
       shape: [2, 512 >> i, 1024 >> i],
@@ -620,8 +623,13 @@ function levelShapeStore(layout: unknown[]): MemoryStore {
   })
 }
 
-async function describeLevels(layout: unknown[]) {
-  const { keys, store: recorded } = recordReads(levelShapeStore(layout))
+async function describeLevels(
+  layout: unknown[],
+  rootAttrs: Record<string, unknown> = {}
+) {
+  const { keys, store: recorded } = recordReads(
+    levelShapeStore(layout, rootAttrs)
+  )
   const store = new ZarrStore({
     customStore: recorded,
     variable: 'temperature',
@@ -892,5 +900,76 @@ describe('a declaration on the level group', () => {
     expect(d.crs).toBe('EPSG:4326')
     expect(d.xyLimits).toEqual(GLOBAL_LIMITS)
     expect(d.latIsAscending).toBe(false)
+  })
+})
+
+describe('per-level extents from the layout entries', () => {
+  it('gives each level the extent its own transform describes', async () => {
+    // Level 1 is floor-divided: 4 columns of 90 covers 360, but 2 columns of
+    // 180 starting at -180 stops at 180 -- while a 3-column level would not.
+    const { d } = await describeLevels([
+      {
+        asset: '0',
+        'spatial:transform': GLOBAL_TRANSFORM,
+        'spatial:shape': [4, 8],
+      },
+      {
+        asset: '1',
+        'spatial:transform': [90, 0, -180, 0, -90, 90],
+        'spatial:shape': [2, 3],
+      },
+    ])
+
+    expect(d.untiledLevels[0].xyLimits).toEqual(GLOBAL_LIMITS)
+    // 3 columns x 90 = 270 wide, not the dataset's 360.
+    expect(d.untiledLevels[1].xyLimits).toEqual({
+      xMin: -180,
+      xMax: 90,
+      yMin: -90,
+      yMax: 90,
+    })
+  })
+
+  it('leaves a level with no declared transform without one', async () => {
+    const { d } = await describeLevels([
+      {
+        asset: '0',
+        'spatial:transform': GLOBAL_TRANSFORM,
+        'spatial:shape': [4, 8],
+      },
+      { asset: '1', 'spatial:shape': [2, 4] },
+    ])
+
+    expect(d.untiledLevels[0].xyLimits).toEqual(GLOBAL_LIMITS)
+    expect(d.untiledLevels[1].xyLimits).toBeUndefined()
+  })
+})
+
+describe('a level extent competing with a dataset bbox', () => {
+  it("uses the level's own transform, not the dataset bbox", async () => {
+    // The bbox describes the base level. Applying it to level 1 would stretch
+    // that level's 270 units of coverage across the full 360.
+    const { d } = await describeLevels(
+      [
+        {
+          asset: '0',
+          'spatial:transform': GLOBAL_TRANSFORM,
+          'spatial:shape': [4, 8],
+        },
+        {
+          asset: '1',
+          'spatial:transform': [90, 0, -180, 0, -90, 90],
+          'spatial:shape': [2, 3],
+        },
+      ],
+      { 'spatial:bbox': [-180, -90, 180, 90] }
+    )
+
+    expect(d.untiledLevels[1].xyLimits).toEqual({
+      xMin: -180,
+      xMax: 90,
+      yMin: -90,
+      yMax: 90,
+    })
   })
 })

--- a/src/zarr-store.geozarr.test.ts
+++ b/src/zarr-store.geozarr.test.ts
@@ -582,3 +582,85 @@ describe('axis identification from spatial:dimensions', () => {
     ).rejects.toThrow(/spatial:dimensions names \[y, x\]/)
   })
 })
+
+/**
+ * A two-level pyramid carrying a time dimension, so a level's shape cannot just
+ * be the declared [height, width] pair — the non-spatial dimension has to
+ * survive and the spatial ones have to land in the array's own axis order.
+ */
+function levelShapeStore(layout: unknown[]): MemoryStore {
+  return buildMemoryZarrStore({
+    attributes: { multiscales: { layout, crs: 'EPSG:4326' } },
+    arrays: [0, 1].map((i) => ({
+      name: `${i}/temperature`,
+      shape: [2, 512 >> i, 1024 >> i],
+      chunkShape: [2, 512 >> i, 1024 >> i],
+      dimensionNames: ['time', 'lat', 'lon'],
+    })),
+  })
+}
+
+async function describeLevels(layout: unknown[]) {
+  const { keys, store: recorded } = recordReads(levelShapeStore(layout))
+  const store = new ZarrStore({
+    customStore: recorded,
+    variable: 'temperature',
+    version: 3,
+    bounds: [-180, -90, 180, 90],
+    latIsAscending: false,
+  })
+  await store.initialized
+  return { d: store.describe(), keys }
+}
+
+describe('level shapes from spatial:shape', () => {
+  it('substitutes the declared pair into the array axis order', async () => {
+    const { d } = await describeLevels([
+      { asset: '0', 'spatial:shape': [512, 1024] },
+      { asset: '1', 'spatial:shape': [256, 512] },
+    ])
+
+    // The time dimension is carried over from the base shape.
+    expect(d.untiledLevels).toEqual([
+      { asset: '0', shape: [2, 512, 1024] },
+      { asset: '1', shape: [2, 256, 512] },
+    ])
+  })
+
+  it('matches what opening the level array would have reported', async () => {
+    const { d } = await describeLevels([
+      { asset: '0', 'spatial:shape': [512, 1024] },
+      { asset: '1', 'spatial:shape': [256, 512] },
+    ])
+    const declared = d.untiledLevels[1].shape
+
+    const opened = await new ZarrStore({
+      customStore: levelShapeStore([{ asset: '0' }, { asset: '1' }]),
+      variable: 'temperature',
+      version: 3,
+      bounds: [-180, -90, 180, 90],
+      latIsAscending: false,
+    }).initialized.then((s) => s.getUntiledLevelMetadata('1'))
+
+    expect(declared).toEqual(opened.shape)
+  })
+
+  it('never opens the deeper level to size the pyramid', async () => {
+    const { keys } = await describeLevels([
+      { asset: '0', 'spatial:shape': [512, 1024] },
+      { asset: '1', 'spatial:shape': [256, 512] },
+    ])
+
+    expect(keys).not.toContain('/1/temperature/zarr.json')
+  })
+
+  it('leaves a level that declares nothing for the renderer to fetch', async () => {
+    const { d } = await describeLevels([
+      { asset: '0', 'spatial:shape': [512, 1024] },
+      { asset: '1' },
+    ])
+
+    expect(d.untiledLevels[0].shape).toEqual([2, 512, 1024])
+    expect(d.untiledLevels[1].shape).toBeUndefined()
+  })
+})

--- a/src/zarr-store.geozarr.test.ts
+++ b/src/zarr-store.geozarr.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import proj4 from 'proj4'
+import { ZarrStore } from './zarr-store'
+import {
+  buildMemoryZarrStore,
+  type MemoryStore,
+} from './__fixtures__/memory-zarr'
+
+/**
+ * Integration coverage for the zarr-conventions attributes, driven through the
+ * real `ZarrStore._initialize()` against an in-memory v3 fixture.
+ *
+ * Bounds are supplied explicitly on the CRS cases so nothing depends on
+ * coordinate arrays, isolating what `proj:` alone settles.
+ */
+
+// EPSG:5070, which proj4 has no built-in definition for — the store has to
+// carry the full description for it to resolve.
+const ALBERS_WKT2 =
+  'PROJCRS["NAD83 / Conus Albers",BASEGEOGCRS["NAD83",DATUM["North American Datum 1983",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]]],CONVERSION["Conus Albers",METHOD["Albers Equal Area",ID["EPSG",9822]],PARAMETER["Latitude of false origin",23,ANGLEUNIT["degree",0.0174532925199433]],PARAMETER["Longitude of false origin",-96,ANGLEUNIT["degree",0.0174532925199433]],PARAMETER["Latitude of 1st standard parallel",29.5,ANGLEUNIT["degree",0.0174532925199433]],PARAMETER["Latitude of 2nd standard parallel",45.5,ANGLEUNIT["degree",0.0174532925199433]],PARAMETER["Easting at false origin",0,LENGTHUNIT["metre",1]],PARAMETER["Northing at false origin",0,LENGTHUNIT["metre",1]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],ID["EPSG",5070]]'
+
+const ALBERS_PROJ4 =
+  '+proj=aea +lat_0=23 +lon_0=-96 +lat_1=29.5 +lat_2=45.5 +x_0=0 +y_0=0 +datum=NAD83 +units=m'
+
+const UTM31_PROJJSON = {
+  type: 'ProjectedCRS',
+  name: 'WGS 84 / UTM zone 31N',
+  base_crs: {
+    name: 'WGS 84',
+    datum: {
+      type: 'GeodeticReferenceFrame',
+      name: 'World Geodetic System 1984',
+      ellipsoid: {
+        name: 'WGS 84',
+        semi_major_axis: 6378137,
+        inverse_flattening: 298.257223563,
+      },
+    },
+    coordinate_system: {
+      subtype: 'ellipsoidal',
+      axis: [
+        { name: 'Geodetic latitude', direction: 'north', unit: 'degree' },
+        { name: 'Geodetic longitude', direction: 'east', unit: 'degree' },
+      ],
+    },
+  },
+  conversion: {
+    name: 'UTM zone 31N',
+    method: {
+      name: 'Transverse Mercator',
+      id: { authority: 'EPSG', code: 9807 },
+    },
+    parameters: [
+      { name: 'Latitude of natural origin', value: 0, unit: 'degree' },
+      { name: 'Longitude of natural origin', value: 3, unit: 'degree' },
+      { name: 'Scale factor at natural origin', value: 0.9996, unit: 'unity' },
+      { name: 'False easting', value: 500000, unit: 'metre' },
+      { name: 'False northing', value: 0, unit: 'metre' },
+    ],
+  },
+  coordinate_system: {
+    subtype: 'Cartesian',
+    axis: [
+      { name: 'Easting', direction: 'east', unit: 'metre' },
+      { name: 'Northing', direction: 'north', unit: 'metre' },
+    ],
+  },
+  id: { authority: 'EPSG', code: 32631 },
+}
+
+const METRIC_BOUNDS: [number, number, number, number] = [-2e6, 1e6, 2e6, 3e6]
+
+interface GeoStoreSpec {
+  groupAttrs?: Record<string, unknown>
+  arrayAttrs?: Record<string, unknown>
+  /** Attributes of a CF grid-mapping variable named `spatial_ref`. */
+  gridMappingAttrs?: Record<string, unknown>
+}
+
+function geoStore({
+  groupAttrs,
+  arrayAttrs,
+  gridMappingAttrs,
+}: GeoStoreSpec): MemoryStore {
+  return buildMemoryZarrStore({
+    attributes: groupAttrs ?? {},
+    arrays: [
+      {
+        name: 'temperature',
+        shape: [4, 8],
+        chunkShape: [4, 8],
+        dimensionNames: ['y', 'x'],
+        attributes: arrayAttrs ?? {},
+      },
+      {
+        name: 'y',
+        shape: [4],
+        chunkShape: [4],
+        dimensionNames: ['y'],
+        chunks: { '0': [2.75e6, 2.25e6, 1.75e6, 1.25e6] },
+      },
+      {
+        name: 'x',
+        shape: [8],
+        chunkShape: [8],
+        dimensionNames: ['x'],
+        chunks: {
+          '0': [-1.75e6, -1.25e6, -7.5e5, -2.5e5, 2.5e5, 7.5e5, 1.25e6, 1.75e6],
+        },
+      },
+      ...(gridMappingAttrs
+        ? [
+            {
+              name: 'spatial_ref',
+              shape: [1],
+              chunkShape: [1],
+              attributes: gridMappingAttrs,
+            },
+          ]
+        : []),
+    ],
+  })
+}
+
+/**
+ * `latIsAscending: false` keeps the CRS cases off the coordinate-read path
+ * entirely. The cases that exercise bounds-based CRS inference pass `null`
+ * instead, since that inference only runs once the coordinate path has been
+ * walked.
+ */
+async function describeGeoStore(
+  spec: GeoStoreSpec,
+  options: {
+    crs?: string
+    proj4?: string
+    latIsAscending?: boolean | null
+  } = {}
+) {
+  const store = new ZarrStore({
+    customStore: geoStore(spec),
+    variable: 'temperature',
+    version: 3,
+    bounds: METRIC_BOUNDS,
+    latIsAscending: false,
+    ...options,
+  })
+  await store.initialized
+  return store.describe()
+}
+
+const silenceWarnings = () =>
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('CRS from the proj: convention', () => {
+  it.each([
+    ['EPSG:4326', 'EPSG:4326'],
+    ['EPSG:3857', 'EPSG:3857'],
+    ['epsg:4326', 'EPSG:4326'],
+    // WGS84 lon/lat under its OGC identity, same axis order the renderer assumes.
+    ['OGC:CRS84', 'EPSG:4326'],
+  ])('keeps %s on the native path', async (code, expected) => {
+    const d = await describeGeoStore({ arrayAttrs: { 'proj:code': code } })
+
+    expect(d.crs).toBe(expected)
+    expect(d.proj4).toBeNull()
+  })
+
+  it('resolves a proj:code proj4 already ships a definition for', async () => {
+    const d = await describeGeoStore({
+      arrayAttrs: { 'proj:code': 'EPSG:32631' },
+    })
+
+    expect(d.proj4).toBe('EPSG:32631')
+  })
+
+  it('registers proj:wkt2 and reprojects through it', async () => {
+    const d = await describeGeoStore({
+      arrayAttrs: { 'proj:wkt2': ALBERS_WKT2 },
+    })
+
+    expect(d.proj4).toBeTruthy()
+    const [lon, lat] = proj4(d.proj4!, 'EPSG:4326').forward([0, 0])
+    const [refLon, refLat] = proj4(ALBERS_PROJ4, 'EPSG:4326').forward([0, 0])
+    expect(lon).toBeCloseTo(refLon, 9)
+    expect(lat).toBeCloseTo(refLat, 9)
+  })
+
+  it('registers proj:projjson and reprojects through it', async () => {
+    const d = await describeGeoStore({
+      arrayAttrs: { 'proj:projjson': UTM31_PROJJSON },
+    })
+
+    expect(d.proj4).toBeTruthy()
+    // The false easting of UTM zone 31N sits on its central meridian, 3°E.
+    const [lon] = proj4(d.proj4!, 'EPSG:4326').forward([500000, 0])
+    expect(lon).toBeCloseTo(3, 9)
+  })
+
+  it('gives each store its own key so two layers cannot collide', async () => {
+    const [first, second] = await Promise.all([
+      describeGeoStore({ arrayAttrs: { 'proj:wkt2': ALBERS_WKT2 } }),
+      describeGeoStore({ arrayAttrs: { 'proj:projjson': UTM31_PROJJSON } }),
+    ])
+
+    expect(first.proj4).not.toBe(second.proj4)
+  })
+
+  it('prefers a built-in proj:code over a wkt2 describing the same CRS', async () => {
+    const d = await describeGeoStore({
+      arrayAttrs: { 'proj:code': 'EPSG:4326', 'proj:wkt2': ALBERS_WKT2 },
+    })
+
+    expect(d.crs).toBe('EPSG:4326')
+    expect(d.proj4).toBeNull()
+  })
+
+  it('lets array attributes override the group they inherit from', async () => {
+    const d = await describeGeoStore({
+      groupAttrs: { 'proj:code': 'EPSG:4326' },
+      arrayAttrs: { 'proj:code': 'EPSG:3857' },
+    })
+
+    expect(d.crs).toBe('EPSG:3857')
+  })
+
+  it('reads a CF grid mapping when no proj: attribute is declared', async () => {
+    const d = await describeGeoStore({
+      arrayAttrs: { grid_mapping: 'spatial_ref' },
+      gridMappingAttrs: { crs_wkt: ALBERS_WKT2 },
+    })
+
+    expect(d.proj4).toBeTruthy()
+    const [lon, lat] = proj4(d.proj4!, 'EPSG:4326').forward([0, 0])
+    const [refLon, refLat] = proj4(ALBERS_PROJ4, 'EPSG:4326').forward([0, 0])
+    expect(lon).toBeCloseTo(refLon, 9)
+    expect(lat).toBeCloseTo(refLat, 9)
+  })
+
+  it('reads the spatial_ref attribute rioxarray writes alongside crs_wkt', async () => {
+    const d = await describeGeoStore({
+      arrayAttrs: { grid_mapping: 'spatial_ref' },
+      gridMappingAttrs: { spatial_ref: ALBERS_WKT2 },
+    })
+
+    expect(d.proj4).toBeTruthy()
+  })
+})
+
+describe('CRS resolution precedence', () => {
+  it('lets the crs option win over the store attributes', async () => {
+    const d = await describeGeoStore(
+      { arrayAttrs: { 'proj:wkt2': ALBERS_WKT2 } },
+      { crs: 'EPSG:3857' }
+    )
+
+    expect(d.crs).toBe('EPSG:3857')
+    expect(d.proj4).toBeNull()
+  })
+
+  it('lets the proj4 option win over the store attributes', async () => {
+    const d = await describeGeoStore(
+      { arrayAttrs: { 'proj:wkt2': ALBERS_WKT2 } },
+      { proj4: ALBERS_PROJ4 }
+    )
+
+    expect(d.proj4).toBe(ALBERS_PROJ4)
+  })
+})
+
+describe('an unresolvable proj:code', () => {
+  it('warns naming the code and the proj4.defs remedy', async () => {
+    const warn = silenceWarnings()
+    await describeGeoStore({ arrayAttrs: { 'proj:code': 'EPSG:5070' } })
+
+    const message = warn.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(message).toContain('EPSG:5070')
+    expect(message).toContain('proj4.defs')
+  })
+
+  it('does not fall back to guessing a CRS from the bounds', async () => {
+    silenceWarnings()
+    // Metric bounds otherwise infer as EPSG:3857, as the next case shows. The
+    // store said EPSG:5070, so contradicting it is worse than leaving it
+    // unresolved.
+    const d = await describeGeoStore(
+      { arrayAttrs: { 'proj:code': 'EPSG:5070' } },
+      { latIsAscending: null }
+    )
+
+    expect(d.crs).toBe('EPSG:4326')
+    expect(d.proj4).toBeNull()
+  })
+
+  it('still infers from bounds when nothing declares a CRS', async () => {
+    const d = await describeGeoStore({}, { latIsAscending: null })
+
+    expect(d.crs).toBe('EPSG:3857')
+  })
+})

--- a/src/zarr-store.geozarr.test.ts
+++ b/src/zarr-store.geozarr.test.ts
@@ -623,9 +623,41 @@ function levelShapeStore(
   })
 }
 
+/**
+ * `bounds` defaults to the dataset extent for layouts that declare only
+ * shapes. Cases exercising per-level extents pass `null`, since explicit
+ * bounds deliberately suppress them.
+ */
+async function describeLevelsWithStore(
+  layout: unknown[],
+  {
+    rootAttrs = {},
+    bounds = [-180, -90, 180, 90] as [number, number, number, number] | null,
+  }: {
+    rootAttrs?: Record<string, unknown>
+    bounds?: [number, number, number, number] | null
+  } = {}
+) {
+  const store = new ZarrStore({
+    customStore: levelShapeStore(layout, rootAttrs),
+    variable: 'temperature',
+    version: 3,
+    ...(bounds ? { bounds } : {}),
+    latIsAscending: false,
+  })
+  await store.initialized
+  return { d: store.describe(), store }
+}
+
 async function describeLevels(
   layout: unknown[],
-  rootAttrs: Record<string, unknown> = {}
+  {
+    rootAttrs = {},
+    bounds = [-180, -90, 180, 90] as [number, number, number, number] | null,
+  }: {
+    rootAttrs?: Record<string, unknown>
+    bounds?: [number, number, number, number] | null
+  } = {}
 ) {
   const { keys, store: recorded } = recordReads(
     levelShapeStore(layout, rootAttrs)
@@ -634,7 +666,7 @@ async function describeLevels(
     customStore: recorded,
     variable: 'temperature',
     version: 3,
-    bounds: [-180, -90, 180, 90],
+    ...(bounds ? { bounds } : {}),
     latIsAscending: false,
   })
   await store.initialized
@@ -907,18 +939,21 @@ describe('per-level extents from the layout entries', () => {
   it('gives each level the extent its own transform describes', async () => {
     // Level 1 is floor-divided: 4 columns of 90 covers 360, but 2 columns of
     // 180 starting at -180 stops at 180 -- while a 3-column level would not.
-    const { d } = await describeLevels([
-      {
-        asset: '0',
-        'spatial:transform': GLOBAL_TRANSFORM,
-        'spatial:shape': [4, 8],
-      },
-      {
-        asset: '1',
-        'spatial:transform': [90, 0, -180, 0, -90, 90],
-        'spatial:shape': [2, 3],
-      },
-    ])
+    const { d } = await describeLevels(
+      [
+        {
+          asset: '0',
+          'spatial:transform': GLOBAL_TRANSFORM,
+          'spatial:shape': [4, 8],
+        },
+        {
+          asset: '1',
+          'spatial:transform': [90, 0, -180, 0, -90, 90],
+          'spatial:shape': [2, 3],
+        },
+      ],
+      { bounds: null }
+    )
 
     expect(d.untiledLevels[0].xyLimits).toEqual(GLOBAL_LIMITS)
     // 3 columns x 90 = 270 wide, not the dataset's 360.
@@ -931,14 +966,17 @@ describe('per-level extents from the layout entries', () => {
   })
 
   it('leaves a level with no declared transform without one', async () => {
-    const { d } = await describeLevels([
-      {
-        asset: '0',
-        'spatial:transform': GLOBAL_TRANSFORM,
-        'spatial:shape': [4, 8],
-      },
-      { asset: '1', 'spatial:shape': [2, 4] },
-    ])
+    const { d } = await describeLevels(
+      [
+        {
+          asset: '0',
+          'spatial:transform': GLOBAL_TRANSFORM,
+          'spatial:shape': [4, 8],
+        },
+        { asset: '1', 'spatial:shape': [2, 4] },
+      ],
+      { bounds: null }
+    )
 
     expect(d.untiledLevels[0].xyLimits).toEqual(GLOBAL_LIMITS)
     expect(d.untiledLevels[1].xyLimits).toBeUndefined()
@@ -962,12 +1000,80 @@ describe('a level extent competing with a dataset bbox', () => {
           'spatial:shape': [2, 3],
         },
       ],
-      { 'spatial:bbox': [-180, -90, 180, 90] }
+      { rootAttrs: { 'spatial:bbox': [-180, -90, 180, 90] }, bounds: null }
     )
 
     expect(d.untiledLevels[1].xyLimits).toEqual({
       xMin: -180,
       xMax: 90,
+      yMin: -90,
+      yMax: 90,
+    })
+  })
+})
+
+describe('explicit bounds against per-level extents', () => {
+  it('suppresses per-level extents when the caller supplies bounds', async () => {
+    // `bounds` overrides the store's georeferencing. Re-deriving level extents
+    // from the same metadata would quietly reinstate what was overridden.
+    const { keys, store: recorded } = recordReads(
+      levelShapeStore([
+        {
+          asset: '0',
+          'spatial:transform': GLOBAL_TRANSFORM,
+          'spatial:shape': [4, 8],
+        },
+        {
+          asset: '1',
+          'spatial:transform': [90, 0, -180, 0, -90, 90],
+          'spatial:shape': [2, 3],
+        },
+      ])
+    )
+    const store = new ZarrStore({
+      customStore: recorded,
+      variable: 'temperature',
+      version: 3,
+      bounds: [-10, -10, 10, 10],
+      latIsAscending: false,
+    })
+    await store.initialized
+    const d = store.describe()
+
+    expect(d.xyLimits).toEqual({ xMin: -10, xMax: 10, yMin: -10, yMax: 10 })
+    expect(d.untiledLevels.every((l) => l.xyLimits === undefined)).toBe(true)
+    expect(keys.length).toBeGreaterThan(0)
+  })
+})
+
+describe('a level transform without a declared shape', () => {
+  it('derives the extent once the real shape is loaded', async () => {
+    // The fixture's arrays are 512x1024 and 256x512, so a global extent means
+    // cells of 360/1024 and 360/512 degrees.
+    const { d, store } = await describeLevelsWithStore(
+      [
+        {
+          asset: '0',
+          'spatial:transform': [0.3515625, 0, -180, 0, -0.3515625, 90],
+          'spatial:shape': [512, 1024],
+        },
+        // Transform but no spatial:shape: the extent cannot be worked out
+        // until the array itself is opened.
+        {
+          asset: '1',
+          'spatial:transform': [0.703125, 0, -180, 0, -0.703125, 90],
+        },
+      ],
+      { bounds: null }
+    )
+
+    expect(d.untiledLevels[1].xyLimits).toBeUndefined()
+
+    await store.getUntiledLevelMetadata('1')
+
+    expect(d.untiledLevels[1].xyLimits).toEqual({
+      xMin: -180,
+      xMax: 180,
       yMin: -90,
       yMax: 90,
     })

--- a/src/zarr-store.geozarr.test.ts
+++ b/src/zarr-store.geozarr.test.ts
@@ -802,3 +802,95 @@ describe('georeferencing declared on the layout entries', () => {
     })
   })
 })
+
+/**
+ * `proj:` inherits only to a group's direct child arrays, so a pyramid whose
+ * levels are groups may restate it on each level group rather than at the
+ * store root. Both placements are sanctioned by the convention.
+ */
+describe('a declaration on the level group', () => {
+  const levelGroupStore = (
+    rootAttrs: Record<string, unknown>,
+    levelAttrs: Record<string, unknown>
+  ) => {
+    const spec = buildMemoryZarrStore({
+      attributes: { multiscales: { layout: [{ asset: '0' }] }, ...rootAttrs },
+      arrays: [
+        {
+          name: '0/temperature',
+          shape: [4, 8],
+          chunkShape: [4, 8],
+          dimensionNames: ['lat', 'lon'],
+        },
+      ],
+    })
+    // Give the level group its own attributes.
+    const enc = new TextEncoder()
+    const inner = spec.get.bind(spec)
+    return {
+      get: async (key: string) => {
+        if (key === '/0/zarr.json') {
+          return enc.encode(
+            JSON.stringify({
+              zarr_format: 3,
+              node_type: 'group',
+              attributes: levelAttrs,
+            })
+          )
+        }
+        return inner(key)
+      },
+    }
+  }
+
+  const describeLevelGroup = async (
+    rootAttrs: Record<string, unknown>,
+    levelAttrs: Record<string, unknown>
+  ) => {
+    const store = new ZarrStore({
+      customStore: levelGroupStore(rootAttrs, levelAttrs),
+      variable: 'temperature',
+      version: 3,
+      latIsAscending: false,
+    })
+    await store.initialized
+    return store.describe()
+  }
+
+  it('is read when the root declares nothing', async () => {
+    const d = await describeLevelGroup(
+      {},
+      {
+        'proj:code': 'EPSG:32631',
+        'spatial:transform': [45, 0, -180, 0, -45, 90],
+      }
+    )
+
+    expect(d.proj4).toBe('EPSG:32631')
+    expect(d.xyLimits).toEqual(GLOBAL_LIMITS)
+  })
+
+  it('wins over the root, being nearer the array', async () => {
+    const d = await describeLevelGroup(
+      { 'proj:code': 'EPSG:4326', 'spatial:bbox': [-180, -90, 180, 90] },
+      { 'proj:code': 'EPSG:32631' }
+    )
+
+    expect(d.proj4).toBe('EPSG:32631')
+  })
+
+  it('leaves the root in charge of what it does not restate', async () => {
+    const d = await describeLevelGroup(
+      {
+        'proj:code': 'EPSG:4326',
+        'spatial:bbox': [-180, -90, 180, 90],
+        'spatial:registration': 'pixel',
+      },
+      { 'spatial:transform': [45, 0, -180, 0, -45, 90] }
+    )
+
+    expect(d.crs).toBe('EPSG:4326')
+    expect(d.xyLimits).toEqual(GLOBAL_LIMITS)
+    expect(d.latIsAscending).toBe(false)
+  })
+})

--- a/src/zarr-store.test.ts
+++ b/src/zarr-store.test.ts
@@ -223,14 +223,11 @@ describe('ZarrStore multiscale classification', () => {
     //    cement it — see the CRS-resolution test for the tiled default.
   })
 
-  it('classifies a zarr-conventions layout pyramid as untiled with transforms', async () => {
+  it('classifies a zarr-conventions layout pyramid as untiled', async () => {
     const store = new ZarrStore({
       customStore: pyramidStore(
         {
-          layout: [
-            { asset: '0', transform: { scale: [1, 1], translation: [0, 0] } },
-            { asset: '1', transform: { scale: [2, 2], translation: [0, 0] } },
-          ],
+          layout: [{ asset: '0' }, { asset: '1' }],
           crs: 'EPSG:4326',
         },
         ['0', '1']
@@ -246,10 +243,7 @@ describe('ZarrStore multiscale classification', () => {
     expect(d.multiscaleType).toBe('untiled')
     expect(d.levels).toEqual(['0', '1'])
     expect(d.crs).toBe('EPSG:4326')
-    expect(d.untiledLevels).toEqual([
-      { asset: '0', scale: [1, 1], translation: [0, 0] },
-      { asset: '1', scale: [2, 2], translation: [0, 0] },
-    ])
+    expect(d.untiledLevels).toEqual([{ asset: '0' }, { asset: '1' }])
   })
 
   it('resolves the CRS of a tiled OME-NGFF pyramid from the dataset crs field', async () => {

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -506,6 +506,7 @@ export class ZarrStore {
 
     await this._computeDimIndices()
     this._applyDeclaredLevelShapes()
+    this._applyDeclaredLevelExtents()
   }
 
   /**
@@ -531,6 +532,43 @@ export class ZarrStore {
       shape[lat.index] = declared[0]
       shape[lon.index] = declared[1]
       level.shape = shape
+    })
+  }
+
+  /**
+   * Give each level the extent its own `spatial:transform` describes.
+   *
+   * Levels of a pyramid normally share the dataset extent, but floor division
+   * leaves a coarse level covering a partial trailing cell less, and the
+   * convention permits levels to differ outright. Placing a level against the
+   * dataset extent instead of its own stretches it by that difference.
+   */
+  private _applyDeclaredLevelExtents(): void {
+    const attrs = this.geoZarr
+    if (!attrs) return
+
+    this._declaredLevelTransforms.forEach((transform, i) => {
+      const level = this.untiledLevels[i]
+      const shape = this._declaredLevelShapes[i]
+      if (!level || !transform || !shape) return
+
+      const [nRows, nCols] = shape
+      // The level's own transform places it; a dataset-wide bbox describes the
+      // base level and would defeat the point.
+      const extent = boundsFromSpatialAttrs(
+        { ...attrs, transform, bbox: undefined },
+        { nCols, nRows }
+      )
+      if (!extent) return
+
+      const { xMin, xMax, yMin, yMax } = extent
+      level.xyLimits = this.isGeographic()
+        ? {
+            yMin,
+            yMax,
+            ...normalizeLongitudeExtent(xMin, xMax, (xMax - xMin) / nCols),
+          }
+        : { xMin, xMax, yMin, yMax }
     })
   }
 

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -15,6 +15,7 @@ import { WEB_MERCATOR_EXTENT } from './constants'
 import { identifyDimensionIndices, resolveOpenFunc } from './zarr-utils'
 import {
   parseGeoZarrAttrs,
+  parseLayoutItemSpatial,
   boundsFromSpatialAttrs,
   type GeoZarrAttrs,
   type SpatialExtent,
@@ -40,10 +41,6 @@ interface Multiscale {
 // zarr-conventions/multiscales format (untiled multiscales)
 interface UntiledMultiscaleLayoutEntry {
   asset: string
-  transform?: {
-    scale?: [number, number]
-    translation?: [number, number]
-  }
   derived_from?: string
 }
 
@@ -185,6 +182,8 @@ export class ZarrStore {
   private _crsOverride: boolean = false // Track if CRS was explicitly set by user
   private _proj4Override: boolean = false // Track if proj4 was explicitly set by user
   private geoZarr: GeoZarrAttrs | null = null
+  /** Per-level `spatial:shape` as declared, [height, width], before axis mapping. */
+  private _declaredLevelShapes: ([number, number] | undefined)[] = []
 
   store: ZarrStoreType | null = null
   root: zarr.Location<ZarrStoreType> | null = null
@@ -499,6 +498,33 @@ export class ZarrStore {
       typeof arrayAttrs?.add_offset === 'number' ? arrayAttrs.add_offset : 0
 
     await this._computeDimIndices()
+    this._applyDeclaredLevelShapes()
+  }
+
+  /**
+   * Fill in each level's shape from the `spatial:shape` its layout entry
+   * declares, sparing the renderer an array open per level just to size the
+   * pyramid.
+   *
+   * `spatial:shape` is [height, width]; a level's shape follows the array's own
+   * dimension order and carries its non-spatial dimensions too, so the declared
+   * pair is substituted into the base shape rather than used directly.
+   */
+  private _applyDeclaredLevelShapes(): void {
+    if (this._declaredLevelShapes.length === 0 || this.shape.length === 0)
+      return
+
+    const { lat, lon } = this.dimIndices
+    if (!lat || !lon) return
+
+    this._declaredLevelShapes.forEach((declared, i) => {
+      const level = this.untiledLevels[i]
+      if (!declared || !level) return
+      const shape = [...this.shape]
+      shape[lat.index] = declared[0]
+      shape[lon.index] = declared[1]
+      level.shape = shape
+    })
   }
 
   /**
@@ -1073,11 +1099,7 @@ export class ZarrStore {
       // `_loadSpatialMetadata` (global extent, latIsAscending=false, no
       // coordinate-array reads).
       this.multiscaleType = pixelsPerTile ? 'tiled' : 'untiled'
-      this.untiledLevels = levels.map((level) => ({
-        asset: level,
-        scale: [1.0, 1.0] as [number, number],
-        translation: [0.0, 0.0] as [number, number],
-      }))
+      this.untiledLevels = levels.map((level) => ({ asset: level }))
       return { levels, maxLevelIndex, crs }
     }
 
@@ -1089,14 +1111,14 @@ export class ZarrStore {
    *
    * This format uses a `layout` array where each entry specifies:
    * - `asset`: path to the level (e.g., "0", "1", ...)
-   * - `transform`: optional scale/translation for georeferencing
+   * - `spatial:shape`: optional level dimensions as [height, width]
    *
    * Example metadata:
    * ```json
    * {
    *   "layout": [
-   *     { "asset": "0", "transform": { "scale": [1.0, 1.0], "translation": [0, 0] } },
-   *     { "asset": "1", "transform": { "scale": [2.0, 2.0], "translation": [0, 0] } }
+   *     { "asset": "0", "spatial:shape": [1024, 2048] },
+   *     { "asset": "1", "spatial:shape": [512, 1024] }
    *   ],
    *   "crs": "EPSG:4326"
    * }
@@ -1115,12 +1137,11 @@ export class ZarrStore {
     const levels = layout.map((entry) => entry.asset)
     const maxLevelIndex = levels.length - 1
 
-    // Build untiledLevels with transform info (shapes loaded lazily via getUntiledLevelMetadata)
-    this.untiledLevels = layout.map((entry) => ({
-      asset: entry.asset,
-      scale: entry.transform?.scale ?? [1.0, 1.0],
-      translation: entry.transform?.translation ?? [0.0, 0.0],
-    }))
+    this.untiledLevels = layout.map((entry) => ({ asset: entry.asset }))
+    // Applied once the dimension order is known; see `_applyDeclaredLevelShapes`.
+    this._declaredLevelShapes = layout.map(
+      (entry) => parseLayoutItemSpatial(entry).shape
+    )
 
     this.multiscaleType = 'untiled'
 

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -411,6 +411,18 @@ export class ZarrStore {
       }
     }
 
+    // A level may declare its transform without a `spatial:shape`, in which
+    // case its extent can only be worked out once the real shape is known.
+    const index = this.untiledLevels.findIndex((l) => l.asset === levelAsset)
+    const level = this.untiledLevels[index]
+    const { lat, lon } = this.dimIndices
+    if (level && !level.xyLimits && lat && lon) {
+      level.xyLimits = this._deriveLevelExtent(index, [
+        array.shape[lat.index],
+        array.shape[lon.index],
+      ])
+    }
+
     return {
       shape: array.shape,
       chunks: array.chunks,
@@ -544,32 +556,47 @@ export class ZarrStore {
    * dataset extent instead of its own stretches it by that difference.
    */
   private _applyDeclaredLevelExtents(): void {
-    const attrs = this.geoZarr
-    if (!attrs) return
-
-    this._declaredLevelTransforms.forEach((transform, i) => {
-      const level = this.untiledLevels[i]
+    this._declaredLevelTransforms.forEach((_, i) => {
       const shape = this._declaredLevelShapes[i]
-      if (!level || !transform || !shape) return
-
-      const [nRows, nCols] = shape
-      // The level's own transform places it; a dataset-wide bbox describes the
-      // base level and would defeat the point.
-      const extent = boundsFromSpatialAttrs(
-        { ...attrs, transform, bbox: undefined },
-        { nCols, nRows }
-      )
-      if (!extent) return
-
-      const { xMin, xMax, yMin, yMax } = extent
-      level.xyLimits = this.isGeographic()
-        ? {
-            yMin,
-            yMax,
-            ...normalizeLongitudeExtent(xMin, xMax, (xMax - xMin) / nCols),
-          }
-        : { xMin, xMax, yMin, yMax }
+      if (!shape) return
+      const extent = this._deriveLevelExtent(i, shape)
+      if (extent) this.untiledLevels[i].xyLimits = extent
     })
+  }
+
+  /**
+   * The extent level `index` covers, from its own `spatial:transform` and the
+   * given `[rows, cols]`.
+   *
+   * Returns nothing when the caller supplied explicit `bounds`: those override
+   * the store's georeferencing wholesale, and re-deriving a level extent from
+   * the same metadata would quietly reinstate what was overridden.
+   */
+  private _deriveLevelExtent(
+    index: number,
+    shape: [number, number]
+  ): XYLimits | undefined {
+    const attrs = this.geoZarr
+    const transform = this._declaredLevelTransforms[index]
+    if (!attrs || !transform || this.explicitBounds) return undefined
+
+    const [nRows, nCols] = shape
+    // The level's own transform places it; a dataset-wide bbox describes the
+    // base level and would defeat the point.
+    const extent = boundsFromSpatialAttrs(
+      { ...attrs, transform, bbox: undefined },
+      { nCols, nRows }
+    )
+    if (!extent) return undefined
+
+    const { xMin, xMax, yMin, yMax } = extent
+    return this.isGeographic()
+      ? {
+          yMin,
+          yMax,
+          ...normalizeLongitudeExtent(xMin, xMax, (xMax - xMin) / nCols),
+        }
+      : { xMin, xMax, yMin, yMax }
   }
 
   /**

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -619,12 +619,43 @@ export class ZarrStore {
     return true
   }
 
+  /**
+   * The spatial dimension names to identify axes by.
+   *
+   * `spatial:dimensions` names them outright, ordered [y, x], which beats
+   * guessing from an alias list and is the only thing that works for a store
+   * whose axes are named something the alias list has never heard of. The
+   * constructor option still wins per axis.
+   */
+  private _resolveSpatialDimensions(): SpatialDimensions {
+    const declared = this.geoZarr?.dimensions
+    if (!declared) return this.spatialDimensions
+
+    const known = this.dimensions.map((d) => d.toLowerCase())
+    const missing = declared.filter((n) => !known.includes(n.toLowerCase()))
+    if (missing.length > 0) {
+      throw new Error(
+        `spatial:dimensions names [${missing.join(
+          ', '
+        )}], which the array does not have. Available: [${this.dimensions.join(
+          ', '
+        )}]`
+      )
+    }
+
+    const [lat, lon] = declared
+    return {
+      lat: this.spatialDimensions.lat ?? lat,
+      lon: this.spatialDimensions.lon ?? lon,
+    }
+  }
+
   private async _computeDimIndices() {
     if (this.dimensions.length === 0) return
 
     this.dimIndices = identifyDimensionIndices(
       this.dimensions,
-      this.spatialDimensions
+      this._resolveSpatialDimensions()
     )
 
     // Collect the actual names of identified spatial dimensions

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -673,9 +673,11 @@ export class ZarrStore {
    * Resolve the CRS the store declares through the `proj:` convention, falling
    * back to the CF grid-mapping variable when it declares none.
    *
-   * A `proj:code` naming one of the two built-in CRSs is honored first: those
-   * render through a native path that needs no proj4 transformer, and a store
-   * naming one has already said everything we need. WKT2 and PROJJSON come
+   * A `proj:code` naming one of the two built-in CRSs is honored first: it
+   * keeps `crs` set rather than `proj4`, which is what the geographic
+   * behaviors -- longitude folding, antimeridian query splitting, pole
+   * rendering -- key off, and it needs no synthetic registration for a CRS
+   * proj4 already knows. WKT2 and PROJJSON come
    * next, since they describe the CRS in full and proj4 parses both without a
    * lookup table. Only then does an unfamiliar code get looked up against
    * proj4's built-in definitions.

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -229,15 +229,26 @@ export class ZarrStore {
     this.proj4 = proj4 ?? null
     this._proj4Override = !!proj4
     if (crs) {
-      const normalized = crs.toUpperCase()
-      if (normalized === 'EPSG:4326' || normalized === 'EPSG:3857') {
-        this.crs = normalized
+      const builtin =
+        crs.trim().toUpperCase() === CRS84
+          ? 'EPSG:4326'
+          : normalizeBuiltinProjectionDef(crs)
+      if (builtin) {
+        this.crs = builtin
         this._crsOverride = true
       } else if (!this.proj4) {
-        console.warn(
-          `[zarr-layer] CRS "${crs}" requires 'proj4' to render correctly. ` +
-            `Falling back to inferred CRS.`
-        )
+        const registered = this._registeredProjectionCode(crs)
+        if (registered) {
+          this.proj4 = registered
+          this._crsOverride = true
+        } else {
+          console.warn(
+            `[zarr-layer] CRS "${crs}" is not one proj4 has a definition ` +
+              `for. Pass 'proj4', or register the code first with ` +
+              `proj4.defs('${crs}', '<proj4 string>'). Falling back to ` +
+              `inferred CRS.`
+          )
+        }
       }
     }
     this.transformRequest = transformRequest
@@ -648,6 +659,17 @@ export class ZarrStore {
   }
 
   /**
+   * A code proj4 can already transform under: one of its built-in definitions
+   * (all UTM zones among them) or one registered with `proj4.defs` before the
+   * layer was created. The registry is keyed on the canonical uppercase form,
+   * so "epsg:32631" needs normalizing to be found.
+   */
+  private _registeredProjectionCode(code: string): string | null {
+    const key = proj4.defs(code) ? code : code.trim().toUpperCase()
+    return proj4.defs(key) ? key : null
+  }
+
+  /**
    * Resolve the CRS the store declares through the `proj:` convention, falling
    * back to the CF grid-mapping variable when it declares none.
    *
@@ -695,10 +717,8 @@ export class ZarrStore {
 
     if (code) {
       this._crsFromMetadata = true
-      // proj4's registry is keyed on the canonical uppercase form, so a store
-      // writing "epsg:32631" needs normalizing to find it.
-      const registered = proj4.defs(code) ? code : code.toUpperCase()
-      if (proj4.defs(registered)) {
+      const registered = this._registeredProjectionCode(code)
+      if (registered) {
         this.proj4 = registered
         return
       }

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -484,7 +484,11 @@ export class ZarrStore {
     const array = await this._getArray(basePath)
     const arrayAttrs = array.attrs as Record<string, unknown>
 
-    this.geoZarr = parseGeoZarrAttrs(rootAttrs, arrayAttrs)
+    this.geoZarr = parseGeoZarrAttrs(
+      rootAttrs,
+      await this._readBaseLevelGroupAttrs(),
+      arrayAttrs
+    )
     await this._applyGeoZarrCrs(arrayAttrs)
 
     // zarrita's dimensionNames returns the unified answer for v2
@@ -528,6 +532,30 @@ export class ZarrStore {
       shape[lon.index] = declared[1]
       level.shape = shape
     })
+  }
+
+  /**
+   * Attributes of the group holding the base level's arrays.
+   *
+   * `proj:` inherits only to a group's direct child arrays, so a pyramid whose
+   * levels are groups may restate it on each of them instead of at the root.
+   * That group sits between the two we already read, and is one metadata
+   * lookup -- served from cache on a consolidated store, and never per level.
+   */
+  private async _readBaseLevelGroupAttrs(): Promise<
+    Record<string, unknown> | undefined
+  > {
+    if (this.levels.length === 0 || !this.root) return undefined
+    try {
+      const openFunc = resolveOpenFunc(this.version)
+      const group = await openFunc(this.root.resolve(this.levels[0]), {
+        kind: 'group',
+      })
+      return group.attrs as Record<string, unknown>
+    } catch {
+      // A level that isn't a group at all just contributes nothing.
+      return undefined
+    }
   }
 
   /**

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -578,8 +578,11 @@ export class ZarrStore {
 
     if (code) {
       this._crsFromMetadata = true
-      if (proj4.defs(code)) {
-        this.proj4 = code
+      // proj4's registry is keyed on the canonical uppercase form, so a store
+      // writing "epsg:32631" needs normalizing to find it.
+      const registered = proj4.defs(code) ? code : code.toUpperCase()
+      if (proj4.defs(registered)) {
+        this.proj4 = registered
         return
       }
       console.warn(
@@ -660,8 +663,18 @@ export class ZarrStore {
     const declared = this.geoZarr?.dimensions
     if (!declared) return this.spatialDimensions
 
+    const [declaredLat, declaredLon] = declared
+    const lat = this.spatialDimensions.lat ?? declaredLat
+    const lon = this.spatialDimensions.lon ?? declaredLon
+
+    // Only the declarations actually being used are worth rejecting. An axis
+    // the caller overrode is repaired already, and a bad override is the
+    // caller's own error, which `identifyDimensionIndices` reports.
     const known = this.dimensions.map((d) => d.toLowerCase())
-    const missing = declared.filter((n) => !known.includes(n.toLowerCase()))
+    const missing = [
+      this.spatialDimensions.lat ? null : declaredLat,
+      this.spatialDimensions.lon ? null : declaredLon,
+    ].filter((n): n is string => !!n && !known.includes(n.toLowerCase()))
     if (missing.length > 0) {
       throw new Error(
         `spatial:dimensions names [${missing.join(
@@ -672,11 +685,7 @@ export class ZarrStore {
       )
     }
 
-    const [lat, lon] = declared
-    return {
-      lat: this.spatialDimensions.lat ?? lat,
-      lon: this.spatialDimensions.lon ?? lon,
-    }
+    return { lat, lon }
   }
 
   private async _computeDimIndices() {
@@ -811,8 +820,9 @@ export class ZarrStore {
     })
     if (!extent) {
       console.warn(
-        `[zarr-layer] Could not derive bounds from the store's spatial: attributes ` +
-          `(a rotated transform needs a spatial:bbox alongside it). ` +
+        `[zarr-layer] Could not derive bounds from the store's spatial: attributes. ` +
+          `A rotated transform has no axis-aligned placement this layer can render, ` +
+          `and a node-registered bbox needs a cell size to expand by. ` +
           `Reading bounds from coordinate arrays.`
       )
       return null

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -764,19 +764,23 @@ export class ZarrStore {
   /**
    * The declaration to place the grid from.
    *
-   * The array's own attributes come first. Failing those, the base level's
-   * `multiscales.layout` entry: a multiscale store's absolute georeferencing
-   * belongs on the layout entries, one per resolution, so that is where a
-   * pyramid declares where it sits. Its grid size comes from the base array
-   * either way, which is the level that entry describes.
+   * A pyramid's absolute georeferencing belongs on its `multiscales.layout`
+   * entries, one per resolution, so the base entry's transform stands in
+   * whenever the group or array declares none of its own. The two sources
+   * combine rather than compete: a group that states only a `spatial:bbox`
+   * still gets its row direction from that transform, which is the difference
+   * between placing the grid outright and falling back to coordinate reads.
+   *
+   * The grid size comes from the base array either way, which is the level
+   * that entry describes.
    */
   private _effectiveSpatialAttrs(): GeoZarrAttrs | null {
     const attrs = this.geoZarr
     if (!attrs) return null
-    if (attrs.bbox || attrs.transform) return attrs
 
-    const baseTransform = this._declaredLevelTransforms[0]
-    return baseTransform ? { ...attrs, transform: baseTransform } : null
+    const transform = attrs.transform ?? this._declaredLevelTransforms[0]
+    if (!attrs.bbox && !transform) return null
+    return transform === attrs.transform ? attrs : { ...attrs, transform }
   }
 
   /**

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -10,7 +10,7 @@ import type {
   UntiledLevel,
   TransformRequest,
 } from './types'
-import type { XYLimits } from './map-utils'
+import { normalizeLongitudeExtent, type XYLimits } from './map-utils'
 import { WEB_MERCATOR_EXTENT } from './constants'
 import { identifyDimensionIndices, resolveOpenFunc } from './zarr-utils'
 import { parseGeoZarrAttrs, type GeoZarrAttrs } from './geozarr'
@@ -651,6 +651,11 @@ export class ZarrStore {
     }
   }
 
+  /** Whether x/y are longitude/latitude in degrees rather than projected units. */
+  private isGeographic(): boolean {
+    return !this.proj4 && this.crs !== 'EPSG:3857'
+  }
+
   private normalizeFillValue(value: unknown): number | null {
     if (value === undefined || value === null) return null
     if (typeof value === 'string') {
@@ -846,34 +851,14 @@ export class ZarrStore {
       const dy = Math.abs(y1 - y0)
 
       // Apply half-pixel expansion (coords are pixel centers, we need edge bounds)
-      let xMin = coordXMin - (Number.isFinite(dx) ? dx / 2 : 0)
-      let xMax = coordXMax + (Number.isFinite(dx) ? dx / 2 : 0)
+      const rawXMin = coordXMin - (Number.isFinite(dx) ? dx / 2 : 0)
+      const rawXMax = coordXMax + (Number.isFinite(dx) ? dx / 2 : 0)
       const yMin = coordYMin - (Number.isFinite(dy) ? dy / 2 : 0)
       const yMax = coordYMax + (Number.isFinite(dy) ? dy / 2 : 0)
 
-      // Normalize 0–360° longitude convention to -180–180°.
-      // Only applies when both bounds are > 180 (clearly 0–360° data, not
-      // projected meters) and within the degree range (xMax <= 360).
-      if (
-        xMin > 180 &&
-        xMax > 180 &&
-        xMax <= 360 &&
-        !this.proj4 &&
-        this.crs !== 'EPSG:3857'
-      ) {
-        xMin -= 360
-        xMax -= 360
-      }
-
-      // For global datasets, snap bounds to exactly ±180 to avoid antimeridian
-      // seams caused by grid alignment not landing on ±180. A truly global grid
-      // has extent = N * dx = 360°; use dx/2 tolerance for float32 precision.
-      // A dataset one cell short has extent = 360 - dx, which fails the check.
-      const lonExtent = xMax - xMin
-      if (Number.isFinite(dx) && Math.abs(lonExtent - 360) < dx / 2) {
-        if (Math.abs(xMin + 180) < dx) xMin = -180
-        if (Math.abs(xMax - 180) < dx) xMax = 180
-      }
+      const { xMin, xMax } = this.isGeographic()
+        ? normalizeLongitudeExtent(rawXMin, rawXMax, dx)
+        : { xMin: rawXMin, xMax: rawXMax }
 
       if (needsBounds) {
         this.xyLimits = { xMin, xMax, yMin, yMax }

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -17,6 +17,7 @@ import {
   parseGeoZarrAttrs,
   parseLayoutItemSpatial,
   boundsFromSpatialAttrs,
+  type AffineTransform,
   type GeoZarrAttrs,
   type SpatialExtent,
 } from './geozarr'
@@ -184,6 +185,8 @@ export class ZarrStore {
   private geoZarr: GeoZarrAttrs | null = null
   /** Per-level `spatial:shape` as declared, [height, width], before axis mapping. */
   private _declaredLevelShapes: ([number, number] | undefined)[] = []
+  /** Per-level `spatial:transform` as declared, indexed alongside the levels. */
+  private _declaredLevelTransforms: (AffineTransform | undefined)[] = []
 
   store: ZarrStoreType | null = null
   root: zarr.Location<ZarrStoreType> | null = null
@@ -759,6 +762,24 @@ export class ZarrStore {
   }
 
   /**
+   * The declaration to place the grid from.
+   *
+   * The array's own attributes come first. Failing those, the base level's
+   * `multiscales.layout` entry: a multiscale store's absolute georeferencing
+   * belongs on the layout entries, one per resolution, so that is where a
+   * pyramid declares where it sits. Its grid size comes from the base array
+   * either way, which is the level that entry describes.
+   */
+  private _effectiveSpatialAttrs(): GeoZarrAttrs | null {
+    const attrs = this.geoZarr
+    if (!attrs) return null
+    if (attrs.bbox || attrs.transform) return attrs
+
+    const baseTransform = this._declaredLevelTransforms[0]
+    return baseTransform ? { ...attrs, transform: baseTransform } : null
+  }
+
+  /**
    * The grid extent the store declares through the `spatial:` convention, in
    * the renderer's edge-to-edge terms and its -180–180 longitude range.
    *
@@ -766,8 +787,8 @@ export class ZarrStore {
    * the coordinate-array read as the fallback.
    */
   private _declaredSpatialExtent(): SpatialExtent | null {
-    const attrs = this.geoZarr
-    if (!attrs || (!attrs.bbox && !attrs.transform)) return null
+    const attrs = this._effectiveSpatialAttrs()
+    if (!attrs) return null
 
     if (attrs.transformType !== 'affine') {
       console.warn(
@@ -1138,10 +1159,10 @@ export class ZarrStore {
     const maxLevelIndex = levels.length - 1
 
     this.untiledLevels = layout.map((entry) => ({ asset: entry.asset }))
+    const perLevel = layout.map((entry) => parseLayoutItemSpatial(entry))
     // Applied once the dimension order is known; see `_applyDeclaredLevelShapes`.
-    this._declaredLevelShapes = layout.map(
-      (entry) => parseLayoutItemSpatial(entry).shape
-    )
+    this._declaredLevelShapes = perLevel.map((s) => s.shape)
+    this._declaredLevelTransforms = perLevel.map((s) => s.transform)
 
     this.multiscaleType = 'untiled'
 

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -301,6 +301,9 @@ export class ZarrStore {
     await this._loadMetadata()
 
     await this._loadSpatialMetadata()
+    // After spatial metadata, so a level whose declared row direction
+    // contradicts the dataset's resolved one can be recognized and declined.
+    this._applyDeclaredLevelExtents()
     await this._loadCoordinates()
 
     return this
@@ -518,7 +521,6 @@ export class ZarrStore {
 
     await this._computeDimIndices()
     this._applyDeclaredLevelShapes()
-    this._applyDeclaredLevelExtents()
   }
 
   /**
@@ -570,7 +572,10 @@ export class ZarrStore {
    *
    * Returns nothing when the caller supplied explicit `bounds`: those override
    * the store's georeferencing wholesale, and re-deriving a level extent from
-   * the same metadata would quietly reinstate what was overridden.
+   * the same metadata would quietly reinstate what was overridden. Also
+   * declines a transform whose row direction contradicts the store's own
+   * declared one, since the renderer draws every level in a single row
+   * direction and cannot honor what that transform declares.
    */
   private _deriveLevelExtent(
     index: number,
@@ -588,6 +593,25 @@ export class ZarrStore {
       { nCols, nRows }
     )
     if (!extent) return undefined
+
+    // Consistency is measured against the store's own declared direction, not
+    // the renderer's: a caller's `latIsAscending` override changes how rows
+    // are drawn, not what the store's transforms declare about placement.
+    const base = this._effectiveSpatialAttrs()?.transform
+    const baseAscending = base ? base[4] > 0 : this.latIsAscending
+    if (
+      extent.latIsAscending !== null &&
+      extent.latIsAscending !== baseAscending
+    ) {
+      console.warn(
+        `[zarr-layer] Level '${
+          this.untiledLevels[index]?.asset ?? index
+        }' declares a spatial:transform whose row direction contradicts the ` +
+          `rest of the store's. Every level renders in one row direction, so ` +
+          `this one may appear flipped; its declared extent is ignored.`
+      )
+      return undefined
+    }
 
     const { xMin, xMax, yMin, yMax } = extent
     return this.isGeographic()

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -1,4 +1,5 @@
 import * as zarr from 'zarrita'
+import proj4 from 'proj4'
 import { withDecodedChunkCaching } from './decoded-chunk-cache'
 import type { Readable, AsyncReadable } from '@zarrita/storage'
 import type {
@@ -12,6 +13,8 @@ import type {
 import type { XYLimits } from './map-utils'
 import { WEB_MERCATOR_EXTENT } from './constants'
 import { identifyDimensionIndices, resolveOpenFunc } from './zarr-utils'
+import { parseGeoZarrAttrs, type GeoZarrAttrs } from './geozarr'
+import { normalizeBuiltinProjectionDef } from './projection-utils'
 
 interface PyramidMetadata {
   levels: string[]
@@ -44,6 +47,18 @@ interface UntiledMultiscaleMetadata {
   resampling_method?: string
   crs?: 'EPSG:4326' | 'EPSG:3857'
 }
+
+/**
+ * `proj4.defs` is a module-global registry, so a definition read out of one
+ * store's metadata needs a key no other layer on the page will reuse.
+ */
+let syntheticProjectionCount = 0
+
+/**
+ * A `proj:code` naming WGS84 lon/lat under its OGC identity. Same axis order
+ * as the renderer already assumes, so it maps straight onto the native path.
+ */
+const CRS84 = 'OGC:CRS84'
 
 type ZarrStoreType =
   | zarr.FetchStore
@@ -163,6 +178,8 @@ export class ZarrStore {
   proj4: string | null = null
   private _crsFromMetadata: boolean = false // Track if CRS was explicitly set from metadata
   private _crsOverride: boolean = false // Track if CRS was explicitly set by user
+  private _proj4Override: boolean = false // Track if proj4 was explicitly set by user
+  private geoZarr: GeoZarrAttrs | null = null
 
   store: ZarrStoreType | null = null
   root: zarr.Location<ZarrStoreType> | null = null
@@ -203,6 +220,7 @@ export class ZarrStore {
       this._latIsAscendingUserSet = true
     }
     this.proj4 = proj4 ?? null
+    this._proj4Override = !!proj4
     if (crs) {
       const normalized = crs.toUpperCase()
       if (normalized === 'EPSG:4326' || normalized === 'EPSG:3857') {
@@ -459,6 +477,9 @@ export class ZarrStore {
     const array = await this._getArray(basePath)
     const arrayAttrs = array.attrs as Record<string, unknown>
 
+    this.geoZarr = parseGeoZarrAttrs(rootAttrs, arrayAttrs)
+    await this._applyGeoZarrCrs(arrayAttrs)
+
     // zarrita's dimensionNames returns the unified answer for v2
     // (_ARRAY_DIMENSIONS) and v3 (dimension_names).
     this.dimensions = array.dimensionNames ?? []
@@ -473,6 +494,124 @@ export class ZarrStore {
       typeof arrayAttrs?.add_offset === 'number' ? arrayAttrs.add_offset : 0
 
     await this._computeDimIndices()
+  }
+
+  /**
+   * Resolve the CRS the store declares through the `proj:` convention, falling
+   * back to the CF grid-mapping variable when it declares none.
+   *
+   * A `proj:code` naming one of the two built-in CRSs is honored first: those
+   * render through a native path that needs no proj4 transformer, and a store
+   * naming one has already said everything we need. WKT2 and PROJJSON come
+   * next, since they describe the CRS in full and proj4 parses both without a
+   * lookup table. Only then does an unfamiliar code get looked up against
+   * proj4's built-in definitions.
+   *
+   * A declared CRS that stays unresolved is left alone rather than guessed at
+   * from bounds. Inferring a different CRS would silently contradict what the
+   * store said; rendering visibly wrong is the honest outcome, and
+   * `proj4.defs()` is the caller's remedy.
+   */
+  private async _applyGeoZarrCrs(
+    arrayAttrs: Record<string, unknown>
+  ): Promise<void> {
+    if (this._crsOverride || this._proj4Override) return
+
+    const declared = this.geoZarr?.crs
+    const code = declared?.code
+    const builtin =
+      code?.trim().toUpperCase() === CRS84
+        ? 'EPSG:4326'
+        : normalizeBuiltinProjectionDef(code)
+    if (builtin) {
+      this.crs = builtin
+      this._crsFromMetadata = true
+      return
+    }
+
+    if (
+      declared?.wkt2 &&
+      this._registerProjection(declared.wkt2, 'proj:wkt2')
+    ) {
+      return
+    }
+    if (
+      declared?.projjson &&
+      this._registerProjection(declared.projjson, 'proj:projjson')
+    ) {
+      return
+    }
+
+    if (code) {
+      this._crsFromMetadata = true
+      if (proj4.defs(code)) {
+        this.proj4 = code
+        return
+      }
+      console.warn(
+        `[zarr-layer] Store declares proj:code "${code}", which proj4 does not ` +
+          `know and which the store gives no proj:wkt2 or proj:projjson for. ` +
+          `Register it before creating the layer with ` +
+          `proj4.defs('${code}', '<proj4 string>') to render it correctly.`
+      )
+      return
+    }
+
+    await this._applyCfGridMappingCrs(arrayAttrs)
+  }
+
+  /**
+   * Read a WKT definition off the CF grid-mapping variable the data array
+   * points at. rioxarray writes the same WKT under both `crs_wkt` and
+   * `spatial_ref`.
+   */
+  private async _applyCfGridMappingCrs(
+    arrayAttrs: Record<string, unknown>
+  ): Promise<void> {
+    const gridMapping = arrayAttrs?.grid_mapping
+    if (typeof gridMapping !== 'string' || !gridMapping.trim()) return
+
+    const prefix = this.levels.length > 0 ? `${this.levels[0]}/` : ''
+    try {
+      const mapping = await this._getArray(`${prefix}${gridMapping.trim()}`)
+      const attrs = mapping.attrs as Record<string, unknown>
+      const wkt = [attrs?.crs_wkt, attrs?.spatial_ref].find(
+        (value): value is string =>
+          typeof value === 'string' && value.trim().length > 0
+      )
+      if (wkt) this._registerProjection(wkt, `${gridMapping}.crs_wkt`)
+    } catch (err) {
+      console.warn(
+        `[zarr-layer] Could not read grid mapping variable '${gridMapping}': `,
+        err
+      )
+    }
+  }
+
+  /**
+   * Register a full CRS definition under a key of our own and point the store
+   * at it. proj4 parses WKT2 strings and PROJJSON objects directly, so a store
+   * carrying either is self-describing with no lookup table.
+   */
+  private _registerProjection(
+    def: string | Record<string, unknown>,
+    source: string
+  ): boolean {
+    const key = `ZARRLAYER:${++syntheticProjectionCount}`
+    try {
+      proj4.defs(key, def as string)
+      if (!proj4.defs(key)) throw new Error('definition did not parse')
+      proj4(key, 'EPSG:4326')
+    } catch (err) {
+      console.warn(
+        `[zarr-layer] Could not use '${source}' from store metadata: ` +
+          `${err instanceof Error ? err.message : err}`
+      )
+      return false
+    }
+    this.proj4 = key
+    this._crsFromMetadata = true
+    return true
   }
 
   private async _computeDimIndices() {

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -13,7 +13,12 @@ import type {
 import { normalizeLongitudeExtent, type XYLimits } from './map-utils'
 import { WEB_MERCATOR_EXTENT } from './constants'
 import { identifyDimensionIndices, resolveOpenFunc } from './zarr-utils'
-import { parseGeoZarrAttrs, type GeoZarrAttrs } from './geozarr'
+import {
+  parseGeoZarrAttrs,
+  boundsFromSpatialAttrs,
+  type GeoZarrAttrs,
+  type SpatialExtent,
+} from './geozarr'
 import { normalizeBuiltinProjectionDef } from './projection-utils'
 
 interface PyramidMetadata {
@@ -696,6 +701,50 @@ export class ZarrStore {
     }
   }
 
+  /**
+   * The grid extent the store declares through the `spatial:` convention, in
+   * the renderer's edge-to-edge terms and its -180–180 longitude range.
+   *
+   * Returns null whenever the declaration doesn't settle the extent, leaving
+   * the coordinate-array read as the fallback.
+   */
+  private _declaredSpatialExtent(): SpatialExtent | null {
+    const attrs = this.geoZarr
+    if (!attrs || (!attrs.bbox && !attrs.transform)) return null
+
+    if (attrs.transformType !== 'affine') {
+      console.warn(
+        `[zarr-layer] Store declares spatial:transform_type "${attrs.transformType}", ` +
+          `which this layer cannot map to a grid. Reading bounds from coordinate arrays.`
+      )
+      return null
+    }
+
+    const { lon, lat } = this.dimIndices
+    if (!lon || !lat) return null
+
+    const extent = boundsFromSpatialAttrs(attrs, {
+      nCols: this.shape[lon.index],
+      nRows: this.shape[lat.index],
+    })
+    if (!extent) {
+      console.warn(
+        `[zarr-layer] Could not derive bounds from the store's spatial: attributes ` +
+          `(a rotated transform needs a spatial:bbox alongside it). ` +
+          `Reading bounds from coordinate arrays.`
+      )
+      return null
+    }
+
+    if (!this.isGeographic()) return extent
+
+    const cellWidth = (extent.xMax - extent.xMin) / this.shape[lon.index]
+    return {
+      ...extent,
+      ...normalizeLongitudeExtent(extent.xMin, extent.xMax, cellWidth),
+    }
+  }
+
   private async _loadSpatialMetadata() {
     // Apply explicit bounds first (takes precedence for all multiscale types)
     // Bounds are in source CRS units (degrees for EPSG:4326, meters for EPSG:3857/proj4)
@@ -726,8 +775,29 @@ export class ZarrStore {
     }
 
     // For untiled: determine what we still need to detect
-    const needsBounds = !this.xyLimits
-    const needsLatAscending = !this._latIsAscendingUserSet
+    let needsBounds = !this.xyLimits
+    let needsLatAscending = !this._latIsAscendingUserSet
+
+    // A store declaring the spatial: convention has already said where its grid
+    // sits, so take it at its word and skip the coordinate reads.
+    if (needsBounds || needsLatAscending) {
+      const declared = this._declaredSpatialExtent()
+      if (declared) {
+        if (needsBounds) {
+          this.xyLimits = {
+            xMin: declared.xMin,
+            xMax: declared.xMax,
+            yMin: declared.yMin,
+            yMax: declared.yMax,
+          }
+          needsBounds = false
+        }
+        if (needsLatAscending && declared.latIsAscending !== null) {
+          this.latIsAscending = declared.latIsAscending
+          needsLatAscending = false
+        }
+      }
+    }
 
     // If explicit bounds provided and user doesn't need latIsAscending detection, skip coord fetch
     // (respects user intent to avoid coord reads by providing bounds)


### PR DESCRIPTION
This improves our handling of geozarr metadata which will improve performance by reducing coordinate lookups on load. It'll also just make setting up new layers in varying crs much simpler since many more will just render off the bat now without specifying/looking up any magic strings.

It reads:

- `proj:code` resolves natively for EPSG:4326/3857/OGC:CRS84, or through proj4's built-in definitions (all UTM zones among them). `proj:wkt2` and `proj:projjson` are parsed by proj4 directly, so full CRS descriptions need no lookup table and no new dependencies. A CF `grid_mapping` variable's `crs_wkt` is read when no `proj:` attribute is present.
- `spatial:transform` and `spatial:bbox` settle the extent and row direction, with `spatial:registration` (pixel/node) deciding whether declared coordinates sit on cell edges or centers. `spatial:dimensions` names the y/x axes outright, ahead of the alias heuristic.
- Per-level `spatial:shape` and `spatial:transform` on `multiscales.layout` entries size and place each pyramid level, so levels are no longer opened at init just to read their shape, and a floor-divided level renders against its own extent instead of being stretched to the dataset's. The dead `UntiledLevel.scale`/`translation` fields are removed.

Stores without these attributes behave exactly as before (coordinate reads, dimension name aliases, bounds inference), so nothing changes for existing data. One deliberate behavior choice worth flagging: declared attributes are taken as authoritative rather than cross-checked against coordinate arrays, so a store whose metadata disagrees with its own data will now render wrong (with a console warning naming the cause) instead of being silently corrected. User options (`crs`, `proj4`, `bounds`, `latIsAscending`, `spatialDimensions`) still win over anything the store declares.

The `crs` option also resolves through the same proj4 built-ins and registry now, so `crs: 'EPSG:32610'` alone works where a proj4 string used to be required, and pre-registering with `proj4.defs` covers anything else. Between that and the `crs_wkt` passthrough this should absorb most of #61's goals without pulling in the more comprehensive devseed dep. Leaving that potential addition for later since it'll be a bit of a bundle increase, and what's left is only stores/consumers holding a bare code proj4 doesn't ship with no WKT anywhere. Curious whether that actually comes up in practice.

This supersedes #42 (sorry for the delay there). The approach there held up well and this covers the same ground. I've credited @wietzesuijker as coauthor on the commits carrying that logic! Thanks for your work!!
