### PR TITLE
Make data queries readiness-aware and resolution-selectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ By default a query reads the level the map is currently drawing, so results agre
 
 `queryData` waits for metadata and a committed resolution level, so it can be called immediately after `map.addLayer(layer)` with no render pass in between and no polling. Readiness failures — initialization failure, failure to load a level, removal from the map, or querying before the layer was added — reject with a `ZarrLayerNotReadyError` rather than returning empty. Initialization failures carry the underlying error on `.cause`.
 
+Failed reads reject as well, so an empty result means the geometry found no data.
+
 `layer.ready` exposes the same wait as a promise, for uses other than queries:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ const result = await layer.queryData(geometry, selector, {
 
 By default a query reads the level the map is currently drawing, so results agree with what the user sees and zooming out coarsens them. Pass `level: 'finest'` to always read the highest-resolution level in the store, which is what you want when the answer shouldn't depend on the camera — sampling point features, for instance.
 
-`'finest'` reads a level the renderer may not hold, so it can cost an extra fetch, and on a deep pyramid at low zoom that fetch is much larger than the default's. It doesn't disturb rendering: the query reads its own level and leaves the drawn one alone. No effect on single-level stores.
+`'finest'` reads a level the renderer may not hold, so it fetches cold instead of reusing chunks the render path already cached. A point costs about one chunk either way; a polygon covers quadratically more pixels at a finer level, so on a deep pyramid at low zoom it can read many more. It doesn't disturb rendering: the query reads its own level and leaves the drawn one alone. No effect on single-level stores.
 
 ### query readiness
 

--- a/README.md
+++ b/README.md
@@ -312,10 +312,17 @@ You can pass a third `options` argument to control query behavior:
 const result = await layer.queryData(geometry, selector, {
   signal: abortController.signal, // cancel in-flight query
   includeSpatialCoordinates: false, // omit per-pixel coordinates for slimmer results
+  level: 'finest', // read the highest-resolution level instead of the drawn one
 })
 ```
 
 **Note:** Query results match rendered values (`scale_factor`/`add_offset` applied, `fillValue`/NaN filtered).
+
+### query resolution
+
+By default a query reads the level the map is currently drawing, so results agree with what the user sees and zooming out coarsens them. Pass `level: 'finest'` to always read the highest-resolution level in the store, which is what you want when the answer shouldn't depend on the camera — sampling point features, for instance.
+
+`'finest'` reads a level the renderer may not hold, so it can cost an extra fetch, and on a deep pyramid at low zoom that fetch is much larger than the default's. It doesn't disturb rendering: the query reads its own level and leaves the drawn one alone. No effect on single-level stores.
 
 ### query readiness
 

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ By default a query reads the level the map is currently drawing, so results agre
 
 ### query readiness
 
-`queryData` waits for the layer to become queryable, so it can be called immediately after `map.addLayer(layer)` with no render pass in between and no polling. An empty result therefore always means the geometry found no data. If the layer can never answer — init failed, no level could be loaded, removed from the map, never added to one — it rejects with a `ZarrLayerNotReadyError` (with the underlying error on `.cause`) instead of returning empty. A level that can't be opened rejects too, so an unreachable asset never passes for absent data.
+`queryData` waits for the layer to become queryable, so it can be called immediately after `map.addLayer(layer)` with no render pass in between and no polling. An empty result therefore always means the geometry found no data. If the layer can never answer — init failed, no level could be loaded, removed from the map, never added to one — it rejects with a `ZarrLayerNotReadyError` (with the underlying error on `.cause`) instead of returning empty.
 
 `layer.ready` exposes the same wait as a promise, for uses other than queries:
 

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ By default a query reads the level the map is currently drawing, so results agre
 
 ### query readiness
 
-`queryData` waits for the layer to become queryable, so it can be called immediately after `map.addLayer(layer)` with no render pass in between and no polling. An empty result therefore always means the geometry found no data. If the layer can never answer — init failed, removed from the map, never added to one — it rejects with a `ZarrLayerNotReadyError` (with the underlying error on `.cause`) instead of returning empty.
+`queryData` waits for the layer to become queryable, so it can be called immediately after `map.addLayer(layer)` with no render pass in between and no polling. An empty result therefore always means the geometry found no data. If the layer can never answer — init failed, no level could be loaded, removed from the map, never added to one — it rejects with a `ZarrLayerNotReadyError` (with the underlying error on `.cause`) instead of returning empty. A level that can't be opened rejects too, so an unreachable asset never passes for absent data.
 
 `layer.ready` exposes the same wait as a promise, for uses other than queries:
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,19 @@ const result = await layer.queryData(geometry, selector, {
 
 **Note:** Query results match rendered values (`scale_factor`/`add_offset` applied, `fillValue`/NaN filtered).
 
+### query readiness
+
+`queryData` waits for the layer to become queryable, so it can be called immediately after `map.addLayer(layer)` with no render pass in between and no polling. An empty result therefore always means the geometry found no data. If the layer can never answer — init failed, removed from the map, never added to one — it rejects with a `ZarrLayerNotReadyError` (with the underlying error on `.cause`) instead of returning empty.
+
+`layer.ready` exposes the same wait as a promise, for uses other than queries:
+
+```ts
+map.addLayer(layer)
+await layer.ready // metadata loaded and a resolution level committed
+```
+
+Not the same signal as `onLoadingStateChange`, which is a spinner: it flips as chunks load and reports nothing about the level commit, so `loading: false` can be emitted while the layer still has no level.
+
 ## authentication
 
 Use `transformRequest` to add headers or credentials to requests. The function receives the fully resolved URL for each request, enabling per-path authentication like presigned S3 URLs. Supports any [fetch options](https://developer.mozilla.org/en-US/docs/Web/API/fetch#options).

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ By default a query reads the level the map is currently drawing, so results agre
 
 ### query readiness
 
-`queryData` waits for the layer to become queryable, so it can be called immediately after `map.addLayer(layer)` with no render pass in between and no polling. An empty result therefore always means the geometry found no data. If the layer can never answer — init failed, no level could be loaded, removed from the map, never added to one — it rejects with a `ZarrLayerNotReadyError` (with the underlying error on `.cause`) instead of returning empty.
+`queryData` waits for metadata and a committed resolution level, so it can be called immediately after `map.addLayer(layer)` with no render pass in between and no polling. Readiness failures — initialization failure, failure to load a level, removal from the map, or querying before the layer was added — reject with a `ZarrLayerNotReadyError` rather than returning empty. Initialization failures carry the underlying error on `.cause`.
 
 `layer.ready` exposes the same wait as a promise, for uses other than queries:
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,11 +1,3 @@
-/**
- * Thrown when a layer can never answer a query: initialization failed, the
- * layer was removed from the map, or it was never added to one.
- *
- * Queries wait for a layer that is merely still initializing, so this is
- * distinct from an empty result — an empty result means the geometry found no
- * data, never that the layer wasn't ready.
- */
 /** Re-throw with context attached. `cause` is assigned rather than passed to
  *  `super`, which needs a newer lib target than this package builds against. */
 export function wrapError(message: string, cause: unknown): Error {
@@ -16,9 +8,18 @@ export function wrapError(message: string, cause: unknown): Error {
   return error
 }
 
+/**
+ * Thrown when a layer can never answer a query: initialization failed, no
+ * resolution level could be loaded, the layer was removed from the map, or it
+ * was never added to one.
+ *
+ * Queries wait out a layer that is merely still initializing, so an unready
+ * layer never comes back as an empty result.
+ */
 export class ZarrLayerNotReadyError extends Error {
   readonly name = 'ZarrLayerNotReadyError'
-  /** The error that caused initialization to fail, when there was one. */
+  /** The underlying failure, when one was available. Initialization failures
+   *  carry the error they failed with; the other cases have none to attach. */
   readonly cause?: unknown
 
   constructor(

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,6 +6,16 @@
  * distinct from an empty result — an empty result means the geometry found no
  * data, never that the layer wasn't ready.
  */
+/** Re-throw with context attached. `cause` is assigned rather than passed to
+ *  `super`, which needs a newer lib target than this package builds against. */
+export function wrapError(message: string, cause: unknown): Error {
+  const error = new Error(
+    `${message}: ${cause instanceof Error ? cause.message : String(cause)}`
+  )
+  ;(error as Error & { cause?: unknown }).cause = cause
+  return error
+}
+
 export class ZarrLayerNotReadyError extends Error {
   readonly name = 'ZarrLayerNotReadyError'
   /** The error that caused initialization to fail, when there was one. */

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,23 @@
+/**
+ * Thrown when a layer can never answer a query: initialization failed, the
+ * layer was removed from the map, or it was never added to one.
+ *
+ * Queries wait for a layer that is merely still initializing, so this is
+ * distinct from an empty result — an empty result means the geometry found no
+ * data, never that the layer wasn't ready.
+ */
+export class ZarrLayerNotReadyError extends Error {
+  readonly name = 'ZarrLayerNotReadyError'
+  /** The error that caused initialization to fail, when there was one. */
+  readonly cause?: unknown
+
+  constructor(
+    /** The layer's `id`, so callers juggling several can tell which failed. */
+    readonly layerId: string,
+    message: string,
+    options?: { cause?: unknown }
+  ) {
+    super(`[ZarrLayer:${layerId}] ${message}`)
+    this.cause = options?.cause
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { ZarrLayer } from './zarr-layer'
+export { ZarrLayerNotReadyError } from './errors'
 export type {
   ZarrLayerOptions,
   ColormapArray,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export type {
   QueryResult,
   QueryDataValues,
   QueryGeometry,
+  QueryLevel,
   QueryOptions,
 } from './query/types'
 

--- a/src/level-loader.ts
+++ b/src/level-loader.ts
@@ -7,6 +7,26 @@ type ResolvedLevel = Pick<
   'zarrArray' | 'width' | 'height' | 'regionSize' | 'xyLimits'
 > & { reusedArray: boolean }
 
+/**
+ * Why a load stopped.
+ *
+ * `superseded` is not a failure: a newer load (a zoom change, a selector
+ * rebuild) took over, and its result is the one that counts. Callers waiting
+ * on a level must retry rather than conclude there is none — which is the
+ * whole reason this is reported instead of inferred from `activeLevel`.
+ */
+export type LevelLoadOutcome =
+  | 'committed'
+  | 'superseded'
+  | 'failed'
+  /** Index out of range, or non-zero on a single-level store. */
+  | 'ignored'
+
+/** How many times `ensureActive` will follow a supersession before giving up.
+ *  Each retry waits on the load that displaced the last one, so this only
+ *  bites if the level target keeps moving faster than loads complete. */
+const MAX_SUPERSEDED_RETRIES = 5
+
 export type LevelLoaderContext = {
   isMultiscale: () => boolean
   getLevelCount: () => number
@@ -29,7 +49,7 @@ export class LevelLoader {
   private desiredLevelIndex = 0
   private loadingLevelIndex: number | null = null
   private activeLevel: LevelRuntime | null = null
-  private inflight: Promise<void> | null = null
+  private inflight: Promise<LevelLoadOutcome> | null = null
 
   constructor(private context: LevelLoaderContext) {}
 
@@ -65,19 +85,19 @@ export class LevelLoader {
   loadLevel(
     levelIndex: number,
     { reuseArray = false }: { reuseArray?: boolean } = {}
-  ): Promise<void> {
+  ): Promise<LevelLoadOutcome> {
     if (this.context.isMultiscale() && this.context.getLevelCount() > 0) {
       if (levelIndex < 0 || levelIndex >= this.context.getLevelCount()) {
-        return Promise.resolve()
+        return Promise.resolve('ignored')
       }
     } else if (levelIndex !== 0) {
-      return Promise.resolve()
+      return Promise.resolve('ignored')
     }
 
     // Dedupe: an in-flight load for the same target is already on it.
     // A selector rebuild (`reuseArray`) intentionally supersedes.
     if (this.loadingLevelIndex === levelIndex && !reuseArray) {
-      return this.inflight ?? Promise.resolve()
+      return this.inflight ?? Promise.resolve('ignored')
     }
 
     const pending = this.runLoad(levelIndex, reuseArray)
@@ -93,24 +113,32 @@ export class LevelLoader {
 
   /**
    * Await a committed level, loading the desired one if the render loop
-   * hasn't. Returns null when the load fails or was superseded by a newer
-   * one — callers treat that the same as "no level".
+   * hasn't. Returns null only when no level can be had: the load failed, or
+   * the loader was disposed.
    *
    * Targets the render loop's own desired index so this can't fight it: the
    * level `update()` wants is the level `update()` would load, and the dedupe
    * in `loadLevel` folds the two onto one request.
+   *
+   * A zoom change mid-load displaces the load we are waiting on, which
+   * finishes without committing. Retrying picks up whichever load replaced
+   * it, so a camera move during startup doesn't read as "this store has no
+   * levels".
    */
   async ensureActive(): Promise<LevelRuntime | null> {
-    if (this.activeLevel) return this.activeLevel
-    if (this.context.isRemoved()) return null
-    await this.loadLevel(this.desiredLevelIndex)
+    for (let attempt = 0; attempt <= MAX_SUPERSEDED_RETRIES; attempt++) {
+      if (this.activeLevel) return this.activeLevel
+      if (this.context.isRemoved()) return null
+      const outcome = await this.loadLevel(this.desiredLevelIndex)
+      if (outcome !== 'superseded') break
+    }
     return this.activeLevel
   }
 
   private async runLoad(
     levelIndex: number,
     reuseArray: boolean
-  ): Promise<void> {
+  ): Promise<LevelLoadOutcome> {
     const token = ++this.loadToken
     // Snapshot the selector so we can detect a concurrent `setSelector`
     // that arrived after `buildSliceArgsForSelector` resolved; committing
@@ -150,7 +178,7 @@ export class LevelLoader {
         !targetStillDesired
       ) {
         this.context.invalidate()
-        return
+        return 'superseded'
       }
 
       // Atomic commit — one reference swap replaces all per-level state.
@@ -171,13 +199,17 @@ export class LevelLoader {
       // longer protected. Bare `.clear()` here would leak WebGL resources.
       if (!resolved.reusedArray) this.context.onNewArrayCommitted()
       this.context.invalidate()
+      return 'committed'
     } catch (err) {
-      if (token === this.loadToken) {
-        console.error(
-          `Failed to load level ${this.context.getAssetLabel(levelIndex)}:`,
-          err
-        )
-      }
+      // A load that a newer one raced past is reported as superseded, not as
+      // a failure: its error is about an attempt nobody is waiting on, and
+      // calling it a failure would stop `ensureActive` retrying.
+      if (token !== this.loadToken) return 'superseded'
+      console.error(
+        `Failed to load level ${this.context.getAssetLabel(levelIndex)}:`,
+        err
+      )
+      return 'failed'
     } finally {
       if (token === this.loadToken) this.loadingLevelIndex = null
     }

--- a/src/level-loader.ts
+++ b/src/level-loader.ts
@@ -22,11 +22,6 @@ export type LevelLoadOutcome =
   /** Index out of range, or non-zero on a single-level store. */
   | 'ignored'
 
-/** How many times `ensureActive` will follow a supersession before giving up.
- *  Each retry waits on the load that displaced the last one, so this only
- *  bites if the level target keeps moving faster than loads complete. */
-const MAX_SUPERSEDED_RETRIES = 5
-
 export type LevelLoaderContext = {
   isMultiscale: () => boolean
   getLevelCount: () => number
@@ -124,15 +119,21 @@ export class LevelLoader {
    * finishes without committing. Retrying picks up whichever load replaced
    * it, so a camera move during startup doesn't read as "this store has no
    * levels".
+   *
+   * The retry is deliberately uncapped. A cap would turn a burst of camera
+   * movement into a spurious "no level" for whoever is waiting, which is the
+   * failure this exists to prevent. It cannot spin: every pass awaits a real
+   * load, so it advances only as fast as loads settle, and it ends as soon as
+   * one commits, one genuinely fails, or the renderer is disposed. Callers
+   * that need to stop waiting sooner pass an AbortSignal.
    */
   async ensureActive(): Promise<LevelRuntime | null> {
-    for (let attempt = 0; attempt <= MAX_SUPERSEDED_RETRIES; attempt++) {
+    for (;;) {
       if (this.activeLevel) return this.activeLevel
       if (this.context.isRemoved()) return null
       const outcome = await this.loadLevel(this.desiredLevelIndex)
-      if (outcome !== 'superseded') break
+      if (outcome !== 'superseded') return this.activeLevel
     }
-    return this.activeLevel
   }
 
   private async runLoad(

--- a/src/level-loader.ts
+++ b/src/level-loader.ts
@@ -29,6 +29,7 @@ export class LevelLoader {
   private desiredLevelIndex = 0
   private loadingLevelIndex: number | null = null
   private activeLevel: LevelRuntime | null = null
+  private inflight: Promise<void> | null = null
 
   constructor(private context: LevelLoaderContext) {}
 
@@ -55,21 +56,61 @@ export class LevelLoader {
    * `setSelector` to rebuild slice args without refetching. `loadToken`
    * acts as a cancellation token: any load whose token is stale at
    * commit time drops its result.
+   *
+   * The returned promise settles when the load does, so callers outside the
+   * render loop (`ensureActive`) can await a commit. The synchronous guards
+   * live here rather than in `runLoad` so a deduped call hands back the
+   * in-flight promise instead of an already-resolved one.
    */
-  async loadLevel(
+  loadLevel(
     levelIndex: number,
     { reuseArray = false }: { reuseArray?: boolean } = {}
   ): Promise<void> {
     if (this.context.isMultiscale() && this.context.getLevelCount() > 0) {
-      if (levelIndex < 0 || levelIndex >= this.context.getLevelCount()) return
+      if (levelIndex < 0 || levelIndex >= this.context.getLevelCount()) {
+        return Promise.resolve()
+      }
     } else if (levelIndex !== 0) {
-      return
+      return Promise.resolve()
     }
 
     // Dedupe: an in-flight load for the same target is already on it.
     // A selector rebuild (`reuseArray`) intentionally supersedes.
-    if (this.loadingLevelIndex === levelIndex && !reuseArray) return
+    if (this.loadingLevelIndex === levelIndex && !reuseArray) {
+      return this.inflight ?? Promise.resolve()
+    }
 
+    const pending = this.runLoad(levelIndex, reuseArray)
+    this.inflight = pending
+    const clear = () => {
+      if (this.inflight === pending) this.inflight = null
+    }
+    // Settled both ways, and handled here so the bookkeeping chain can't
+    // surface as an unhandled rejection alongside the caller's own.
+    pending.then(clear, clear)
+    return pending
+  }
+
+  /**
+   * Await a committed level, loading the desired one if the render loop
+   * hasn't. Returns null when the load fails or was superseded by a newer
+   * one — callers treat that the same as "no level".
+   *
+   * Targets the render loop's own desired index so this can't fight it: the
+   * level `update()` wants is the level `update()` would load, and the dedupe
+   * in `loadLevel` folds the two onto one request.
+   */
+  async ensureActive(): Promise<LevelRuntime | null> {
+    if (this.activeLevel) return this.activeLevel
+    if (this.context.isRemoved()) return null
+    await this.loadLevel(this.desiredLevelIndex)
+    return this.activeLevel
+  }
+
+  private async runLoad(
+    levelIndex: number,
+    reuseArray: boolean
+  ): Promise<void> {
     const token = ++this.loadToken
     // Snapshot the selector so we can detect a concurrent `setSelector`
     // that arrived after `buildSliceArgsForSelector` resolved; committing
@@ -147,5 +188,6 @@ export class LevelLoader {
     this.loadToken++
     this.loadingLevelIndex = null
     this.activeLevel = null
+    this.inflight = null
   }
 }

--- a/src/query/data-query.test.ts
+++ b/src/query/data-query.test.ts
@@ -23,7 +23,9 @@ import { buildMemoryZarrStore, ramp } from '../__fixtures__/memory-zarr'
 
 const WORLD = { xMin: -180, xMax: 180, yMin: -90, yMax: 90 }
 
-async function makeQueryHarness(opts: { gateReads?: boolean } = {}) {
+async function makeQueryHarness(
+  opts: { gateReads?: boolean; failReads?: boolean } = {}
+) {
   const memory = buildMemoryZarrStore({
     arrays: [
       {
@@ -47,10 +49,18 @@ async function makeQueryHarness(opts: { gateReads?: boolean } = {}) {
   const readsReleased = new Promise<void>((res) => {
     releaseReads = res
   })
+  const chunkKey = (key: string) => key.includes('/temp/c/')
   const customStore = opts.gateReads
     ? {
         get: async (key: string) => {
-          if (key.includes('/temp/c/')) await readsReleased
+          if (chunkKey(key)) await readsReleased
+          return memory.get(key)
+        },
+      }
+    : opts.failReads
+    ? {
+        get: async (key: string) => {
+          if (chunkKey(key)) throw new Error('network down')
           return memory.get(key)
         },
       }
@@ -209,6 +219,17 @@ describe('queryData', () => {
     controller.abort()
     releaseReads()
     await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('propagates a failed chunk read instead of answering empty', async () => {
+    const { context } = await makeQueryHarness({ failReads: true })
+
+    // A read that failed is not a region that holds no data; reporting it as
+    // an empty result is the silent wrong answer this contract exists to
+    // avoid.
+    await expect(queryData(context, point(-157.5, 67.5))).rejects.toThrow(
+      /failed to read query data/
+    )
   })
 })
 

--- a/src/query/data-query.ts
+++ b/src/query/data-query.ts
@@ -16,6 +16,7 @@ import {
   type DimensionValuesCache,
 } from '../selector-resolution'
 import { normalizeSelector } from '../zarr-utils'
+import { wrapError } from '../errors'
 import { queryRegionUntiled, findSpatialDimNames } from './region-query'
 import {
   computePixelBoundsFromGeometry,
@@ -70,7 +71,7 @@ export async function fetchQueryData(
   channels: number
   channelLabels: (string | number)[][]
   multiValueDimNames: string[]
-} | null> {
+}> {
   try {
     const { sliceArgs: baseSliceArgs, multiValueDims } =
       await buildSliceArgsForSelector(
@@ -145,8 +146,9 @@ export async function fetchQueryData(
     }
   } catch (err) {
     if (err instanceof DOMException && err.name === 'AbortError') throw err
-    console.error('Error fetching query data:', err)
-    return null
+    // Propagated, not swallowed: a read that failed is not a region that holds
+    // no data, and returning empty here makes the two indistinguishable.
+    throw wrapError('[ZarrLayer] failed to read query data', err)
   }
 }
 
@@ -198,7 +200,7 @@ export async function queryData(
     geom: QueryGeometry,
     pixelBounds: PixelRect,
     opts?: QueryOptions
-  ): Promise<QueryResult | null> => {
+  ): Promise<QueryResult> => {
     const fetched = await fetchQueryData(
       context,
       level,
@@ -206,7 +208,6 @@ export async function queryData(
       pixelBounds,
       opts?.signal
     )
-    if (!fetched) return null
 
     const { minX, minY, maxX, maxY } = pixelBounds
     const [xMin0, yMin0] = pixelToSourceCRS(
@@ -265,8 +266,7 @@ export async function queryData(
       context.projection.toWGS84 ?? undefined
     )
     if (!pixelBounds) return emptyResult()
-    const result = await runStrip(geom, pixelBounds, options)
-    return result ?? emptyResult()
+    return runStrip(geom, pixelBounds, options)
   }
 
   const { geometry: processedGeometry, bbox: wrappedBbox } =
@@ -320,10 +320,8 @@ export async function queryData(
     ? await runStrip(processedGeometry, spans.east, options)
     : null
 
-  // If either requested strip failed, return empty rather than partial data
-  if ((spans.west && !westResult) || (spans.east && !eastResult)) {
-    return emptyResult()
-  }
+  // A strip is null only when the wrapped bbox produced no span on that side;
+  // a strip that failed to read threw rather than coming back empty.
   if (!westResult && !eastResult) return emptyResult()
   if (!westResult || !eastResult) return (westResult ?? eastResult)!
 

--- a/src/query/types.ts
+++ b/src/query/types.ts
@@ -91,9 +91,25 @@ export interface QueryTransformOptions {
 /**
  * Options for queryData calls.
  */
+/**
+ * Which resolution level a query reads from.
+ *
+ * `'current'` (the default) uses the level the map is drawing, so a query
+ * agrees with what the user sees. `'finest'` uses the highest-resolution
+ * level in the store regardless of zoom — what you want when the answer
+ * should not depend on the camera, such as sampling point features.
+ *
+ * `'finest'` reads a level the renderer may not hold, so it can cost an
+ * extra fetch, and on a deep pyramid at low zoom that fetch is much larger
+ * than the one `'current'` would make.
+ */
+export type QueryLevel = 'current' | 'finest'
+
 export interface QueryOptions {
   /** AbortSignal to cancel the query. */
   signal?: AbortSignal
   /** Include per-pixel coordinates in the result. Defaults to true. */
   includeSpatialCoordinates?: boolean
+  /** Resolution level to read from. Defaults to `'current'`. */
+  level?: QueryLevel
 }

--- a/src/query/types.ts
+++ b/src/query/types.ts
@@ -99,9 +99,10 @@ export interface QueryTransformOptions {
  * level in the store regardless of zoom — what you want when the answer
  * should not depend on the camera, such as sampling point features.
  *
- * `'finest'` reads a level the renderer may not hold, so it can cost an
- * extra fetch, and on a deep pyramid at low zoom that fetch is much larger
- * than the one `'current'` would make.
+ * `'finest'` reads a level the renderer may not hold, so it fetches cold
+ * rather than reusing chunks the render path already cached. A point costs
+ * about one chunk either way — it selects a single pixel at any resolution —
+ * while a polygon covers quadratically more pixels the finer the level.
  */
 export type QueryLevel = 'current' | 'finest'
 

--- a/src/region-renderer.test.ts
+++ b/src/region-renderer.test.ts
@@ -510,3 +510,66 @@ describe('RegionRenderer', () => {
     expect(seam(renderer).getRegionStates(gl)).toEqual([])
   })
 })
+
+/**
+ * A multiscale renderer commits no level during `initialize()` — the level
+ * comes from map zoom, which only `update()` knows. `queryData` therefore has
+ * to commit one itself, or a query on a map that never painted indexes into
+ * nothing and comes back empty.
+ */
+describe('RegionRenderer queries before the render loop runs', () => {
+  async function makeMultiscaleRenderer() {
+    const store = new ZarrStore({
+      customStore: buildMemoryZarrStore({
+        attributes: {
+          multiscales: {
+            layout: [{ asset: '0' }],
+            crs: 'EPSG:4326',
+          },
+        },
+        arrays: [
+          {
+            name: '0/temperature',
+            shape: [HEIGHT, WIDTH],
+            chunkShape: [HEIGHT, WIDTH],
+            dimensionNames: ['lat', 'lon'],
+            chunks: {
+              '0/0': Array.from({ length: HEIGHT * WIDTH }, (_, i) => i),
+            },
+          },
+        ],
+      }),
+      variable: 'temperature',
+      version: 3,
+      bounds: [-180, -90, 180, 90],
+      latIsAscending: false,
+    })
+    await store.initialized
+    const renderer = new RegionRenderer(store, 'temperature', {}, vi.fn())
+    await renderer.initialize()
+    return renderer
+  }
+
+  it('commits a level for a query when update() never ran', async () => {
+    const renderer = await makeMultiscaleRenderer()
+
+    // Pixel (0, 0) of the 8x4 grid: lon -157.5, lat 67.5.
+    const result = await renderer.queryData({
+      type: 'Point',
+      coordinates: [-157.5, 67.5],
+    })
+
+    expect(result.temperature).toEqual([0])
+  })
+
+  it('commits the level once for concurrent queries', async () => {
+    const renderer = await makeMultiscaleRenderer()
+
+    const results = await Promise.all([
+      renderer.queryData({ type: 'Point', coordinates: [-157.5, 67.5] }),
+      renderer.queryData({ type: 'Point', coordinates: [-112.5, 22.5] }),
+    ])
+
+    expect(results.map((r) => r.temperature)).toEqual([[0], [9]])
+  })
+})

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -69,7 +69,7 @@ import {
   makeRegionKey,
 } from './region-cache'
 import { RegionFetcher } from './region-fetcher'
-import { LevelLoader } from './level-loader'
+import { LevelLoader, type LevelLoadOutcome } from './level-loader'
 import { wrapError } from './errors'
 import { createHybridMesh } from './mesh-reprojector'
 import {
@@ -897,7 +897,7 @@ export class RegionRenderer {
   private loadLevel(
     levelIndex: number,
     options: { reuseArray?: boolean } = {}
-  ): Promise<void> {
+  ): Promise<LevelLoadOutcome> {
     return this.levelLoader.loadLevel(levelIndex, options)
   }
 

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -18,7 +18,12 @@ import type {
   RegionRenderState,
   CustomShaderConfig,
 } from './renderer-types'
-import type { QueryGeometry, QueryOptions, QueryResult } from './query/types'
+import type {
+  QueryGeometry,
+  QueryLevel,
+  QueryOptions,
+  QueryResult,
+} from './query/types'
 import type {
   LoadingStateCallback,
   MapLike,
@@ -37,7 +42,12 @@ import {
   createProjectionContext,
   type ProjectionContext,
 } from './projection-utils'
-import type { LevelMeta, LevelRuntime, RegionState } from './region-state'
+import type {
+  LevelMeta,
+  LevelRuntime,
+  QueryLevelSnapshot,
+  RegionState,
+} from './region-state'
 import {
   buildSliceArgsForSelector,
   type DimensionValuesCache,
@@ -180,24 +190,7 @@ export class RegionRenderer {
             reusedArray: true,
           }
         }
-        const zarrArray = this.isMultiscale
-          ? await (async () => {
-              await this.ensureLevelMetadata(levelIndex)
-              return this.zarrStore.getLevelArray(this.levels[levelIndex].asset)
-            })()
-          : await this.zarrStore.getArray()
-        const width = zarrArray.shape[this.dimIndices.lon.index]
-        const height = zarrArray.shape[this.dimIndices.lat.index]
-        return {
-          zarrArray,
-          width,
-          height,
-          regionSize: this.getRegionSize(zarrArray) ?? [height, width],
-          xyLimits: this.isMultiscale
-            ? this.levels[levelIndex]?.xyLimits
-            : undefined,
-          reusedArray: false,
-        }
+        return { ...(await this.openLevel(levelIndex)), reusedArray: false }
       },
       buildSliceArgs: async (selectorSnapshot, array, coordLevelIndex) => {
         const { sliceArgs, multiValueDims } =
@@ -275,6 +268,31 @@ export class RegionRenderer {
     } finally {
       this.loadingManager.metadataLoading = false
       this.emitLoadingState()
+    }
+  }
+
+  /**
+   * Open a level's array and derive its pixel dimensions. Shared by the
+   * render loop's level commit and by query-local level reads; the store
+   * caches array handles, so opening the same level twice is cheap.
+   */
+  private async openLevel(levelIndex: number) {
+    const zarrArray = this.isMultiscale
+      ? await (async () => {
+          await this.ensureLevelMetadata(levelIndex)
+          return this.zarrStore.getLevelArray(this.levels[levelIndex].asset)
+        })()
+      : await this.zarrStore.getArray()
+    const width = zarrArray.shape[this.dimIndices.lon.index]
+    const height = zarrArray.shape[this.dimIndices.lat.index]
+    return {
+      zarrArray,
+      width,
+      height,
+      regionSize: this.getRegionSize(zarrArray) ?? [height, width],
+      xyLimits: this.isMultiscale
+        ? this.levels[levelIndex]?.xyLimits
+        : undefined,
     }
   }
 
@@ -1209,13 +1227,80 @@ export class RegionRenderer {
     return this.levelLoader.ensureActive()
   }
 
+  /**
+   * The highest-resolution level, by pixel width rather than by position:
+   * level order follows whatever the store declared, which is conventionally
+   * coarsest-first but is not guaranteed to be.
+   */
+  private finestLevelIndex(): number {
+    if (!this.isMultiscale || this.levels.length === 0) return 0
+    let finest = 0
+    let widest = -1
+    for (let i = 0; i < this.levels.length; i++) {
+      const shape = this.levels[i].shape
+      if (!shape) continue
+      const width = shape[this.dimIndices.lon?.index ?? shape.length - 1]
+      if (width > widest) {
+        widest = width
+        finest = i
+      }
+    }
+    return finest
+  }
+
+  /**
+   * Resolve the level a query reads from.
+   *
+   * `'finest'` deliberately bypasses `LevelLoader` when the renderer is on a
+   * different level: committing the finest level would drag the render loop
+   * onto it and fight the zoom-driven target over `loadToken`. A query-local
+   * snapshot leaves render state untouched.
+   */
+  private async resolveQueryLevel(
+    requested: QueryLevel = 'current'
+  ): Promise<QueryLevelSnapshot | null> {
+    const snapshot = (level: LevelRuntime): QueryLevelSnapshot => ({
+      index: level.index,
+      zarrArray: level.zarrArray,
+      width: level.width,
+      height: level.height,
+      xyLimits: level.xyLimits,
+    })
+
+    if (requested !== 'finest') {
+      const active = await this.ensureQueryableLevel()
+      return active && snapshot(active)
+    }
+
+    const finest = this.finestLevelIndex()
+    if (this.activeLevel?.index === finest) return snapshot(this.activeLevel)
+    try {
+      const opened = await this.openLevel(finest)
+      return {
+        index: finest,
+        zarrArray: opened.zarrArray,
+        width: opened.width,
+        height: opened.height,
+        xyLimits: opened.xyLimits,
+      }
+    } catch (err) {
+      console.error(
+        `Failed to open level ${
+          this.levels[finest]?.asset ?? finest
+        } for query:`,
+        err
+      )
+      return null
+    }
+  }
+
   /** Query data for point or region geometries. */
   async queryData(
     geometry: QueryGeometry,
     selector?: Selector,
     options?: QueryOptions
   ): Promise<QueryResult> {
-    const activeLevel = await this.ensureQueryableLevel()
+    const level = await this.resolveQueryLevel(options?.level)
     return queryDataWithContext(
       {
         zarrStore: this.zarrStore,
@@ -1225,20 +1310,12 @@ export class RegionRenderer {
         mercatorBounds: this.mercatorBounds,
         latIsAscending: this.latIsAscending,
         levels: this.levels,
-        level: activeLevel
-          ? {
-              index: activeLevel.index,
-              zarrArray: activeLevel.zarrArray,
-              width: activeLevel.width,
-              height: activeLevel.height,
-              xyLimits: activeLevel.xyLimits,
-            }
-          : null,
+        level,
         projection: this.projection,
         antimeridianWarnings: this._antimeridianWarnings,
         dimensionValues: this.dimensionValues,
         isMultiscale: this.isMultiscale,
-        coordLevelIndex: activeLevel?.index ?? 0,
+        coordLevelIndex: level?.index ?? 0,
       },
       geometry,
       selector,

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -1200,13 +1200,22 @@ export class RegionRenderer {
     emitLoadingStateUtil(this.loadingManager)
   }
 
+  /**
+   * Await a committed level. Multiscale init deliberately leaves the level
+   * to `update()`, which only runs from the render path, so a query issued
+   * against a map that hasn't painted has to commit one itself.
+   */
+  ensureQueryableLevel(): Promise<LevelRuntime | null> {
+    return this.levelLoader.ensureActive()
+  }
+
   /** Query data for point or region geometries. */
   async queryData(
     geometry: QueryGeometry,
     selector?: Selector,
     options?: QueryOptions
   ): Promise<QueryResult> {
-    const activeLevel = this.activeLevel
+    const activeLevel = await this.ensureQueryableLevel()
     return queryDataWithContext(
       {
         zarrStore: this.zarrStore,

--- a/src/region-renderer.ts
+++ b/src/region-renderer.ts
@@ -70,6 +70,7 @@ import {
 } from './region-cache'
 import { RegionFetcher } from './region-fetcher'
 import { LevelLoader } from './level-loader'
+import { wrapError } from './errors'
 import { createHybridMesh } from './mesh-reprojector'
 import {
   type RequestCanceller,
@@ -1284,13 +1285,14 @@ export class RegionRenderer {
         xyLimits: opened.xyLimits,
       }
     } catch (err) {
-      console.error(
-        `Failed to open level ${
+      // Propagated, not swallowed: an unreachable or malformed finest asset
+      // must not come back looking like a geometry that found no data.
+      throw wrapError(
+        `[ZarrLayer] failed to open level ${
           this.levels[finest]?.asset ?? finest
-        } for query:`,
+        } for query`,
         err
       )
-      return null
     }
   }
 

--- a/src/zarr-layer.query-readiness.test.ts
+++ b/src/zarr-layer.query-readiness.test.ts
@@ -115,6 +115,17 @@ function samefieldPyramid({ declareShapes = false } = {}) {
   })
 }
 
+/** A static map whose zoom can be moved between frames. */
+function zoomableMap(initialZoom: number) {
+  const map = staticMap(initialZoom) as MapLike & { getZoom: () => number }
+  let zoom = initialZoom
+  map.getZoom = () => zoom
+  return { map, setZoom: (next: number) => (zoom = next) }
+}
+
+/** Let pending load chains advance one macrotask. */
+const tick = () => new Promise((r) => setTimeout(r, 0))
+
 /** Center of coarse-grid pixel (x, y) as [lon, lat] on a global extent. */
 function pixelCenter(x: number, y: number): [number, number] {
   return [
@@ -657,15 +668,6 @@ describe('queryData readiness under a level change mid-load', () => {
     }
   }
 
-  function zoomableMap(initialZoom: number) {
-    const map = staticMap(initialZoom) as MapLike & { getZoom: () => number }
-    let zoom = initialZoom
-    map.getZoom = () => zoom
-    return { map, setZoom: (next: number) => (zoom = next) }
-  }
-
-  const tick = () => new Promise((r) => setTimeout(r, 0))
-
   it('follows the level change instead of reporting no level', async () => {
     const { store, release } = gatedPyramid()
     const layer = makeLayer({ store })
@@ -736,12 +738,107 @@ describe('queryData readiness under a level change mid-load', () => {
 
     const first = failing.ready
     await expect(first).rejects.toBeInstanceOf(ZarrLayerNotReadyError)
-    expect(failing.ready).not.toBe(first)
+    // Held and awaited, not just compared: reading `ready` again mints a fresh
+    // attempt, and leaving that one unconsumed is an unhandled rejection.
+    const second = failing.ready
+    expect(second).not.toBe(first)
+    await expect(second).rejects.toBeInstanceOf(ZarrLayerNotReadyError)
 
     const working = makeLayer({ store: samefieldPyramid() })
     working.onAdd(staticMap(), createRecordingGl())
     const settled = working.ready
     await settled
     expect(working.ready).toBe(settled)
+  })
+})
+
+/**
+ * Supersession has no retry budget. A burst of camera movement during a slow
+ * first load must not exhaust some allowance and leave a waiting query
+ * reporting "no resolution level" while a load is still in flight.
+ *
+ * Driving many *distinct* level selections needs many distinguishable
+ * resolutions, which a narrow extent provides without large arrays: level
+ * selection compares `width / worldFraction` against `256 * 2^zoom`, and a
+ * 0.36-degree span makes worldFraction 0.001, so an 8px level already reads as
+ * 8000 effective pixels. Level 0 is never selected — `ZarrStore` opens it
+ * during init for the variable's dimensions, so it must not be gated.
+ */
+describe('queryData readiness under repeated level changes', () => {
+  const EXTENT: [number, number, number, number] = [0, 0, 0.36, 0.36]
+  const WIDTHS = [4, 8, 16, 32, 64, 128, 256, 512]
+  const LAST = WIDTHS.length - 1
+  /** Level i is selected at this zoom; see the effective-pixel math above. */
+  const zoomFor = (level: number) => level + 3
+
+  function narrowPyramid() {
+    const shapeOf = (level: number): [number, number] => [2, WIDTHS[level]]
+    const backing = buildMemoryZarrStore({
+      attributes: {
+        multiscales: {
+          layout: WIDTHS.map((_, level) => ({
+            asset: String(level),
+            'spatial:shape': shapeOf(level),
+          })),
+          crs: 'EPSG:4326',
+        },
+      },
+      arrays: WIDTHS.map((width, level) => ({
+        name: `${level}/temperature`,
+        shape: shapeOf(level),
+        chunkShape: shapeOf(level),
+        dimensionNames: ['lat', 'lon'],
+        chunks: { '0/0': new Float32Array(2 * width).fill(level) },
+      })),
+    })
+    const release: Record<number, () => void> = {}
+    const gates = new Map<number, Promise<void>>()
+    for (let level = 1; level <= LAST; level++) {
+      gates.set(
+        level,
+        new Promise<void>((resolve) => {
+          release[level] = resolve
+        })
+      )
+    }
+    return {
+      release,
+      store: {
+        get: async (key: string) => {
+          const match = key.match(/^\/(\d+)\/temperature\/zarr\.json$/)
+          const gate = match && gates.get(Number(match[1]))
+          if (gate) await gate
+          return backing.get(key)
+        },
+      },
+    }
+  }
+
+  it('keeps following the level target however many times it moves', async () => {
+    const { store, release } = narrowPyramid()
+    const layer = makeLayer({ store, bounds: EXTENT, clim: [0, LAST] })
+    const { map, setZoom } = zoomableMap(zoomFor(1))
+    const gl = createRecordingGl()
+    layer.onAdd(map, gl)
+    await tick()
+
+    const pending = layer.queryData({
+      type: 'Point',
+      coordinates: [0.18, 0.18],
+    })
+    await tick()
+
+    // Each pass moves the target, then lets the load the query was waiting on
+    // finish as superseded — one retry per pass, more than any fixed budget.
+    for (let level = 1; level < LAST; level++) {
+      setZoom(zoomFor(level + 1))
+      layer.prerender(gl, {})
+      await tick()
+      release[level]()
+      await tick()
+    }
+
+    release[LAST]()
+    expect((await pending).temperature).toEqual([LAST])
   })
 })

--- a/src/zarr-layer.query-readiness.test.ts
+++ b/src/zarr-layer.query-readiness.test.ts
@@ -476,3 +476,119 @@ describe('queryData level option', () => {
     )
   })
 })
+
+/**
+ * Failures on the readiness path must surface as rejections. Reporting them as
+ * an empty result would recreate the exact bug this work exists to fix: a
+ * layer that holds no usable data answering identically to a point that
+ * genuinely has none.
+ */
+describe('queryData failure reporting', () => {
+  /** Backing store with every key under `prefix` missing, so opening that
+   *  level fails while the rest of the store stays intact. */
+  const withMissingLevel = (prefix: string) => {
+    const backing = samefieldPyramid({ declareShapes: true })
+    return {
+      get: async (key: string) =>
+        key.startsWith(prefix) ? undefined : backing.get(key),
+    }
+  }
+
+  const point = { type: 'Point' as const, coordinates: pixelCenter(0, 0) }
+
+  it('rejects rather than answering empty when no level can be loaded', async () => {
+    // Zoom 0 targets the fine level here, so making it unreadable leaves the
+    // renderer with nothing committed.
+    const layer = makeLayer({ store: withMissingLevel('/1/') })
+    layer.onAdd(staticMap(), createRecordingGl())
+
+    await expect(layer.queryData(point)).rejects.toBeInstanceOf(
+      ZarrLayerNotReadyError
+    )
+    await expect(layer.ready).rejects.toThrow(/no resolution level/)
+  })
+
+  it('rejects when the layer is removed while it is becoming ready', async () => {
+    let releaseLevel = () => {}
+    const levelGate = new Promise<void>((resolve) => {
+      releaseLevel = resolve
+    })
+    const backing = samefieldPyramid({ declareShapes: true })
+    const layer = makeLayer({
+      store: {
+        get: async (key: string) => {
+          if (key === '/1/temperature/zarr.json') await levelGate
+          return backing.get(key)
+        },
+      },
+    })
+    const map = staticMap()
+    const gl = createRecordingGl()
+    layer.onAdd(map, gl)
+
+    const pending = layer.queryData(point)
+    await new Promise((r) => setTimeout(r, 0))
+    layer.onRemove(map, gl)
+    releaseLevel()
+
+    // Reported as a removal, not as "no level could be loaded" — disposal
+    // clears the committed level too, so both branches would fire and only
+    // the earlier one names the actual cause.
+    await expect(pending).rejects.toThrow(/removed while it was becoming ready/)
+  })
+
+  it('rejects when the finest level cannot be opened', async () => {
+    // Levels wide enough that zoom 0 draws the coarse one, so the render
+    // level commits normally and only the finest read fails. Shapes are
+    // declared so the finest level is identifiable without opening it.
+    const backing = buildMemoryZarrStore({
+      attributes: {
+        multiscales: {
+          layout: [
+            { asset: '0', 'spatial:shape': [128, 256] },
+            { asset: '1', 'spatial:shape': [256, 512] },
+          ],
+          crs: 'EPSG:4326',
+        },
+      },
+      arrays: [
+        {
+          name: '0/temperature',
+          shape: [128, 256],
+          chunkShape: [128, 256],
+          dimensionNames: ['lat', 'lon'],
+          chunks: { '0/0': new Float32Array(128 * 256).fill(1) },
+        },
+      ],
+    })
+    const layer = makeLayer({
+      store: {
+        get: async (key: string) =>
+          key.startsWith('/1/') ? undefined : backing.get(key),
+      },
+    })
+    layer.onAdd(staticMap(0), createRecordingGl())
+
+    // The default query still works — only the finest read is broken.
+    expect((await layer.queryData(point)).temperature).toEqual([1])
+    await expect(
+      layer.queryData(point, undefined, { level: 'finest' })
+    ).rejects.toThrow(/failed to open level 1 for query/)
+  })
+
+  it('wraps an initialization that rejected before its own error handling', async () => {
+    // resolveGl throws on a context that isn't WebGL2, before _onAddAsync
+    // reaches the try block that would have recorded the failure.
+    const layer = makeLayer({ store: samefieldPyramid() })
+    layer.onAdd(staticMap(), {} as WebGL2RenderingContext)
+
+    const error = await layer.queryData(point).then(
+      () => null,
+      (e) => e
+    )
+
+    expect(error).toBeInstanceOf(ZarrLayerNotReadyError)
+    expect((error as ZarrLayerNotReadyError).cause).toBeInstanceOf(Error)
+    expect((error as ZarrLayerNotReadyError).message).toMatch(/WebGL2/)
+  })
+})

--- a/src/zarr-layer.query-readiness.test.ts
+++ b/src/zarr-layer.query-readiness.test.ts
@@ -548,6 +548,40 @@ describe('queryData failure reporting', () => {
     await expect(pending).rejects.toThrow(/removed while it was becoming ready/)
   })
 
+  it('rejects when the layer is removed while a query is in flight', async () => {
+    // Readiness passes, then removal lands mid-query. What the inner path
+    // does next depends on exactly when disposal lands: it answers empty if
+    // the committed level is already cleared, and otherwise finishes the read
+    // and returns data from a torn-down layer. Neither belongs to the caller,
+    // so the check is on the way out rather than at one of those two moments.
+    let releaseChunk = () => {}
+    const chunkGate = new Promise<void>((resolve) => {
+      releaseChunk = resolve
+    })
+    const backing = samefieldPyramid()
+    const layer = makeLayer({
+      store: {
+        get: async (key: string) => {
+          if (key.startsWith('/1/temperature/c/')) await chunkGate
+          return backing.get(key)
+        },
+      },
+    })
+    const map = staticMap()
+    const gl = createRecordingGl()
+    layer.onAdd(map, gl)
+    await layer.ready
+
+    const pending = layer.queryData(point)
+    await tick()
+    layer.onRemove(map, gl)
+    releaseChunk()
+
+    await expect(pending).rejects.toThrow(
+      /removed while the query was in flight/
+    )
+  })
+
   it('rejects when the finest level cannot be opened', async () => {
     // Levels wide enough that zoom 0 draws the coarse one, so the render
     // level commits normally and only the finest read fails. Shapes are

--- a/src/zarr-layer.query-readiness.test.ts
+++ b/src/zarr-layer.query-readiness.test.ts
@@ -373,3 +373,106 @@ describe('queryData on a layer that cannot become ready', () => {
     releaseMetadata()
   })
 })
+
+/**
+ * `options.level` decides which resolution a query reads. The default follows
+ * the map so results agree with what is drawn; `'finest'` pins the answer to
+ * the highest-resolution level regardless of zoom.
+ *
+ * Fixture: levels wide enough that zoom picks between them (selection compares
+ * a level's pixel width against 256 * 2^zoom), each filled with a constant
+ * naming the level.
+ */
+describe('queryData level option', () => {
+  const MARKER = { coarse: 1, fine: 2 }
+
+  function markedPyramid({ reversed = false } = {}) {
+    const levels = [
+      {
+        asset: '0',
+        shape: [128, 256] as [number, number],
+        fill: MARKER.coarse,
+      },
+      { asset: '1', shape: [256, 512] as [number, number], fill: MARKER.fine },
+    ]
+    const layout = reversed
+      ? [{ asset: '1' }, { asset: '0' }]
+      : [{ asset: '0' }, { asset: '1' }]
+    return buildMemoryZarrStore({
+      attributes: { multiscales: { layout, crs: 'EPSG:4326' } },
+      arrays: levels.map((l) => ({
+        name: `${l.asset}/temperature`,
+        shape: l.shape,
+        chunkShape: l.shape,
+        dimensionNames: ['lat', 'lon'],
+        chunks: {
+          '0/0': new Float32Array(l.shape[0] * l.shape[1]).fill(l.fill),
+        },
+      })),
+    })
+  }
+
+  const queryOrigin = (layer: ZarrLayer, level?: 'current' | 'finest') =>
+    layer.queryData({ type: 'Point', coordinates: [0, 0] }, undefined, {
+      level,
+    })
+
+  it('defaults to the level the map is drawing', async () => {
+    const layer = makeLayer({ store: markedPyramid() })
+    layer.onAdd(staticMap(0), createRecordingGl())
+
+    expect((await queryOrigin(layer)).temperature).toEqual([MARKER.coarse])
+  })
+
+  it('reads the finest level at a zoom that would draw the coarse one', async () => {
+    const layer = makeLayer({ store: markedPyramid() })
+    layer.onAdd(staticMap(0), createRecordingGl())
+
+    expect((await queryOrigin(layer, 'finest')).temperature).toEqual([
+      MARKER.fine,
+    ])
+  })
+
+  it('leaves the rendered level alone when a finest query reads past it', async () => {
+    const layer = makeLayer({ store: markedPyramid() })
+    layer.onAdd(staticMap(0), createRecordingGl())
+
+    expect((await queryOrigin(layer, 'finest')).temperature).toEqual([
+      MARKER.fine,
+    ])
+    // The finest read is query-local: a default query still answers from the
+    // level the renderer committed, so it never dragged the render loop along.
+    expect((await queryOrigin(layer)).temperature).toEqual([MARKER.coarse])
+  })
+
+  it('finds the finest level by resolution, not by position in the pyramid', async () => {
+    const layer = makeLayer({ store: markedPyramid({ reversed: true }) })
+    layer.onAdd(staticMap(0), createRecordingGl())
+
+    expect((await queryOrigin(layer, 'finest')).temperature).toEqual([
+      MARKER.fine,
+    ])
+  })
+
+  it('is a no-op on a single-level store', async () => {
+    const layer = makeLayer({
+      clim: [0, 4],
+      store: buildMemoryZarrStore({
+        arrays: [
+          {
+            name: 'temperature',
+            shape: [2, 2],
+            chunkShape: [2, 2],
+            dimensionNames: ['lat', 'lon'],
+            chunks: { '0/0': [1, 2, 3, 4] },
+          },
+        ],
+      }),
+    })
+    layer.onAdd(staticMap(0), createRecordingGl())
+
+    expect((await queryOrigin(layer, 'finest')).temperature).toEqual(
+      (await queryOrigin(layer)).temperature
+    )
+  })
+})

--- a/src/zarr-layer.query-readiness.test.ts
+++ b/src/zarr-layer.query-readiness.test.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ZarrLayer } from './zarr-layer'
+import { ZarrLayerNotReadyError } from './errors'
+import { buildMemoryZarrStore } from './__fixtures__/memory-zarr'
+import { createRecordingGl } from './__fixtures__/fake-gl'
+import type { MapLike, ZarrLayerOptions } from './types'
+
+/**
+ * `queryData` readiness on a map that never renders.
+ *
+ * A multiscale store deliberately commits no level during init — the level is
+ * picked from the map zoom, which only the render path knows. On a map that
+ * never paints, nothing ever commits one, so a query had no level to index
+ * into. The failure was silent: "layer isn't ready" and "point has no data"
+ * were the same empty result, so callers rendered "no data" over data.
+ *
+ * These pin the contract that a query resolves against real data whenever it
+ * is issued after `onAdd`, with no render pass and no caller-side polling.
+ */
+
+/** A map that never paints: `triggerRepaint` is recorded but runs no frame. */
+function staticMap(zoom = 0) {
+  return {
+    getProjection: () => ({ type: 'mercator' }),
+    getTerrain: () => null,
+    getZoom: () => zoom,
+    getBounds: () => ({
+      getWest: () => -180,
+      getEast: () => 180,
+      toArray: () => [
+        [-180, -85],
+        [180, 85],
+      ],
+    }),
+    getRenderWorldCopies: () => true,
+    triggerRepaint: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as MapLike
+}
+
+function makeLayer(overrides: Partial<ZarrLayerOptions> = {}) {
+  return new ZarrLayer({
+    id: 'zarr',
+    variable: 'temperature',
+    colormap: [
+      [0, 0, 0],
+      [255, 255, 255],
+    ],
+    clim: [0, 32],
+    crs: 'EPSG:4326',
+    bounds: [-180, -90, 180, 90],
+    latIsAscending: false,
+    ...overrides,
+  } as ZarrLayerOptions)
+}
+
+/**
+ * A 2-level global pyramid carrying the same field at two resolutions: the
+ * coarse level is a 4x8 index ramp (value = y*8 + x) and the fine level is its
+ * 8x16 nearest-neighbour upsampling. A point therefore has one correct value
+ * no matter which level answers, so value assertions test the query rather
+ * than the level-selection heuristic.
+ */
+const COARSE = { width: 8, height: 4 }
+
+function samefieldPyramid({ declareShapes = false } = {}) {
+  const shapeOf = (level: 0 | 1) =>
+    declareShapes
+      ? {
+          'spatial:shape': [
+            COARSE.height * (level + 1),
+            COARSE.width * (level + 1),
+          ],
+        }
+      : {}
+  const coarse = Array.from(
+    { length: COARSE.height * COARSE.width },
+    (_, i) => i
+  )
+  const fine = Array.from(
+    { length: COARSE.height * 2 * COARSE.width * 2 },
+    (_, i) => {
+      const y = Math.floor(i / (COARSE.width * 2))
+      const x = i % (COARSE.width * 2)
+      return Math.floor(y / 2) * COARSE.width + Math.floor(x / 2)
+    }
+  )
+  return buildMemoryZarrStore({
+    attributes: {
+      multiscales: {
+        layout: [
+          { asset: '0', ...shapeOf(0) },
+          { asset: '1', ...shapeOf(1) },
+        ],
+        crs: 'EPSG:4326',
+      },
+    },
+    arrays: [
+      {
+        name: '0/temperature',
+        shape: [COARSE.height, COARSE.width],
+        chunkShape: [COARSE.height, COARSE.width],
+        dimensionNames: ['lat', 'lon'],
+        chunks: { '0/0': coarse },
+      },
+      {
+        name: '1/temperature',
+        shape: [COARSE.height * 2, COARSE.width * 2],
+        chunkShape: [COARSE.height * 2, COARSE.width * 2],
+        dimensionNames: ['lat', 'lon'],
+        chunks: { '0/0': fine },
+      },
+    ],
+  })
+}
+
+/** Center of coarse-grid pixel (x, y) as [lon, lat] on a global extent. */
+function pixelCenter(x: number, y: number): [number, number] {
+  return [
+    ((x + 0.5) / COARSE.width) * 360 - 180,
+    90 - ((y + 0.5) / COARSE.height) * 180,
+  ]
+}
+
+describe('queryData readiness', () => {
+  it('resolves with data when called immediately after onAdd on a map that never renders', async () => {
+    const layer = makeLayer({ store: samefieldPyramid() })
+    layer.onAdd(staticMap(), createRecordingGl())
+
+    const result = await layer.queryData({
+      type: 'Point',
+      coordinates: pixelCenter(3, 1),
+    })
+
+    expect(result.temperature).toEqual([1 * COARSE.width + 3])
+  })
+
+  it('queries without the caller awaiting any loading-state callback', async () => {
+    const onLoadingStateChange = vi.fn()
+    const layer = makeLayer({
+      store: samefieldPyramid(),
+      onLoadingStateChange,
+    })
+    layer.onAdd(staticMap(), createRecordingGl())
+
+    const result = await layer.queryData({
+      type: 'Point',
+      coordinates: pixelCenter(0, 0),
+    })
+
+    expect(result.temperature).toEqual([0])
+  })
+
+  it('returns a genuine empty result for a point outside coverage', async () => {
+    const layer = makeLayer({
+      store: samefieldPyramid(),
+      bounds: [0, 0, 10, 10],
+    })
+    layer.onAdd(staticMap(), createRecordingGl())
+
+    const result = await layer.queryData({
+      type: 'Point',
+      coordinates: [100, 50],
+    })
+
+    expect(result.temperature).toEqual([])
+  })
+
+  it('resolves `ready` after the first level commits', async () => {
+    const layer = makeLayer({ store: samefieldPyramid() })
+    layer.onAdd(staticMap(), createRecordingGl())
+
+    await layer.ready
+
+    const result = await layer.queryData({
+      type: 'Point',
+      coordinates: pixelCenter(7, 3),
+    })
+    expect(result.temperature).toEqual([3 * COARSE.width + 7])
+  })
+
+  it('holds `ready` open until the level commits, not just until metadata lands', async () => {
+    // Init opens level 0's array to learn the variable's dimensions, and
+    // declaring `spatial:shape` stops it probing the rest. The fine level is
+    // therefore first read when it commits, so gating it separates the two
+    // readiness stages. Zoom 0 picks the fine level here: both are narrower
+    // than a 256px world, so selection falls through to the finest.
+    let releaseLevel = () => {}
+    const levelGate = new Promise<void>((resolve) => {
+      releaseLevel = resolve
+    })
+    const backing = samefieldPyramid({ declareShapes: true })
+
+    let metadataSettled = () => {}
+    const metadataDone = new Promise<void>((resolve) => {
+      metadataSettled = resolve
+    })
+
+    const layer = makeLayer({
+      store: {
+        get: async (key: string) => {
+          if (key === '/1/temperature/zarr.json') await levelGate
+          return backing.get(key)
+        },
+      },
+      onLoadingStateChange: (state) => {
+        if (!state.metadata) metadataSettled()
+      },
+    })
+    const map = staticMap()
+    layer.onAdd(map, createRecordingGl())
+
+    let resolved = false
+    void layer.ready.then(() => {
+      resolved = true
+    })
+
+    await metadataDone
+    await new Promise((r) => setTimeout(r, 0))
+    expect(resolved).toBe(false)
+    const repaintsBeforeCommit = vi.mocked(map.triggerRepaint!).mock.calls
+      .length
+
+    releaseLevel()
+    await layer.ready
+    expect(resolved).toBe(true)
+    // The commit asks the map to paint. Without it a layer added to an idle
+    // map never gets the frame whose update() starts chunk fetches, so it
+    // stays blank however long you wait.
+    expect(vi.mocked(map.triggerRepaint!).mock.calls.length).toBeGreaterThan(
+      repaintsBeforeCommit
+    )
+  })
+
+  it('serves concurrent queries issued before any level is committed', async () => {
+    const layer = makeLayer({ store: samefieldPyramid() })
+    layer.onAdd(staticMap(), createRecordingGl())
+
+    const results = await Promise.all([
+      layer.queryData({ type: 'Point', coordinates: pixelCenter(1, 0) }),
+      layer.queryData({ type: 'Point', coordinates: pixelCenter(2, 2) }),
+      layer.queryData({ type: 'Point', coordinates: pixelCenter(6, 1) }),
+    ])
+
+    expect(results.map((r) => r.temperature)).toEqual([
+      [1],
+      [2 * COARSE.width + 2],
+      [1 * COARSE.width + 6],
+    ])
+  })
+})
+
+/**
+ * The query commits the level the render loop would have picked, not a
+ * hardcoded index. Fixture: two levels wide enough that zoom decides between
+ * them (level selection compares a level's pixel width against
+ * 256 * 2^zoom), each filled with a constant that names the level.
+ */
+describe('queryData level selection', () => {
+  const LEVEL_MARKER = { coarse: 1, fine: 2 }
+
+  function markedPyramid() {
+    return buildMemoryZarrStore({
+      attributes: {
+        multiscales: {
+          layout: [{ asset: '0' }, { asset: '1' }],
+          crs: 'EPSG:4326',
+        },
+      },
+      arrays: [
+        {
+          name: '0/temperature',
+          shape: [128, 256],
+          chunkShape: [128, 256],
+          dimensionNames: ['lat', 'lon'],
+          chunks: { '0/0': new Float32Array(128 * 256).fill(1) },
+        },
+        {
+          name: '1/temperature',
+          shape: [256, 512],
+          chunkShape: [256, 512],
+          dimensionNames: ['lat', 'lon'],
+          chunks: { '0/0': new Float32Array(256 * 512).fill(2) },
+        },
+      ],
+    })
+  }
+
+  it('uses the coarse level at low zoom', async () => {
+    const layer = makeLayer({ store: markedPyramid() })
+    layer.onAdd(staticMap(0), createRecordingGl())
+
+    const result = await layer.queryData({ type: 'Point', coordinates: [0, 0] })
+
+    expect(result.temperature).toEqual([LEVEL_MARKER.coarse])
+  })
+
+  it('uses the fine level at higher zoom', async () => {
+    const layer = makeLayer({ store: markedPyramid() })
+    layer.onAdd(staticMap(1), createRecordingGl())
+
+    const result = await layer.queryData({ type: 'Point', coordinates: [0, 0] })
+
+    expect(result.temperature).toEqual([LEVEL_MARKER.fine])
+  })
+})
+
+describe('queryData on a layer that cannot become ready', () => {
+  it('throws when the layer was never added to a map', async () => {
+    const layer = makeLayer({ store: samefieldPyramid() })
+
+    await expect(
+      layer.queryData({ type: 'Point', coordinates: [0, 0] })
+    ).rejects.toBeInstanceOf(ZarrLayerNotReadyError)
+  })
+
+  it('throws when the layer has been removed', async () => {
+    const layer = makeLayer({ store: samefieldPyramid() })
+    const gl = createRecordingGl()
+    layer.onAdd(staticMap(), gl)
+    await layer.ready
+    layer.onRemove(staticMap(), gl)
+
+    await expect(
+      layer.queryData({ type: 'Point', coordinates: pixelCenter(0, 0) })
+    ).rejects.toThrow(/removed from the map/)
+  })
+
+  it('throws when initialization failed, carrying the cause', async () => {
+    const layer = makeLayer({
+      store: { get: async () => undefined },
+      bounds: undefined,
+    })
+    layer.onAdd(staticMap(), createRecordingGl())
+
+    const error = await layer
+      .queryData({ type: 'Point', coordinates: [0, 0] })
+      .then(
+        () => null,
+        (e) => e
+      )
+
+    expect(error).toBeInstanceOf(ZarrLayerNotReadyError)
+    expect((error as ZarrLayerNotReadyError).cause).toBeInstanceOf(Error)
+  })
+
+  it('rejects with the abort reason when the query signal aborts mid-wait', async () => {
+    let releaseMetadata = () => {}
+    const gate = new Promise<void>((resolve) => {
+      releaseMetadata = resolve
+    })
+    const backing = samefieldPyramid()
+    const layer = makeLayer({
+      store: {
+        get: async (key: string) => {
+          if (key.includes('/1/')) await gate
+          return backing.get(key)
+        },
+      },
+    })
+    layer.onAdd(staticMap(), createRecordingGl())
+
+    const controller = new AbortController()
+    const pending = layer.queryData(
+      { type: 'Point', coordinates: pixelCenter(0, 0) },
+      undefined,
+      { signal: controller.signal }
+    )
+    controller.abort()
+
+    await expect(pending).rejects.toThrow(/abort/i)
+    releaseMetadata()
+  })
+})

--- a/src/zarr-layer.query-readiness.test.ts
+++ b/src/zarr-layer.query-readiness.test.ts
@@ -592,3 +592,156 @@ describe('queryData failure reporting', () => {
     expect((error as ZarrLayerNotReadyError).message).toMatch(/WebGL2/)
   })
 })
+
+/**
+ * A load that a newer one displaces is not a failure. Zooming while the first
+ * level is still loading is ordinary map behavior, and the displaced load must
+ * not be reported as "this store has no levels" — least of all through `ready`,
+ * whose result callers hold onto.
+ */
+describe('queryData readiness under a level change mid-load', () => {
+  /**
+   * Three levels, each filled with a constant naming it. Level 0 is too small
+   * for any zoom under test to select, which matters because `ZarrStore` opens
+   * it during init to learn the variable's dimensions — gating it would gate
+   * initialization rather than the level load. Only the two contested levels
+   * are gated: zoom 0 selects level 1, zoom 1 selects level 2.
+   */
+  const GATED_LEVELS = ['1', '2']
+
+  function gatedPyramid() {
+    const sizes: Record<string, [number, number]> = {
+      '0': [32, 64],
+      '1': [128, 256],
+      '2': [256, 512],
+    }
+    const backing = buildMemoryZarrStore({
+      attributes: {
+        multiscales: {
+          layout: Object.entries(sizes).map(([asset, shape]) => ({
+            asset,
+            'spatial:shape': shape,
+          })),
+          crs: 'EPSG:4326',
+        },
+      },
+      arrays: Object.entries(sizes).map(([asset, shape]) => ({
+        name: `${asset}/temperature`,
+        shape,
+        chunkShape: shape,
+        dimensionNames: ['lat', 'lon'],
+        chunks: {
+          '0/0': new Float32Array(shape[0] * shape[1]).fill(Number(asset)),
+        },
+      })),
+    })
+    const release: Record<string, () => void> = {}
+    const gates = Object.fromEntries(
+      GATED_LEVELS.map((level) => [
+        level,
+        new Promise<void>((resolve) => {
+          release[level] = resolve
+        }),
+      ])
+    )
+    return {
+      release,
+      store: {
+        get: async (key: string) => {
+          for (const level of GATED_LEVELS) {
+            if (key === `/${level}/temperature/zarr.json`) await gates[level]
+          }
+          return backing.get(key)
+        },
+      },
+    }
+  }
+
+  function zoomableMap(initialZoom: number) {
+    const map = staticMap(initialZoom) as MapLike & { getZoom: () => number }
+    let zoom = initialZoom
+    map.getZoom = () => zoom
+    return { map, setZoom: (next: number) => (zoom = next) }
+  }
+
+  const tick = () => new Promise((r) => setTimeout(r, 0))
+
+  it('follows the level change instead of reporting no level', async () => {
+    const { store, release } = gatedPyramid()
+    const layer = makeLayer({ store })
+    const { map, setZoom } = zoomableMap(0)
+    const gl = createRecordingGl()
+    layer.onAdd(map, gl)
+    await tick()
+
+    // Query waits on the load the initial zoom asked for.
+    const pending = layer.queryData({ type: 'Point', coordinates: [0, 0] })
+    await tick()
+
+    // The camera moves to a zoom wanting the next level down, so the render
+    // loop starts a load that displaces the one the query is waiting on.
+    setZoom(1)
+    layer.prerender(gl, {})
+    await tick()
+
+    // The displaced load finishes first, committing nothing.
+    release['1']()
+    await tick()
+
+    release['2']()
+    expect((await pending).temperature).toEqual([2])
+  })
+
+  it('follows the level change when the displaced load errors on the way out', async () => {
+    // Cancelling a level load can make its in-flight reads throw. That error
+    // belongs to an attempt nobody is waiting on any more, so it must read as
+    // supersession rather than as a failure that ends the retry.
+    const { store, release } = gatedPyramid()
+    const layer = makeLayer({
+      store: {
+        get: async (key: string) => {
+          const value = await store.get(key)
+          if (key === '/1/temperature/zarr.json') {
+            throw new Error('read cancelled')
+          }
+          return value
+        },
+      },
+    })
+    const { map, setZoom } = zoomableMap(0)
+    const gl = createRecordingGl()
+    layer.onAdd(map, gl)
+    await tick()
+
+    const pending = layer.queryData({ type: 'Point', coordinates: [0, 0] })
+    await tick()
+
+    setZoom(1)
+    layer.prerender(gl, {})
+    await tick()
+
+    release['1']()
+    await tick()
+
+    release['2']()
+    expect((await pending).temperature).toEqual([2])
+  })
+
+  it('caches `ready` only on success, so a failure is not permanent', async () => {
+    const failing = makeLayer({
+      store: { get: async () => undefined },
+      bounds: undefined,
+    })
+    failing.onAdd(staticMap(), createRecordingGl())
+
+    const first = failing.ready
+    await expect(first).rejects.toBeInstanceOf(ZarrLayerNotReadyError)
+    expect(failing.ready).not.toBe(first)
+
+    const working = makeLayer({ store: samefieldPyramid() })
+    working.onAdd(staticMap(), createRecordingGl())
+    const settled = working.ready
+    await settled
+    expect(working.ready).toBe(settled)
+  })
+})

--- a/src/zarr-layer.ts
+++ b/src/zarr-layer.ts
@@ -474,7 +474,7 @@ export class ZarrLayer {
     // Queries and `ready` track the new dataset from here on, so a call that
     // lands mid-swap waits for the new store rather than reading the old one.
     this.readyPromise = null
-    this.initPromise = this._setVariableAsync(variable)
+    this.initPromise = this.trackInit(this._setVariableAsync(variable))
     await this.initPromise
   }
 
@@ -540,7 +540,25 @@ export class ZarrLayer {
     map: MapLike,
     gl: WebGL2RenderingContext | WebGLRenderingContext
   ): void {
-    this.initPromise = this._onAddAsync(map, gl)
+    this.initPromise = this.trackInit(this._onAddAsync(map, gl))
+  }
+
+  /**
+   * Funnel an initialization run into `initError` so `initPromise` always
+   * fulfills. `_onAddAsync` does its own error handling once running, but it
+   * can reject before reaching that — `resolveGl` throws on a context that
+   * isn't WebGL2 — and a rejection here would otherwise escape `ready` and
+   * `queryData` raw, and go unhandled when nobody awaits either.
+   */
+  private trackInit(run: Promise<void>): Promise<void> {
+    return run.catch((err) => {
+      this.initError = err instanceof Error ? err : new Error(String(err))
+      console.error(
+        `[zarr-layer] Failed to initialize: ${this.initError.message}`
+      )
+      this.metadataLoading = false
+      this.emitLoadingState()
+    })
   }
 
   private async _onAddAsync(
@@ -976,14 +994,33 @@ export class ZarrLayer {
         { cause: this.initError }
       )
     }
-    if (this.isRemoved || !this.regionRenderer) {
+    const regionRenderer = this.regionRenderer
+    if (this.isRemoved || !regionRenderer) {
       throw new ZarrLayerNotReadyError(
         this.id,
         'layer has been removed from the map'
       )
     }
-    await this.regionRenderer.ensureQueryableLevel()
-    return this.regionRenderer
+    // Held in a local because a removal landing during the await nulls the
+    // field out from under us.
+    const level = await regionRenderer.ensureQueryableLevel()
+    if (this.isRemoved || this.regionRenderer !== regionRenderer) {
+      throw new ZarrLayerNotReadyError(
+        this.id,
+        'layer was removed while it was becoming ready'
+      )
+    }
+    if (!level) {
+      // No level means the load failed or was superseded and never retried.
+      // Returning here would let a query answer empty off a layer that holds
+      // no data at all, which is exactly the silent wrong answer the
+      // readiness contract exists to prevent.
+      throw new ZarrLayerNotReadyError(
+        this.id,
+        'no resolution level could be loaded'
+      )
+    }
+    return regionRenderer
   }
 
   /**

--- a/src/zarr-layer.ts
+++ b/src/zarr-layer.ts
@@ -1036,14 +1036,15 @@ export class ZarrLayer {
   /**
    * Query all data values within a geographic region.
    *
-   * Waits for the layer to become queryable, so it can be called straight
-   * after `map.addLayer()` with no render pass in between. An empty result
-   * therefore always means the geometry found no data.
+   * Waits for metadata and a committed resolution level, so it can be called
+   * straight after `map.addLayer()` with no render pass in between. An unready
+   * layer therefore never answers with an empty result. A chunk read that
+   * fails still does — see `fetchQueryData`.
    *
    * @param geometry - GeoJSON Point, Polygon or MultiPolygon geometry.
    * @param selector - Optional selector to override the layer's selector.
-   * @throws {ZarrLayerNotReadyError} if the layer failed to initialize, was
-   *   removed, or was never added to a map.
+   * @throws {ZarrLayerNotReadyError} if the layer failed to initialize, could
+   *   not load a level, was removed, or was never added to a map.
    * @returns Promise resolving to the query result matching carbonplan/maps structure.
    */
   async queryData(

--- a/src/zarr-layer.ts
+++ b/src/zarr-layer.ts
@@ -1037,9 +1037,9 @@ export class ZarrLayer {
    * Query all data values within a geographic region.
    *
    * Waits for metadata and a committed resolution level, so it can be called
-   * straight after `map.addLayer()` with no render pass in between. An unready
-   * layer therefore never answers with an empty result. A chunk read that
-   * fails still does — see `fetchQueryData`.
+   * straight after `map.addLayer()` with no render pass in between. Neither an
+   * unready layer nor a failed read answers with an empty result, so an empty
+   * result means the geometry found no data.
    *
    * @param geometry - GeoJSON Point, Polygon or MultiPolygon geometry.
    * @param selector - Optional selector to override the layer's selector.

--- a/src/zarr-layer.ts
+++ b/src/zarr-layer.ts
@@ -1056,6 +1056,17 @@ export class ZarrLayer {
       this.resolveReadiness(),
       options?.signal
     )
-    return regionRenderer.queryData(geometry, selector, options)
+    const result = await regionRenderer.queryData(geometry, selector, options)
+    // Readiness held when the query started, but a removal landing while it ran
+    // disposes the renderer and clears its level, and the inner path answers
+    // empty once there is no level to index. Checked here so a layer that went
+    // away can never come back as "no data here".
+    if (this.isRemoved || this.regionRenderer !== regionRenderer) {
+      throw new ZarrLayerNotReadyError(
+        this.id,
+        'layer was removed while the query was in flight'
+      )
+    }
+    return result
   }
 }

--- a/src/zarr-layer.ts
+++ b/src/zarr-layer.ts
@@ -973,7 +973,17 @@ export class ZarrLayer {
    * Awaiting it is optional for queries; `queryData` waits on its own.
    */
   get ready(): Promise<void> {
-    this.readyPromise ??= this.resolveReadiness().then(() => {})
+    this.readyPromise ??= this.resolveReadiness().then(
+      () => {},
+      (err) => {
+        // Only success is cached. Caching the rejection would freeze a
+        // transient failure — a level load that lost a race, a store blip —
+        // into a layer that reports itself permanently unready even after
+        // the render loop has gone on to commit a level.
+        this.readyPromise = null
+        throw err
+      }
+    )
     return this.readyPromise
   }
 

--- a/src/zarr-layer.ts
+++ b/src/zarr-layer.ts
@@ -41,6 +41,7 @@ import {
 import { MAPBOX_IDENTITY_MATRIX } from './mapbox-utils'
 import type { QueryGeometry, QueryOptions, QueryResult } from './query/types'
 import { SPATIAL_DIM_NAMES } from './constants'
+import { ZarrLayerNotReadyError } from './errors'
 
 type MapboxInternals = {
   transform?: {
@@ -87,6 +88,20 @@ function scaleMercatorMatrix(
   for (let i = 4; i < 8; i++) out[i] *= scale
   for (let i = 8; i < 12; i++) out[i] *= scale
   return out
+}
+
+/** Settle as soon as `signal` aborts, so a caller tearing the layer down isn't
+ *  held by a wait it can no longer cancel from the inside. */
+function abortable<T>(work: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return work
+  if (signal.aborted) return Promise.reject(signal.reason)
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason)
+    signal.addEventListener('abort', onAbort, { once: true })
+    work.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort)
+    })
+  })
 }
 
 function smoothstep(edge0: number, edge1: number, x: number): number {
@@ -172,6 +187,10 @@ export class ZarrLayer {
   } = {}
   private normalizedSelector: NormalizedSelector = {}
   private isRemoved: boolean = false
+  /** Settles when the current dataset's metadata init finishes; never rejects
+   *  (failures land in `initError`). Null until the layer is added to a map. */
+  private initPromise: Promise<void> | null = null
+  private readyPromise: Promise<void> | null = null
   private fragmentShaderSource: string = maplibreFragmentShaderSource
   private customFrag: string | undefined
   private customUniforms: Record<string, number> = {}
@@ -452,7 +471,14 @@ export class ZarrLayer {
 
   async setVariable(variable: string) {
     if (variable === this.variable) return
+    // Queries and `ready` track the new dataset from here on, so a call that
+    // lands mid-swap waits for the new store rather than reading the old one.
+    this.readyPromise = null
+    this.initPromise = this._setVariableAsync(variable)
+    await this.initPromise
+  }
 
+  private async _setVariableAsync(variable: string) {
     this.metadataLoading = true
     this.emitLoadingState()
 
@@ -514,7 +540,7 @@ export class ZarrLayer {
     map: MapLike,
     gl: WebGL2RenderingContext | WebGLRenderingContext
   ): void {
-    this._onAddAsync(map, gl)
+    this.initPromise = this._onAddAsync(map, gl)
   }
 
   private async _onAddAsync(
@@ -917,9 +943,60 @@ export class ZarrLayer {
   // ========== Query Interface ==========
 
   /**
+   * Resolves once the layer can serve queries and draw: metadata loaded and a
+   * level committed. Rejects with `ZarrLayerNotReadyError` if initialization
+   * failed or the layer was removed.
+   *
+   * This is not the same signal as `onLoadingStateChange`. That one is a
+   * spinner — it flaps as chunks come and go, and it reports nothing about the
+   * level commit, so `loading: false` can be emitted while the layer still has
+   * no level. `ready` settles once, after both stages.
+   *
+   * Awaiting it is optional for queries; `queryData` waits on its own.
+   */
+  get ready(): Promise<void> {
+    this.readyPromise ??= this.resolveReadiness().then(() => {})
+    return this.readyPromise
+  }
+
+  /** Wait out initialization and commit a level, or explain why neither can
+   *  happen. Shared by `ready` and `queryData`. */
+  private async resolveReadiness(): Promise<RegionRenderer> {
+    if (!this.initPromise) {
+      throw new ZarrLayerNotReadyError(
+        this.id,
+        'layer has not been added to a map — call map.addLayer() first'
+      )
+    }
+    await this.initPromise
+    if (this.initError) {
+      throw new ZarrLayerNotReadyError(
+        this.id,
+        `layer failed to initialize: ${this.initError.message}`,
+        { cause: this.initError }
+      )
+    }
+    if (this.isRemoved || !this.regionRenderer) {
+      throw new ZarrLayerNotReadyError(
+        this.id,
+        'layer has been removed from the map'
+      )
+    }
+    await this.regionRenderer.ensureQueryableLevel()
+    return this.regionRenderer
+  }
+
+  /**
    * Query all data values within a geographic region.
+   *
+   * Waits for the layer to become queryable, so it can be called straight
+   * after `map.addLayer()` with no render pass in between. An empty result
+   * therefore always means the geometry found no data.
+   *
    * @param geometry - GeoJSON Point, Polygon or MultiPolygon geometry.
    * @param selector - Optional selector to override the layer's selector.
+   * @throws {ZarrLayerNotReadyError} if the layer failed to initialize, was
+   *   removed, or was never added to a map.
    * @returns Promise resolving to the query result matching carbonplan/maps structure.
    */
   async queryData(
@@ -927,13 +1004,10 @@ export class ZarrLayer {
     selector?: Selector,
     options?: QueryOptions
   ): Promise<QueryResult> {
-    if (!this.regionRenderer) {
-      return {
-        [this.variable]: [],
-        dimensions: [],
-        coordinates: {},
-      }
-    }
-    return this.regionRenderer.queryData(geometry, selector, options)
+    const regionRenderer = await abortable(
+      this.resolveReadiness(),
+      options?.signal
+    )
+    return regionRenderer.queryData(geometry, selector, options)
   }
 }


### PR DESCRIPTION
  - Make queryData wait for metadata and a committed resolution level, including when called immediately after map.addLayer() without a render pass.
  - Add layer.ready and export ZarrLayerNotReadyError for initialization, level-loading, and layer-lifecycle failures.
  - Add level: 'finest' query support while keeping the rendered level unchanged; 'current' remains the default.
  - Propagate query read failures instead of returning empty results, ensuring empty results only mean no data was found.
  - Handle concurrent queries, zoom changes during level loading, aborts, and layer removal during in-flight queries.
  - Document query readiness, resolution behavior, and performance considerations.