### PR TITLE
Fix rendering of node-registered global datasets

### DIFF
--- a/src/map-utils.test.ts
+++ b/src/map-utils.test.ts
@@ -98,6 +98,15 @@ describe('normalizeLongitudeExtent', () => {
     })
   })
 
+  it('leaves an extent half a cell short of global unsnapped', () => {
+    // This is typical of a global dataset with a node spatial registration, e.g.
+    // ClimateSET's Zarr version of CMIP6.
+    expect(normalizeLongitudeExtent(-180.5, 179.5, 1)).toEqual({
+      xMin: -180.5,
+      xMax: 179.5,
+    })
+  })
+
   it('leaves a regional extent near 180 unsnapped', () => {
     expect(normalizeLongitudeExtent(170, 179.9, 0.25)).toEqual({
       xMin: 170,

--- a/src/map-utils.ts
+++ b/src/map-utils.ts
@@ -108,14 +108,13 @@ export interface XYLimits {
 }
 
 /**
- * Put a longitude extent into the -180–180 representation the renderer works
- * in. Only meaningful for a geographic CRS; callers hold that check.
+ * Put a longitude extent into the -180–180 representation the renderer works in.
+ * Only meaningful for a geographic CRS; callers hold that check.
  *
- * Two corrections, neither of them a judgment about the source. A 0–360 extent
- * is folded, since that convention is just as correct and xarray writes it. A
- * global extent landing within a cell of ±180 is snapped onto it, which is what
- * keeps a seam from opening at the antimeridian when the grid doesn't divide
- * evenly.
+ * Two corrections, neither of them a judgment about the source. A 0–360 extent is
+ * folded, since that convention is just as correct and xarray writes it. A global
+ * extent landing within `1e-3` of ±180 is snapped onto it, which is what keeps a
+ * seam from opening at the antimeridian when the grid doesn't divide evenly.
  *
  * @param cellWidth - Longitude span of one cell, the tolerance for both checks.
  */
@@ -124,6 +123,8 @@ export function normalizeLongitudeExtent(
   xMax: number,
   cellWidth: number
 ): { xMin: number; xMax: number } {
+  const tolerance = 1e-3
+
   let lo = xMin
   let hi = xMax
 
@@ -134,11 +135,13 @@ export function normalizeLongitudeExtent(
     hi -= 360
   }
 
-  // A truly global grid spans exactly N * cellWidth = 360°; one a cell short
-  // spans 360 - cellWidth and fails the check.
-  if (Number.isFinite(cellWidth) && Math.abs(hi - lo - 360) < cellWidth / 2) {
-    if (Math.abs(lo + 180) < cellWidth) lo = -180
-    if (Math.abs(hi - 180) < cellWidth) hi = 180
+  const differenceFromGlobal = Math.abs(hi - lo - 360)
+
+  // Fix seams at the antimeridian created by floating point errors in ostensibly
+  // global datasets.
+  if (Number.isFinite(cellWidth) && differenceFromGlobal < tolerance) {
+    if (Math.abs(lo + 180) < tolerance) lo = -180
+    if (Math.abs(hi - 180) < tolerance) hi = 180
   }
 
   return { xMin: lo, xMax: hi }

--- a/src/zarr-store.geozarr.test.ts
+++ b/src/zarr-store.geozarr.test.ts
@@ -497,18 +497,19 @@ describe('bounds from the spatial: convention', () => {
     })
   })
 
-  it('snaps a node-registered global grid onto the antimeridian', async () => {
-    // Node registration puts this grid's edges at -202.5..157.5, a full 360 deg
-    // of coverage offset by half a cell. The global snap pulls it onto +/-180
-    // rather than leaving a seam. Its tolerance is a whole cell, so the half
-    // cell here is well inside it.
+  it('does not snap a node-registered global grid onto the antimeridian', async () => {
+    // Previously, we combined floating point error mitigation with snapping
+    // global grids (even node-registered ones) to a -180/180 extent. However,
+    // this created new problems wherein node-registered datasets were being
+    // rendered half a grid cell off longitudinally from where they should have
+    // been.
     const { d } = await describeSpatialStore({
       'spatial:transform': GLOBAL_TRANSFORM,
       'spatial:registration': 'node',
     })
 
-    expect(d.xyLimits?.xMin).toBe(-180)
-    expect(d.xyLimits?.xMax).toBe(180)
+    expect(d.xyLimits?.xMin).toBe(-202.5)
+    expect(d.xyLimits?.xMax).toBe(157.5)
   })
 
   it('lets the bounds option win over a declared bbox', async () => {


### PR DESCRIPTION
This fixes excessive grid snapping (#89) by reducing the tolerance in `normalizeLongitudeExtent()`. One of the existing unit tests had to be altered to pass since it was treating the same behavior that is broken for us as desired behavior.

You can see the fix in action with the dataset we’re trying to get to render correctly in our `node-registered-global-rendering/demo-plus-fix` branch:

```sh
git clone git@github.com:Lobelia-Earth/zarr-layer.git lobelia-zarr-layer
cd lobelia-zarr-layer
git checkout node-registered-global-rendering/demo-plus-fix
npm install
npm run build
cd demo
npm run dev
```

http://localhost:3000/?dataset=cerra_cmip6_nhw99p

<img width="816" height="636" alt="Screenshot 2026-09-07 at 20 32 45" src="https://github.com/user-attachments/assets/1d924199-aab2-45ab-b311-21d3bddbae6c" />

If there is a use case that this change breaks, please let me know. I would like to understand and perhaps we can find a different solution.