### PR TITLE
Add onAuthError option for credential-expiry detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ map.on('load', () => {
 | uniforms | object | - | Shader uniform values (requires `customFrag`) |
 | onLoadingStateChange | function | - | Loading state callback |
 | transformRequest | function | - | Transform request URLs and add headers/credentials (see [authentication](#authentication)) |
+| onAuthError | function | - | Called with the HTTP status when a signed request fails with expired credentials (see [authentication](#authentication)) |
 | renderPoles | boolean | `false` | Enable polar coverage in Mapbox globe for EPSG:4326/proj4 datasets (see [globe rendering](#globe-rendering-and-polar-coverage)). No effect on EPSG:3857 data. MapLibre always renders to the poles. |
 
 ## methods
@@ -334,6 +335,20 @@ transformRequest: async (url) => ({
   url: await getPresignedUrl(url),
 })
 ```
+
+### expired credentials
+
+Credentials signed into a request expire mid-session. Those failures are otherwise invisible, because the layer treats a rejected read as a missing chunk and renders a hole. `onAuthError` surfaces the status so you can refresh and re-add the layer:
+
+```ts
+onAuthError: async (status) => {
+  await refreshCredentials()
+  map.removeLayer(layer.id)
+  map.addLayer(newLayerWithFreshCredentials())
+}
+```
+
+It fires on 400 and 401 only, and at most once per store, so a burst of concurrent chunk failures triggers a single refresh. 400 is included because expired temporary AWS credentials return `ExpiredToken`/`InvalidToken` as a 400, often with no readable body on HEAD probes or CORS-gated responses. 403 is excluded: S3 and CloudFront return it for genuinely absent chunks, which sparse pyramids hit routinely. Without a handler, a 400 propagates as an error rather than being read as a missing chunk.
 
 ## custom stores
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export type {
   LoadingStateCallback,
   Selector,
   TransformRequest,
+  OnAuthError,
   RequestParameters,
 } from './types'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,13 @@ export type TransformRequest = (
   options?: TransformRequestOptions
 ) => RequestParameters | Promise<RequestParameters>
 
+/**
+ * Called when a `transformRequest` request fails with a credential-shaped
+ * status, so the consumer can refresh credentials and re-add the layer.
+ * Expired temporary AWS credentials return 400, not 401, so both count.
+ */
+export type OnAuthError = (status: number) => void
+
 export type ColormapArray = number[][] | string[]
 
 export type SelectorValue = number | number[] | string | string[]
@@ -130,6 +137,8 @@ export interface ZarrLayerOptions {
    * When provided, the store cache is bypassed to prevent credential sharing between layers.
    */
   transformRequest?: TransformRequest
+  /** Credential-expiry hook for `transformRequest`. See {@link OnAuthError}. */
+  onAuthError?: OnAuthError
   /**
    * Enable full polar coverage in Mapbox globe view for untiled EPSG:4326 or
    * proj4 datasets. Has no effect on tiled or EPSG:3857 data.

--- a/src/zarr-layer.ts
+++ b/src/zarr-layer.ts
@@ -29,6 +29,7 @@ import type {
   NormalizedSelector,
   ZarrLayerOptions,
   TransformRequest,
+  OnAuthError,
 } from './types'
 import type { RenderContext } from './renderer-types'
 import { RegionRenderer } from './region-renderer'
@@ -182,6 +183,7 @@ export class ZarrLayer {
   private initError: Error | null = null
   private proj4: string | undefined
   private transformRequest: TransformRequest | undefined
+  private onAuthError: OnAuthError | undefined
   private customStore: Readable | undefined
   private renderPoles: boolean
   private lastIsGlobe: boolean | null = null
@@ -297,6 +299,7 @@ export class ZarrLayer {
     onLoadingStateChange,
     proj4,
     transformRequest,
+    onAuthError,
     store,
     renderPoles = false,
   }: ZarrLayerOptions) {
@@ -356,6 +359,7 @@ export class ZarrLayer {
     this.onLoadingStateChange = onLoadingStateChange
     this.proj4 = proj4
     this.transformRequest = transformRequest
+    this.onAuthError = onAuthError
     this.customStore = store
     this.renderPoles = renderPoles
   }
@@ -630,6 +634,7 @@ export class ZarrLayer {
         coordinateKeys: Object.keys(this.selector),
         proj4: this.proj4,
         transformRequest: this.transformRequest,
+        onAuthError: this.onAuthError,
         customStore: this.customStore,
       })
 

--- a/src/zarr-store-auth.test.ts
+++ b/src/zarr-store-auth.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { ZarrStore } from './zarr-store'
+
+/**
+ * `createFetchStore` is internal, so these drive it through a real `ZarrStore`
+ * over a stubbed `fetch`. Initialization always fails (nothing resolves), so
+ * every case awaits `initialized` under a catch.
+ */
+
+const SOURCE = 'https://example.com/store.zarr'
+
+async function readThrough({
+  status,
+  onAuthError,
+  transformRequest = (url: string) => ({ url }),
+}: {
+  status: number
+  onAuthError?: (status: number) => void
+  transformRequest?: (url: string) => { url: string }
+}) {
+  const fetchStub = vi.fn(async () => new Response(null, { status }))
+  vi.stubGlobal('fetch', fetchStub)
+
+  const store = new ZarrStore({
+    source: SOURCE,
+    variable: 'temperature',
+    transformRequest,
+    onAuthError,
+  })
+  await store.initialized.catch(() => {})
+
+  return { calls: fetchStub.mock.calls.length }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('onAuthError', () => {
+  it('fires once for a burst of credential-shaped failures', async () => {
+    const onAuthError = vi.fn()
+    const { calls } = await readThrough({ status: 401, onAuthError })
+
+    expect(calls).toBeGreaterThan(1)
+    expect(onAuthError).toHaveBeenCalledTimes(1)
+    expect(onAuthError).toHaveBeenCalledWith(401)
+  })
+
+  it('fires for 400, which is what expired temporary credentials return', async () => {
+    const onAuthError = vi.fn()
+    await readThrough({ status: 400, onAuthError })
+
+    expect(onAuthError).toHaveBeenCalledWith(400)
+  })
+
+  it('ignores statuses that are not credential-shaped', async () => {
+    const onAuthError = vi.fn()
+    await readThrough({ status: 403, onAuthError })
+    await readThrough({ status: 404, onAuthError })
+    await readThrough({ status: 500, onAuthError })
+
+    expect(onAuthError).not.toHaveBeenCalled()
+  })
+
+  it('leaves 400 unmasked when no handler is set', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 400 }))
+    )
+
+    const store = new ZarrStore({
+      source: SOURCE,
+      variable: 'temperature',
+      transformRequest: (url: string) => ({ url }),
+    })
+    const err = await store.initialized.then(
+      () => null,
+      (e: Error) => e
+    )
+
+    expect(err?.message).toMatch(/400/)
+  })
+})

--- a/src/zarr-store.ts
+++ b/src/zarr-store.ts
@@ -9,6 +9,7 @@ import type {
   CRS,
   UntiledLevel,
   TransformRequest,
+  OnAuthError,
 } from './types'
 import { normalizeLongitudeExtent, type XYLimits } from './map-utils'
 import { WEB_MERCATOR_EXTENT } from './constants'
@@ -81,6 +82,7 @@ interface ZarrStoreOptions {
   latIsAscending?: boolean | null
   proj4?: string
   transformRequest?: TransformRequest
+  onAuthError?: OnAuthError
   /** Custom store to use instead of FetchStore. When provided, source becomes optional. */
   customStore?: Readable | AsyncReadable
 }
@@ -113,11 +115,15 @@ interface StoreDescription {
  */
 const createFetchStore = (
   url: string,
-  transformRequest?: TransformRequest
+  transformRequest?: TransformRequest,
+  onAuthError?: OnAuthError
 ): zarr.FetchStore => {
   if (!transformRequest) {
     return new zarr.FetchStore(url)
   }
+  // One notification per store: an expiry burst fans out into many concurrent
+  // failures, and recovery re-adds the layer with a fresh store anyway.
+  let authErrorSignaled = false
   return new zarr.FetchStore(url, {
     async fetch(request: Request): Promise<Response> {
       const { url: transformedUrl, ...overrides } = await transformRequest(
@@ -141,6 +147,15 @@ const createFetchStore = (
           headers: mergedHeaders,
         })
       )
+      // Masked to a missing chunk only when a handler is set, so callers who
+      // don't opt in still see the failure.
+      if ((response.status === 400 || response.status === 401) && onAuthError) {
+        if (!authErrorSignaled) {
+          authErrorSignaled = true
+          onAuthError(response.status)
+        }
+        return new Response(null, { status: 404 })
+      }
       // Remap 403 to 404 for S3/CloudFront compatibility: these services
       // return 403 (not 404) for missing or inaccessible paths.
       if (response.status === 403) {
@@ -159,6 +174,7 @@ export class ZarrStore {
   private explicitBounds: Bounds | null
   coordinateKeys: string[]
   private transformRequest?: TransformRequest
+  private onAuthError?: OnAuthError
   private customStore?: Readable | AsyncReadable
 
   dimensions: string[] = []
@@ -208,6 +224,7 @@ export class ZarrStore {
     latIsAscending = null,
     proj4,
     transformRequest,
+    onAuthError,
     customStore,
   }: ZarrStoreOptions) {
     if (!source && !customStore) {
@@ -252,6 +269,7 @@ export class ZarrStore {
       }
     }
     this.transformRequest = transformRequest
+    this.onAuthError = onAuthError
     this.customStore = customStore
 
     this.initialized = this._initialize()
@@ -298,7 +316,7 @@ export class ZarrStore {
           ? { format: 'v3' }
           : undefined
       this.store = (await zarr.extendStore(
-        createFetchStore(this.source, this.transformRequest),
+        createFetchStore(this.source, this.transformRequest, this.onAuthError),
         (store) =>
           zarr
             .withMaybeConsolidatedMetadata(store, consolidatedOpts)


### PR DESCRIPTION
Reimplements #75 on current main. Co-authored with @kcheng486.

Adds `onAuthError?: (status: number) => void`. Fires when a `transformRequest` request comes back credential-shaped, so you can refresh and re-add the layer.

```ts
new ZarrLayer({
  transformRequest: async (url) => ({ url: await getPresignedUrl(url) }),
  onAuthError: async (status) => {
    await refreshCredentials()
    map.removeLayer(layer.id)
    map.addLayer(newLayerWithFreshCredentials())
  },
})
```

- **400 and 401 only.** Expired temporary AWS credentials return `ExpiredToken`/`InvalidToken` as a 400, often with no readable body.
- **403 excluded.** S3 and CloudFront return it for genuinely absent chunks, which sparse pyramids hit routinely. Existing 403 to 404 remap untouched.
- **Latched once per store.** An expiry burst fans out across many concurrent fetches; one refresh is the right response. Recovery re-adds the layer, which builds a fresh store.
- **Masking is handler-gated.** No handler means a 400 still throws, so nothing changes for anyone not opting in.

4 new tests driving a real `ZarrStore` over a stubbed `fetch`
